### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/101/912/605/101912605.geojson
+++ b/data/101/912/605/101912605.geojson
@@ -120,6 +120,9 @@
         "wd:id":"Q924278"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3367ec77aa292bb979272e1b52781c69",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":101912605,
-    "wof:lastmodified":1566605437,
+    "wof:lastmodified":1582392769,
     "wof:name":"Gjor\u010de Petrov",
     "wof:parent_id":85674323,
     "wof:placetype":"locality",

--- a/data/856/323/73/85632373.geojson
+++ b/data/856/323/73/85632373.geojson
@@ -1297,6 +1297,11 @@
     },
     "wof:country":"MK",
     "wof:country_alpha3":"MKD",
+    "wof:geom_alt":[
+        "meso",
+        "naturalearth",
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"3879dd936ab56da3855616a3cd0b655e",
     "wof:hierarchy":[
         {
@@ -1312,7 +1317,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605356,
+    "wof:lastmodified":1582392764,
     "wof:name":"Macedonia",
     "wof:parent_id":102191581,
     "wof:placetype":"country",

--- a/data/856/741/47/85674147.geojson
+++ b/data/856/741/47/85674147.geojson
@@ -295,6 +295,9 @@
         "wk:page":"Resen Municipality"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b212fcca637a7b844c8a29b1f415bbd7",
     "wof:hierarchy":[
         {
@@ -311,7 +314,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605358,
+    "wof:lastmodified":1582392765,
     "wof:name":"Resen",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/741/51/85674151.geojson
+++ b/data/856/741/51/85674151.geojson
@@ -221,6 +221,9 @@
         "wk:page":"Vev\u010dani Municipality"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6c30d8cacc760964cd119ffce6d873b3",
     "wof:hierarchy":[
         {
@@ -237,7 +240,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605357,
+    "wof:lastmodified":1582392764,
     "wof:name":"Vev\u010dani",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/741/57/85674157.geojson
+++ b/data/856/741/57/85674157.geojson
@@ -280,6 +280,9 @@
         "wk:page":"Bitola Municipality"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"34f61d0fc7afddf336b9c3e076d12f02",
     "wof:hierarchy":[
         {
@@ -296,7 +299,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605357,
+    "wof:lastmodified":1582392764,
     "wof:name":"Bitola",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/741/61/85674161.geojson
+++ b/data/856/741/61/85674161.geojson
@@ -229,6 +229,9 @@
         "wk:page":"Demir Hisar Municipality"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c9c34b9b432a1c025a798c95c014a484",
     "wof:hierarchy":[
         {
@@ -245,7 +248,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605357,
+    "wof:lastmodified":1582392764,
     "wof:name":"Demir Hisar",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/741/65/85674165.geojson
+++ b/data/856/741/65/85674165.geojson
@@ -286,6 +286,9 @@
         "wk:page":"Ohrid Municipality"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fd0bf5bc0c152c50e60c74667773a2e5",
     "wof:hierarchy":[
         {
@@ -302,7 +305,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605358,
+    "wof:lastmodified":1582392765,
     "wof:name":"Ohrid",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/741/69/85674169.geojson
+++ b/data/856/741/69/85674169.geojson
@@ -282,6 +282,9 @@
         "wk:page":"Debarca Municipality"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ae52ecf3127fdaca6607892e6c250493",
     "wof:hierarchy":[
         {
@@ -298,7 +301,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605357,
+    "wof:lastmodified":1582392764,
     "wof:name":"Debarca",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/741/73/85674173.geojson
+++ b/data/856/741/73/85674173.geojson
@@ -215,6 +215,9 @@
         "wd:id":"Q1018191"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cbc41c33d4f1149a114d8703846a6dcc",
     "wof:hierarchy":[
         {
@@ -231,7 +234,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605358,
+    "wof:lastmodified":1582392765,
     "wof:name":"Skopje",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/741/79/85674179.geojson
+++ b/data/856/741/79/85674179.geojson
@@ -282,6 +282,9 @@
         "wk:page":"Plasnica Municipality"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"dfba837f6ae6b78b09b5897231d9fbcb",
     "wof:hierarchy":[
         {
@@ -298,7 +301,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605358,
+    "wof:lastmodified":1582392765,
     "wof:name":"Plasnica",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/741/83/85674183.geojson
+++ b/data/856/741/83/85674183.geojson
@@ -292,6 +292,9 @@
         "wk:page":"Prilep Municipality"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7dff0b83d7d3212d2d8a6c1b67f0da29",
     "wof:hierarchy":[
         {
@@ -308,7 +311,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605358,
+    "wof:lastmodified":1582392765,
     "wof:name":"Prilep",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/741/87/85674187.geojson
+++ b/data/856/741/87/85674187.geojson
@@ -287,6 +287,9 @@
         "wk:page":"Probi\u0161tip Municipality"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b2380b4aea2bf23c4da24c480a73245c",
     "wof:hierarchy":[
         {
@@ -303,7 +306,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605358,
+    "wof:lastmodified":1582392765,
     "wof:name":"Probistip",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/741/91/85674191.geojson
+++ b/data/856/741/91/85674191.geojson
@@ -286,6 +286,9 @@
         "wd:id":"Q2738284"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fd1a7dd52e6a75266f5ef98f98d5ad61",
     "wof:hierarchy":[
         {
@@ -302,7 +305,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605358,
+    "wof:lastmodified":1582392765,
     "wof:name":"Radovis",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/741/97/85674197.geojson
+++ b/data/856/741/97/85674197.geojson
@@ -282,6 +282,9 @@
         "wk:page":"Kriva Palanka Municipality"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"99afd32b14f32f21930e05291b3cf8cb",
     "wof:hierarchy":[
         {
@@ -298,7 +301,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605358,
+    "wof:lastmodified":1582392765,
     "wof:name":"Kriva Palanka",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/742/01/85674201.geojson
+++ b/data/856/742/01/85674201.geojson
@@ -222,6 +222,9 @@
         "wk:page":"Rosoman Municipality"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a9bf1dcc9970db6e0ae95f2f21d7bcbb",
     "wof:hierarchy":[
         {
@@ -238,7 +241,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605365,
+    "wof:lastmodified":1582392767,
     "wof:name":"Vardar",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/742/05/85674205.geojson
+++ b/data/856/742/05/85674205.geojson
@@ -226,6 +226,9 @@
         "wd:id":"Q1309481"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7c93d7ef691183e5838ba333ca9e75da",
     "wof:hierarchy":[
         {
@@ -242,7 +245,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605364,
+    "wof:lastmodified":1582392767,
     "wof:name":"Saraj",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/742/09/85674209.geojson
+++ b/data/856/742/09/85674209.geojson
@@ -287,6 +287,9 @@
         "wk:page":"Sopi\u0161te Municipality"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"de7d446c855f601c055f87ba31eee1f1",
     "wof:hierarchy":[
         {
@@ -303,7 +306,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605365,
+    "wof:lastmodified":1582392767,
     "wof:name":"Sopiste",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/742/15/85674215.geojson
+++ b/data/856/742/15/85674215.geojson
@@ -199,6 +199,9 @@
         "wk:page":"Staro Nagori\u010dane Municipality"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9e2f8d18702e7ce5efb09708698737e8",
     "wof:hierarchy":[
         {
@@ -215,7 +218,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605366,
+    "wof:lastmodified":1582392767,
     "wof:name":"Northeastern",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/742/19/85674219.geojson
+++ b/data/856/742/19/85674219.geojson
@@ -286,6 +286,9 @@
         "wd:id":"Q2423082"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"52da536a5720396632c67c6a3d40cbb3",
     "wof:hierarchy":[
         {
@@ -302,7 +305,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605365,
+    "wof:lastmodified":1582392767,
     "wof:name":"\u0160tip",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/742/23/85674223.geojson
+++ b/data/856/742/23/85674223.geojson
@@ -287,6 +287,9 @@
         "wk:page":"Studeni\u010dani Municipality"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f8e96388cb6b294358abbae3c0d04c97",
     "wof:hierarchy":[
         {
@@ -303,7 +306,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605366,
+    "wof:lastmodified":1582392767,
     "wof:name":"Sveti Nikole",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/742/27/85674227.geojson
+++ b/data/856/742/27/85674227.geojson
@@ -217,6 +217,9 @@
         "wd:id":"Q1419314"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4f446070c212fb7f9af5f409e1b2fa9f",
     "wof:hierarchy":[
         {
@@ -233,7 +236,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605364,
+    "wof:lastmodified":1582392767,
     "wof:name":"Cair",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/742/29/85674229.geojson
+++ b/data/856/742/29/85674229.geojson
@@ -283,6 +283,9 @@
         "wk:page":"Sveti Nikole Municipality"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1b64e42bd2115ff7ccd0ebcc75135f35",
     "wof:hierarchy":[
         {
@@ -299,7 +302,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605364,
+    "wof:lastmodified":1582392767,
     "wof:name":"Sveti Nikole",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/742/37/85674237.geojson
+++ b/data/856/742/37/85674237.geojson
@@ -250,6 +250,9 @@
         "wd:id":"Q2088561"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"270dd5979b37b118b17593ccfd05644b",
     "wof:hierarchy":[
         {
@@ -266,7 +269,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605365,
+    "wof:lastmodified":1582392767,
     "wof:name":"Veles",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/742/41/85674241.geojson
+++ b/data/856/742/41/85674241.geojson
@@ -284,6 +284,9 @@
         "wk:page":"Vrane\u0161tica Municipality"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c74e4e094679a20a1261592ccf2a3484",
     "wof:hierarchy":[
         {
@@ -300,7 +303,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605366,
+    "wof:lastmodified":1582392767,
     "wof:name":"Vrane\u0161tica",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/742/45/85674245.geojson
+++ b/data/856/742/45/85674245.geojson
@@ -283,6 +283,9 @@
         "wk:page":"Zelenikovo Municipality"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cc920be9b424203d6f64cd8f3128c64a",
     "wof:hierarchy":[
         {
@@ -299,7 +302,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605364,
+    "wof:lastmodified":1582392767,
     "wof:name":"Zelenikovo",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/742/51/85674251.geojson
+++ b/data/856/742/51/85674251.geojson
@@ -287,6 +287,9 @@
         "wk:page":"\u017delino Municipality"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9630e8a5da6e875a581a3b3832e3cee6",
     "wof:hierarchy":[
         {
@@ -303,7 +306,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605364,
+    "wof:lastmodified":1582392767,
     "wof:name":"\u017delino",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/742/53/85674253.geojson
+++ b/data/856/742/53/85674253.geojson
@@ -290,6 +290,9 @@
         "wk:page":"Ara\u010dinovo Municipality"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cb5a410ad3bee3d6c54e052936eeb28a",
     "wof:hierarchy":[
         {
@@ -306,7 +309,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605365,
+    "wof:lastmodified":1582392767,
     "wof:name":"Aracinovo",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/742/57/85674257.geojson
+++ b/data/856/742/57/85674257.geojson
@@ -281,6 +281,9 @@
         "wk:page":"Lipkovo Municipality"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"dbb779fc6494aece6b8190fa3930a977",
     "wof:hierarchy":[
         {
@@ -297,7 +300,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605363,
+    "wof:lastmodified":1582392767,
     "wof:name":"Lipkovo",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/742/61/85674261.geojson
+++ b/data/856/742/61/85674261.geojson
@@ -228,6 +228,9 @@
         "wd:id":"Q935620"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"aea209bb47564544b2b680ad2f6a2629",
     "wof:hierarchy":[
         {
@@ -244,7 +247,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605363,
+    "wof:lastmodified":1582392767,
     "wof:name":"Butel",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/742/65/85674265.geojson
+++ b/data/856/742/65/85674265.geojson
@@ -297,6 +297,9 @@
         "wk:page":"\u010ca\u0161ka Municipality"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f188c3cea38a829ce34a52d4d7d652cf",
     "wof:hierarchy":[
         {
@@ -313,7 +316,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605365,
+    "wof:lastmodified":1582392767,
     "wof:name":"Ca\u0161ka",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/742/73/85674273.geojson
+++ b/data/856/742/73/85674273.geojson
@@ -165,6 +165,9 @@
         "wd:id":"Q1463152"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"47da05fedeff6e85e9ad460c7e7c7300",
     "wof:hierarchy":[
         {
@@ -181,7 +184,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605364,
+    "wof:lastmodified":1582392767,
     "wof:name":"Centar",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/742/75/85674275.geojson
+++ b/data/856/742/75/85674275.geojson
@@ -288,6 +288,9 @@
         "wk:page":"Zrnovci Municipality"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"17471bdabaf94c9bb173b4866dcb5495",
     "wof:hierarchy":[
         {
@@ -304,7 +307,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605365,
+    "wof:lastmodified":1582392767,
     "wof:name":"Zrnovci",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/742/79/85674279.geojson
+++ b/data/856/742/79/85674279.geojson
@@ -298,6 +298,9 @@
         "wd:id":"Q281898"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ee963246c76395eb4adfe06b43c9da46",
     "wof:hierarchy":[
         {
@@ -314,7 +317,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605366,
+    "wof:lastmodified":1582392767,
     "wof:name":"Ce\u0161inovo-Oble\u0161evo",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/742/87/85674287.geojson
+++ b/data/856/742/87/85674287.geojson
@@ -292,6 +292,9 @@
         "wk:page":"\u010cu\u010der-Sandevo Municipality"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"27012eeeeb47945f53a3721fa8097295",
     "wof:hierarchy":[
         {
@@ -308,7 +311,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605365,
+    "wof:lastmodified":1582392767,
     "wof:name":"Cucer Sandevo",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/742/89/85674289.geojson
+++ b/data/856/742/89/85674289.geojson
@@ -216,6 +216,9 @@
         "wd:id":"Q2370973"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ed2a298e9bc566a9386af8ab77d26e7a",
     "wof:hierarchy":[
         {
@@ -232,7 +235,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605364,
+    "wof:lastmodified":1582392767,
     "wof:name":"Demir Kapija",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/742/93/85674293.geojson
+++ b/data/856/742/93/85674293.geojson
@@ -289,6 +289,9 @@
         "wk:page":"Dolneni Municipality"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5bd520fa9bf5d388feabbe3654f2ef8f",
     "wof:hierarchy":[
         {
@@ -305,7 +308,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605364,
+    "wof:lastmodified":1582392767,
     "wof:name":"Dolneni",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/742/97/85674297.geojson
+++ b/data/856/742/97/85674297.geojson
@@ -216,6 +216,9 @@
         "wd:id":"Q2019836"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"34b7b89ffc1167174eeaf5d4e6ca31b0",
     "wof:hierarchy":[
         {
@@ -232,7 +235,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605365,
+    "wof:lastmodified":1582392767,
     "wof:name":"Gazi Baba",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/743/01/85674301.geojson
+++ b/data/856/743/01/85674301.geojson
@@ -289,6 +289,9 @@
         "wk:page":"Gradsko Municipality"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8ef3045a10fb05a4ea4f777c4bae630a",
     "wof:hierarchy":[
         {
@@ -305,7 +308,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605362,
+    "wof:lastmodified":1582392766,
     "wof:name":"Gradsko",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/743/07/85674307.geojson
+++ b/data/856/743/07/85674307.geojson
@@ -286,6 +286,9 @@
         "wk:page":"Lozovo Municipality"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"05ba8ff68600a1fb5bc7d3051cf36afc",
     "wof:hierarchy":[
         {
@@ -302,7 +305,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605362,
+    "wof:lastmodified":1582392766,
     "wof:name":"Lozovo",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/743/11/85674311.geojson
+++ b/data/856/743/11/85674311.geojson
@@ -284,6 +284,9 @@
         "wk:page":"Kon\u010de Municipality"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b79beb4d95a59568ca91b76879f63cce",
     "wof:hierarchy":[
         {
@@ -300,7 +303,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605361,
+    "wof:lastmodified":1582392766,
     "wof:name":"Konce",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/743/15/85674315.geojson
+++ b/data/856/743/15/85674315.geojson
@@ -284,6 +284,9 @@
         "wk:page":"Ilinden Municipality"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"594a0a45e54869a159f23882fea14b69",
     "wof:hierarchy":[
         {
@@ -300,7 +303,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605363,
+    "wof:lastmodified":1582392767,
     "wof:name":"Ilinden",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/743/19/85674319.geojson
+++ b/data/856/743/19/85674319.geojson
@@ -289,6 +289,9 @@
         "wk:page":"Karbinci Municipality"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2597c720d97dfdd0365da0e0534f4c6f",
     "wof:hierarchy":[
         {
@@ -305,7 +308,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605362,
+    "wof:lastmodified":1582392766,
     "wof:name":"Karbinci",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/743/23/85674323.geojson
+++ b/data/856/743/23/85674323.geojson
@@ -220,6 +220,9 @@
         "wd:id":"Q1463246"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f64fc5f132e3cc41e7ce57271fc7e40b",
     "wof:hierarchy":[
         {
@@ -236,7 +239,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605363,
+    "wof:lastmodified":1582392767,
     "wof:name":"Karpo\u0161",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/743/27/85674327.geojson
+++ b/data/856/743/27/85674327.geojson
@@ -283,6 +283,9 @@
         "wk:page":"Kavadarci Municipality"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3f2ed9130e561b3901d0436aa1ddc493",
     "wof:hierarchy":[
         {
@@ -299,7 +302,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605361,
+    "wof:lastmodified":1582392766,
     "wof:name":"Kavadartsi",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/743/31/85674331.geojson
+++ b/data/856/743/31/85674331.geojson
@@ -222,6 +222,9 @@
         "wd:id":"Q1992708"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"07de26e4da17ecdb5b42a9d5fd919893",
     "wof:hierarchy":[
         {
@@ -238,7 +241,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605362,
+    "wof:lastmodified":1582392766,
     "wof:name":"Aerodrom",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/743/37/85674337.geojson
+++ b/data/856/743/37/85674337.geojson
@@ -163,6 +163,9 @@
         "wk:page":"Kisela Voda Municipality"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4aaf036a9fbcedd040ad0ee559b3d882",
     "wof:hierarchy":[
         {
@@ -179,7 +182,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605362,
+    "wof:lastmodified":1582392766,
     "wof:name":"Kisela Voda",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/743/41/85674341.geojson
+++ b/data/856/743/41/85674341.geojson
@@ -290,6 +290,9 @@
         "wk:page":"Ko\u010dani Municipality"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a1d87ac58cf10002509735d446059745",
     "wof:hierarchy":[
         {
@@ -306,7 +309,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605363,
+    "wof:lastmodified":1582392766,
     "wof:name":"Kocani",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/743/45/85674345.geojson
+++ b/data/856/743/45/85674345.geojson
@@ -340,6 +340,9 @@
         "wk:page":"Kratovo, Macedonia"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"201b113013c184519532b87e9ef75555",
     "wof:hierarchy":[
         {
@@ -356,7 +359,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605361,
+    "wof:lastmodified":1582392766,
     "wof:name":"Kratovo",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/743/49/85674349.geojson
+++ b/data/856/743/49/85674349.geojson
@@ -287,6 +287,9 @@
         "wk:page":"Krivoga\u0161tani Municipality"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a0d7777495b163b73ab3959ab9895541",
     "wof:hierarchy":[
         {
@@ -303,7 +306,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605363,
+    "wof:lastmodified":1582392767,
     "wof:name":"Krivoga\u0161tani",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/743/53/85674353.geojson
+++ b/data/856/743/53/85674353.geojson
@@ -293,6 +293,9 @@
         "wk:page":"Kru\u0161evo Municipality"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"286fd551e8d93e136316e2035d8fd997",
     "wof:hierarchy":[
         {
@@ -309,7 +312,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605362,
+    "wof:lastmodified":1582392766,
     "wof:name":"Kru\u0161evo",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/743/55/85674355.geojson
+++ b/data/856/743/55/85674355.geojson
@@ -292,6 +292,9 @@
         "wk:page":"Kumanovo Municipality"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"00a3c4e19b092414367c44d0ec5e3142",
     "wof:hierarchy":[
         {
@@ -308,7 +311,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605363,
+    "wof:lastmodified":1582392766,
     "wof:name":"Kumanovo",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/743/61/85674361.geojson
+++ b/data/856/743/61/85674361.geojson
@@ -274,6 +274,9 @@
         "wk:page":"Makedonski Brod Municipality"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1681b44155730757138c7096c85d1415",
     "wof:hierarchy":[
         {
@@ -290,7 +293,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605361,
+    "wof:lastmodified":1582392766,
     "wof:name":"Brod",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/743/65/85674365.geojson
+++ b/data/856/743/65/85674365.geojson
@@ -219,6 +219,9 @@
         "wk:page":"Mogila Municipality"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a165815dbfa344981de81df3c4d4c96f",
     "wof:hierarchy":[
         {
@@ -235,7 +238,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605362,
+    "wof:lastmodified":1582392766,
     "wof:name":"Pelagonia",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/743/69/85674369.geojson
+++ b/data/856/743/69/85674369.geojson
@@ -286,6 +286,9 @@
         "wk:page":"Negotino Municipality"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"726c1fc768d210f831e79843837295f8",
     "wof:hierarchy":[
         {
@@ -302,7 +305,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605361,
+    "wof:lastmodified":1582392766,
     "wof:name":"Negotino",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/743/73/85674373.geojson
+++ b/data/856/743/73/85674373.geojson
@@ -216,6 +216,9 @@
         "wd:id":"Q2088022"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"566fd832dfb9a432f86e28bd21aa7b90",
     "wof:hierarchy":[
         {
@@ -232,7 +235,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605362,
+    "wof:lastmodified":1582392766,
     "wof:name":"Novatsi",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/743/77/85674377.geojson
+++ b/data/856/743/77/85674377.geojson
@@ -225,6 +225,9 @@
         "wd:id":"Q924278"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2f443db585c7403f66d3a2b86b309f75",
     "wof:hierarchy":[
         {
@@ -241,7 +244,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605363,
+    "wof:lastmodified":1582392766,
     "wof:name":"Gjorce Petrov",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/743/81/85674381.geojson
+++ b/data/856/743/81/85674381.geojson
@@ -277,6 +277,9 @@
         "wk:page":"Zajas Municipality"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"abfd0ba40353f08195bc32de71caab00",
     "wof:hierarchy":[
         {
@@ -293,7 +296,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605362,
+    "wof:lastmodified":1582392766,
     "wof:name":"Zajas",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/743/85/85674385.geojson
+++ b/data/856/743/85/85674385.geojson
@@ -287,6 +287,9 @@
         "wk:page":"Centar \u017dupa Municipality"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2b4f7d61c7682162ad7bd3b312934a82",
     "wof:hierarchy":[
         {
@@ -303,7 +306,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605363,
+    "wof:lastmodified":1582392767,
     "wof:name":"Centar \u017eupa",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/743/89/85674389.geojson
+++ b/data/856/743/89/85674389.geojson
@@ -282,6 +282,9 @@
         "wk:page":"Debar Municipality"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cf85971d129d6cced79993acb7532953",
     "wof:hierarchy":[
         {
@@ -298,7 +301,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605361,
+    "wof:lastmodified":1582392766,
     "wof:name":"Debar",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/743/95/85674395.geojson
+++ b/data/856/743/95/85674395.geojson
@@ -270,6 +270,9 @@
         "wk:page":"Drugovo Municipality"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d8f1f3598c2cd33f066ca5cd384d0e9b",
     "wof:hierarchy":[
         {
@@ -286,7 +289,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605361,
+    "wof:lastmodified":1582392766,
     "wof:name":"Drugovo",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/743/99/85674399.geojson
+++ b/data/856/743/99/85674399.geojson
@@ -293,6 +293,9 @@
         "wk:page":"Ki\u010devo Municipality"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"979770646a545c30a10df852724cc9b4",
     "wof:hierarchy":[
         {
@@ -309,7 +312,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605363,
+    "wof:lastmodified":1582392766,
     "wof:name":"Kicevo",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/744/03/85674403.geojson
+++ b/data/856/744/03/85674403.geojson
@@ -294,6 +294,9 @@
         "wd:id":"Q1323332"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"77d28a406375dc26700e47daec8506d7",
     "wof:hierarchy":[
         {
@@ -310,7 +313,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605359,
+    "wof:lastmodified":1582392765,
     "wof:name":"Mavrovo and Rostusa",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/744/07/85674407.geojson
+++ b/data/856/744/07/85674407.geojson
@@ -275,6 +275,9 @@
         "wd:id":"Q2001785"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9fd665442db115ec073764916c549aa9",
     "wof:hierarchy":[
         {
@@ -291,7 +294,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605360,
+    "wof:lastmodified":1582392765,
     "wof:name":"Oslomej",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/744/13/85674413.geojson
+++ b/data/856/744/13/85674413.geojson
@@ -282,6 +282,9 @@
         "wk:page":"Tearce Municipality"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ced461331e0342b2e8e1030c3f3d5279",
     "wof:hierarchy":[
         {
@@ -298,7 +301,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605361,
+    "wof:lastmodified":1582392766,
     "wof:name":"Tearce",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/744/17/85674417.geojson
+++ b/data/856/744/17/85674417.geojson
@@ -288,6 +288,9 @@
         "wk:page":"Tetovo Municipality"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"113b1af2e34d3a499bb1afb5d46754d6",
     "wof:hierarchy":[
         {
@@ -304,7 +307,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605359,
+    "wof:lastmodified":1582392765,
     "wof:name":"Tetovo",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/744/21/85674421.geojson
+++ b/data/856/744/21/85674421.geojson
@@ -224,6 +224,9 @@
         "wk:page":"Vrap\u010di\u0161te Municipality"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"baa7b925242dc0638ef24afbc95e0020",
     "wof:hierarchy":[
         {
@@ -240,7 +243,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605360,
+    "wof:lastmodified":1582392765,
     "wof:name":"Polog",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/744/25/85674425.geojson
+++ b/data/856/744/25/85674425.geojson
@@ -291,6 +291,9 @@
         "wd:id":"Q9035785"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2c3c364efeb8a9f7a09e4a50d63db76f",
     "wof:hierarchy":[
         {
@@ -307,7 +310,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605361,
+    "wof:lastmodified":1582392766,
     "wof:name":"Bogovinje",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/744/27/85674427.geojson
+++ b/data/856/744/27/85674427.geojson
@@ -286,6 +286,9 @@
         "wk:page":"Brvenica Municipality"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"000b8a0eaa9e92746037e4511531bdcf",
     "wof:hierarchy":[
         {
@@ -302,7 +305,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605359,
+    "wof:lastmodified":1582392765,
     "wof:name":"Brvenica",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/744/33/85674433.geojson
+++ b/data/856/744/33/85674433.geojson
@@ -322,6 +322,9 @@
         "wk:page":"Gostivar Municipality"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"17417210c5ca5314ae38ea4355f21bde",
     "wof:hierarchy":[
         {
@@ -338,7 +341,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605359,
+    "wof:lastmodified":1582392765,
     "wof:name":"Gostivar",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/744/37/85674437.geojson
+++ b/data/856/744/37/85674437.geojson
@@ -289,6 +289,9 @@
         "wk:page":"Jegunovce Municipality"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"412b5d19db1d1ab9aaefb79321bd0081",
     "wof:hierarchy":[
         {
@@ -305,7 +308,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605360,
+    "wof:lastmodified":1582392765,
     "wof:name":"Jegunovce",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/744/39/85674439.geojson
+++ b/data/856/744/39/85674439.geojson
@@ -285,6 +285,9 @@
         "wk:page":"Strumica Municipality"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d03c71b7b39c37e900e0b454f77ee661",
     "wof:hierarchy":[
         {
@@ -301,7 +304,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605360,
+    "wof:lastmodified":1582392765,
     "wof:name":"Southeastern",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/744/43/85674443.geojson
+++ b/data/856/744/43/85674443.geojson
@@ -220,6 +220,9 @@
         "wk:page":"Valandovo Municipality"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"22cecc100e248f2a14a3313235b6649d",
     "wof:hierarchy":[
         {
@@ -236,7 +239,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605360,
+    "wof:lastmodified":1582392765,
     "wof:name":"Valandovo",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/744/49/85674449.geojson
+++ b/data/856/744/49/85674449.geojson
@@ -289,6 +289,9 @@
         "wk:page":"Vasilevo Municipality"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8ee3f2ec7372c38169b02f9abe82ddbd",
     "wof:hierarchy":[
         {
@@ -305,7 +308,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605361,
+    "wof:lastmodified":1582392766,
     "wof:name":"Vasilevo",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/744/53/85674453.geojson
+++ b/data/856/744/53/85674453.geojson
@@ -289,6 +289,9 @@
         "wk:page":"Bogdanci Municipality"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f354fcc097589dcf44884a7aa174c390",
     "wof:hierarchy":[
         {
@@ -305,7 +308,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605360,
+    "wof:lastmodified":1582392765,
     "wof:name":"Bogdanci",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/744/57/85674457.geojson
+++ b/data/856/744/57/85674457.geojson
@@ -285,6 +285,9 @@
         "wk:page":"Bosilovo Municipality"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a5aa62565d923ae8de21b755ff97b766",
     "wof:hierarchy":[
         {
@@ -301,7 +304,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605359,
+    "wof:lastmodified":1582392765,
     "wof:name":"Bosilovo",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/744/61/85674461.geojson
+++ b/data/856/744/61/85674461.geojson
@@ -219,6 +219,9 @@
         "wk:page":"Gevgelija Municipality"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"45b00dc533a7bd532a69a18412616d89",
     "wof:hierarchy":[
         {
@@ -235,7 +238,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605358,
+    "wof:lastmodified":1582392765,
     "wof:name":"Southeastern",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/744/67/85674467.geojson
+++ b/data/856/744/67/85674467.geojson
@@ -280,6 +280,9 @@
         "wk:page":"Novo Selo Municipality"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"10e9f387e15b37fbe309bb42416feedc",
     "wof:hierarchy":[
         {
@@ -296,7 +299,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605359,
+    "wof:lastmodified":1582392765,
     "wof:name":"Novo Selo",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/744/73/85674473.geojson
+++ b/data/856/744/73/85674473.geojson
@@ -230,6 +230,9 @@
         "wk:page":"Dojran Municipality"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b31cf8275c54439879d7249184abfcc3",
     "wof:hierarchy":[
         {
@@ -246,7 +249,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605359,
+    "wof:lastmodified":1582392765,
     "wof:name":"Dojran",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/744/75/85674475.geojson
+++ b/data/856/744/75/85674475.geojson
@@ -283,6 +283,9 @@
         "wk:page":"Vinica Municipality, Macedonia"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"eb43e83f157b0769e05fb3d98d6c4917",
     "wof:hierarchy":[
         {
@@ -299,7 +302,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605360,
+    "wof:lastmodified":1582392765,
     "wof:name":"Vinitsa",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/744/79/85674479.geojson
+++ b/data/856/744/79/85674479.geojson
@@ -285,6 +285,9 @@
         "wd:id":"Q793727"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b76f64038dfe419359e817190c308803",
     "wof:hierarchy":[
         {
@@ -301,7 +304,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605360,
+    "wof:lastmodified":1582392766,
     "wof:name":"Berovo",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/744/85/85674485.geojson
+++ b/data/856/744/85/85674485.geojson
@@ -290,6 +290,9 @@
         "wk:page":"Del\u010devo Municipality"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d320b7de7e5f1b9b7ca30f985827e237",
     "wof:hierarchy":[
         {
@@ -306,7 +309,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605360,
+    "wof:lastmodified":1582392766,
     "wof:name":"Delcevo",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/744/89/85674489.geojson
+++ b/data/856/744/89/85674489.geojson
@@ -277,6 +277,9 @@
         "wk:page":"Makedonska Kamenica Municipality"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"55d84aba269e309b2eebaa36fec8b936",
     "wof:hierarchy":[
         {
@@ -293,7 +296,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605359,
+    "wof:lastmodified":1582392765,
     "wof:name":"Makedonska Kamenica",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/744/95/85674495.geojson
+++ b/data/856/744/95/85674495.geojson
@@ -290,6 +290,9 @@
         "wk:page":"Peh\u010devo Municipality"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a471dfe2346aa25eb782b4afa5c8b212",
     "wof:hierarchy":[
         {
@@ -306,7 +309,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605358,
+    "wof:lastmodified":1582392765,
     "wof:name":"Phecevo",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/744/97/85674497.geojson
+++ b/data/856/744/97/85674497.geojson
@@ -286,6 +286,9 @@
         "wk:page":"Struga Municipality"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b316334319b10e2ca2d1bcd871b32a4c",
     "wof:hierarchy":[
         {
@@ -302,7 +305,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605360,
+    "wof:lastmodified":1582392766,
     "wof:name":"Struga",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/745/03/85674503.geojson
+++ b/data/856/745/03/85674503.geojson
@@ -284,6 +284,9 @@
         "wk:page":"Rankovce Municipality"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2b253cfebfdc815f5d10b5edac5cfd46",
     "wof:hierarchy":[
         {
@@ -300,7 +303,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605366,
+    "wof:lastmodified":1582392768,
     "wof:name":"Rankovce",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/745/07/85674507.geojson
+++ b/data/856/745/07/85674507.geojson
@@ -121,6 +121,9 @@
         "unlc:id":"MK-84"
     },
     "wof:country":"MK",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6c098ef64cdcfa8ea7c6acb86faea6be",
     "wof:hierarchy":[
         {
@@ -137,7 +140,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1566605366,
+    "wof:lastmodified":1582392768,
     "wof:name":"\u0160uto Orizari",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/890/491/957/890491957.geojson
+++ b/data/890/491/957/890491957.geojson
@@ -636,6 +636,9 @@
     },
     "wof:country":"MK",
     "wof:created":1469054871,
+    "wof:geom_alt":[
+        "unknown"
+    ],
     "wof:geomhash":"ef1e2ba9051677f4032425a5e3193e22",
     "wof:hierarchy":[
         {
@@ -646,7 +649,7 @@
         }
     ],
     "wof:id":890491957,
-    "wof:lastmodified":1566605460,
+    "wof:lastmodified":1582392770,
     "wof:name":"Skopje",
     "wof:parent_id":85674273,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.