### PR TITLE
Update non-ascii names, store existing localized names

### DIFF
--- a/data/890/491/769/890491769.geojson
+++ b/data/890/491/769/890491769.geojson
@@ -53,7 +53,7 @@
         }
     ],
     "wof:id":890491769,
-    "wof:lastmodified":1601068497,
+    "wof:lastmodified":1601423136,
     "wof:name":"Creshevo",
     "wof:parent_id":85674297,
     "wof:placetype":"locality",

--- a/data/890/491/769/890491769.geojson
+++ b/data/890/491/769/890491769.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":11.0,
+    "name:eng_x_preferred":[
+        "Creshevo"
+    ],
+    "name:rus_x_preferred":[
+        "\u0426\u0440\u0435\u0448\u0435\u0432\u043e"
+    ],
     "qs:name":"\u0426\u0440\u0435\u0448\u0435\u0432\u043e",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -47,8 +53,8 @@
         }
     ],
     "wof:id":890491769,
-    "wof:lastmodified":1566605461,
-    "wof:name":"\u0426\u0440\u0435\u0448\u0435\u0432\u043e",
+    "wof:lastmodified":1601068497,
+    "wof:name":"Creshevo",
     "wof:parent_id":85674297,
     "wof:placetype":"locality",
     "wof:population":1479,


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/183.

This PR updates loclized `wof:name` values in records that currently have no `name:eng_x_*` properties. There are other records that will need to be updated as part of this work too, but those will be handled in a separate PR.

The existing `wof:name` should be stored in the appropriate `name:*` property, with `wof:name` and `name:eng_x_preferred` properties getting updated English name values.

No PIP work needed, these are just property updates.