### PR TITLE
Update country names

### DIFF
--- a/data/856/323/73/85632373.geojson
+++ b/data/856/323/73/85632373.geojson
@@ -32,28 +32,18 @@
     "mz:is_current":1,
     "mz:max_zoom":10.0,
     "mz:min_zoom":5.0,
-    "name:abk_x_historical":[
-        "\u0410\u04a9\u0430\u0434\u0430\u0442\u04d9\u0438 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u0430"
-    ],
     "name:abk_x_preferred":[
         "\u0410\u04a9\u0430\u0434\u0430\u0442\u04d9\u0438 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u0430"
     ],
-    "name:ace_x_historical":[
-        "Mak\u00e8donia Utara"
-    ],
     "name:ace_x_preferred":[
         "Mak\u00e8donia Utara"
-    ],
-    "name:ady_x_historical":[
-        "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u044d\u0443 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u0435"
     ],
     "name:ady_x_preferred":[
         "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u044d\u0443 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u0435"
     ],
     "name:afr_x_historical":[
         "Masedoni\u00eb (dubbelsinnig)",
-        "Macedoni\u00eb",
-        "Republiek Noord-Masedoni\u00eb"
+        "Macedoni\u00eb"
     ],
     "name:afr_x_preferred":[
         "Republiek Noord-Masedoni\u00eb"
@@ -64,33 +54,24 @@
     "name:aka_x_preferred":[
         "Republic of Macedonia"
     ],
-    "name:als_x_historical":[
-        "Mazedonien (Begriffskl\u00e4rung)"
-    ],
     "name:amh_x_historical":[
-        "\u121b\u12a8\u12f6\u1292\u12eb",
-        "\u12e8\u1218\u1244\u12f6\u1295\u12eb \u122c\u1351\u1265\u120a\u12ad"
+        "\u121b\u12a8\u12f6\u1292\u12eb"
     ],
     "name:amh_x_preferred":[
         "\u12e8\u1218\u1244\u12f6\u1295\u12eb \u122c\u1351\u1265\u120a\u12ad"
-    ],
-    "name:ang_x_historical":[
-        "Cynew\u012bse Macedonia"
     ],
     "name:ang_x_preferred":[
         "Cynew\u012bse Macedonia"
     ],
     "name:ara_x_historical":[
         "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0645\u0642\u062f\u0648\u0646\u064a\u0627",
-        "\u0645\u0642\u062f\u0648\u0646\u064a\u0627",
-        "\u0645\u0642\u062f\u0648\u0646\u064a\u0627 \u0627\u0644\u0634\u0645\u0627\u0644\u064a\u0629"
+        "\u0645\u0642\u062f\u0648\u0646\u064a\u0627"
     ],
     "name:ara_x_preferred":[
         "\u0645\u0642\u062f\u0648\u0646\u064a\u0627 \u0627\u0644\u0634\u0645\u0627\u0644\u064a\u0629"
     ],
     "name:arc_x_historical":[
-        "\u0721\u0729\u0715\u0718\u0722\u071d\u0710",
-        "\u0729\u0718\u071b\u0722\u071d\u0718\u072c\u0710 \u0715\u0721\u0729\u0715\u0718\u0722\u071d\u0710"
+        "\u0721\u0729\u0715\u0718\u0722\u071d\u0710"
     ],
     "name:arc_x_preferred":[
         "\u0729\u0718\u071b\u0722\u071d\u0718\u072c\u0710 \u0715\u0721\u0729\u0715\u0718\u0722\u071d\u0710"
@@ -105,8 +86,7 @@
         "\u0634\u0645\u0627\u0644 \u0645\u0642\u062f\u0648\u0646\u064a\u0627"
     ],
     "name:arz_x_historical":[
-        "\u0645\u0642\u062f\u0648\u0646\u064a\u0627",
-        "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0645\u0642\u062f\u0648\u0646\u064a\u0627"
+        "\u0645\u0642\u062f\u0648\u0646\u064a\u0627"
     ],
     "name:arz_x_preferred":[
         "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0645\u0642\u062f\u0648\u0646\u064a\u0627"
@@ -117,9 +97,6 @@
     ],
     "name:ast_x_preferred":[
         "Macedonia del Norte"
-    ],
-    "name:ava_x_historical":[
-        "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f"
     ],
     "name:ava_x_preferred":[
         "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f"
@@ -139,27 +116,19 @@
     ],
     "name:aze_x_historical":[
         "Makedoniya",
-        "Masedoniya",
-        "\u015eimali Makedoniya"
+        "Masedoniya"
     ],
     "name:aze_x_preferred":[
         "\u015eimali Makedoniya"
     ],
-    "name:bak_x_historical":[
-        "\u0422\u04e9\u043d\u044c\u044f\u04a1 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f"
-    ],
     "name:bak_x_preferred":[
         "\u0422\u04e9\u043d\u044c\u044f\u04a1 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f"
-    ],
-    "name:bam_x_historical":[
-        "Maced\u0254ni"
     ],
     "name:ban_x_preferred":[
         "Macedonia Utara"
     ],
     "name:bar_x_historical":[
-        "Mazedonien (Begriffskl\u00e4rung)",
-        "Noadmazedonien"
+        "Mazedonien (Begriffskl\u00e4rung)"
     ],
     "name:bar_x_preferred":[
         "Noadmazedonien"
@@ -171,8 +140,7 @@
         "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0456\u044f, \u0437\u043d\u0430\u0447\u044d\u043d\u043d\u0456",
         "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0456\u044f",
         "\u0420\u044d\u0441\u043f\u0443\u0431\u043b\u0456\u043a\u0430 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0456\u044f",
-        "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0456\u044f, \u0411\u042e\u0420",
-        "\u041f\u0430\u045e\u043d\u043e\u0447\u043d\u0430\u044f \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0456\u044f"
+        "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0456\u044f, \u0411\u042e\u0420"
     ],
     "name:bel_x_preferred":[
         "\u041f\u0430\u045e\u043d\u043e\u0447\u043d\u0430\u044f \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0456\u044f"
@@ -184,20 +152,11 @@
     "name:ben_x_preferred":[
         "\u0989\u09a4\u09cd\u09a4\u09b0 \u09ae\u09c7\u09b8\u09bf\u09a1\u09cb\u09a8\u09bf\u09af\u09bc\u09be"
     ],
-    "name:bho_x_historical":[
-        "\u092e\u0947\u0938\u0940\u0921\u094b\u0928\u093f\u092f\u093e"
-    ],
     "name:bho_x_preferred":[
         "\u092e\u0947\u0938\u0940\u0921\u094b\u0928\u093f\u092f\u093e"
     ],
-    "name:bis_x_historical":[
-        "Not Macedonia"
-    ],
     "name:bis_x_preferred":[
         "Not Macedonia"
-    ],
-    "name:bod_x_historical":[
-        "\u0f58\u0f0b\u0f66\u0f7a\u0f0b\u0f4c\u0f7c\u0f0b\u0f53\u0f72\u0f61\u0f0d"
     ],
     "name:bod_x_preferred":[
         "\u0f58\u0f0b\u0f66\u0f7a\u0f0b\u0f4c\u0f7c\u0f0b\u0f53\u0f72\u0f61\u0f0d"
@@ -209,9 +168,6 @@
     ],
     "name:bos_x_preferred":[
         "Sjeverna Makedonija"
-    ],
-    "name:bpy_x_historical":[
-        "\u09ae\u09c7\u09b8\u09bf\u09a1\u09cb\u09a8\u09bf\u09af\u09bc\u09be"
     ],
     "name:bpy_x_preferred":[
         "\u09ae\u09c7\u09b8\u09bf\u09a1\u09cb\u09a8\u09bf\u09af\u09bc\u09be"
@@ -226,14 +182,10 @@
     "name:bul_x_historical":[
         "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f",
         "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f, \u0420\u0435\u043f\u0443\u0431\u043b\u0438\u043a\u0430",
-        "\u0420\u0435\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f",
-        "\u0421\u0435\u0432\u0435\u0440\u043d\u0430 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f"
+        "\u0420\u0435\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f"
     ],
     "name:bul_x_preferred":[
         "\u0421\u0435\u0432\u0435\u0440\u043d\u0430 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f"
-    ],
-    "name:bxr_x_historical":[
-        "\u0425\u043e\u0439\u0442\u043e \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438"
     ],
     "name:bxr_x_preferred":[
         "\u0425\u043e\u0439\u0442\u043e \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438"
@@ -244,9 +196,6 @@
     ],
     "name:cat_x_preferred":[
         "Maced\u00f2nia del Nord"
-    ],
-    "name:cdo_x_historical":[
-        "B\u00e1e\u0324k M\u0101-g\u00ec-d\u00f3ng"
     ],
     "name:cdo_x_preferred":[
         "B\u00e1e\u0324k M\u0101-g\u00ec-d\u00f3ng"
@@ -261,8 +210,7 @@
         "Makedonie (rozcestn\u00edk)",
         "Macedonia",
         "Republika Makedonie",
-        "Makedonie",
-        "Severn\u00ed Makedonie"
+        "Makedonie"
     ],
     "name:ces_x_preferred":[
         "Severn\u00ed Makedonie"
@@ -273,15 +221,11 @@
     "name:che_x_preferred":[
         "\u041a\u044a\u0438\u043b\u0431\u0430\u0441\u0435\u0434\u0430 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438"
     ],
-    "name:chr_x_historical":[
-        "\u13b9\u13ce\u13d9\u13c2\u13ef"
-    ],
     "name:chr_x_preferred":[
         "\u13b9\u13ce\u13d9\u13c2\u13ef"
     ],
     "name:chu_x_historical":[
-        "\u041c\u0430\u043a\u0454\u0434\u043e\u043d\u0457\ua657 \u00b7 \u0441\u044a\u043c\ua651\u0441\u043b\u0438",
-        "\u0421\u0463\u0432\u0454\u0440\u044c\u043d\u0430 \u041c\u0430\u043a\u0454\u0434\u043e\u043d\u0457\ua657"
+        "\u041c\u0430\u043a\u0454\u0434\u043e\u043d\u0457\ua657 \u00b7 \u0441\u044a\u043c\ua651\u0441\u043b\u0438"
     ],
     "name:chu_x_preferred":[
         "\u0421\u0463\u0432\u0454\u0440\u044c\u043d\u0430 \u041c\u0430\u043a\u0454\u0434\u043e\u043d\u0457\ua657"
@@ -292,48 +236,33 @@
     "name:chv_x_preferred":[
         "\u00c7\u0443\u0440\u00e7\u0115\u0440 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438"
     ],
-    "name:ckb_x_historical":[
-        "\u06a9\u06c6\u0645\u0627\u0631\u06cc \u0645\u06d5\u0642\u062f\u0648\u0648\u0646\u06cc\u0627"
-    ],
     "name:ckb_x_preferred":[
         "\u06a9\u06c6\u0645\u0627\u0631\u06cc \u0645\u06d5\u0642\u062f\u0648\u0648\u0646\u06cc\u0627"
-    ],
-    "name:cor_x_historical":[
-        "Repoblek Makedoni"
     ],
     "name:cor_x_preferred":[
         "Repoblek Makedoni"
     ],
     "name:crh_x_historical":[
-        "Makedoniya",
-        "\u015eimaliy Makedoniya"
+        "Makedoniya"
     ],
     "name:crh_x_preferred":[
         "\u015eimaliy Makedoniya"
-    ],
-    "name:csb_x_historical":[
-        "Nordow\u00f4 Macedo\u0144sk\u00f4"
     ],
     "name:csb_x_preferred":[
         "Nordow\u00f4 Macedo\u0144sk\u00f4"
     ],
     "name:cym_x_historical":[
         "Macedonia",
-        "Gweriniaeth Macedonia",
-        "Gogledd Macedonia"
+        "Gweriniaeth Macedonia"
     ],
     "name:cym_x_preferred":[
         "Gogledd Macedonia"
-    ],
-    "name:cze_x_historical":[
-        "Republika Makedonie"
     ],
     "name:dan_x_historical":[
         "Makedonien",
         "Republikken Makedonien",
         "Tidligere jugoslaviske republik Makedonien",
-        "Tidligere Jugoslaviske Republik Makedonien",
-        "Nordmakedonien"
+        "Tidligere Jugoslaviske Republik Makedonien"
     ],
     "name:dan_x_preferred":[
         "Nordmakedonien"
@@ -342,8 +271,7 @@
         "Mazedonien (Begriffskl\u00e4rung)",
         "Mazedonien",
         "Ehemalige Jugoslawische Republik Mazedonien",
-        "Ehemalige jugoslawische Republik Mazedonien",
-        "Nordmazedonien"
+        "Ehemalige jugoslawische Republik Mazedonien"
     ],
     "name:deu_x_preferred":[
         "Nordmazedonien"
@@ -354,9 +282,6 @@
     "name:diq_x_preferred":[
         "Makedonya Z\u0131mey"
     ],
-    "name:div_x_historical":[
-        "\u0789\u07ac\u0790\u07ac\u0791\u07af\u0782\u07a8\u0787\u07a7"
-    ],
     "name:div_x_preferred":[
         "\u0789\u07ac\u0790\u07ac\u0791\u07af\u0782\u07a8\u0787\u07a7"
     ],
@@ -366,21 +291,14 @@
     "name:dsb_x_preferred":[
         "P\u00f3dpo\u0142nocna Makedo\u0144ska"
     ],
-    "name:dty_x_historical":[
-        "\u092e\u094d\u092f\u093e\u0938\u0947\u0921\u094b\u0928\u093f\u092f\u093e"
-    ],
     "name:dty_x_preferred":[
         "\u092e\u094d\u092f\u093e\u0938\u0947\u0921\u094b\u0928\u093f\u092f\u093e"
-    ],
-    "name:efi_x_historical":[
-        "Macedonia"
     ],
     "name:ell_x_historical":[
         "\u039c\u03b1\u03ba\u03b5\u03b4\u03bf\u03bd\u03af\u03b1 (\u03b1\u03c0\u03bf\u03c3\u03b1\u03c6\u03ae\u03bd\u03b9\u03c3\u03b7)",
         "\u03a0\u0393\u0394 \u039c\u03b1\u03ba\u03b5\u03b4\u03bf\u03bd\u03af\u03b1\u03c2",
         "\u03a0\u03c1\u03ce\u03b7\u03bd \u0393\u03b9\u03bf\u03c5\u03b3\u03ba\u03bf\u03c3\u03bb\u03b1\u03b2\u03b9\u03ba\u03ae \u0394\u03b7\u03bc\u03bf\u03ba\u03c1\u03b1\u03c4\u03af\u03b1 \u03c4\u03b7\u03c2 \u039c\u03b1\u03ba\u03b5\u03b4\u03bf\u03bd\u03af\u03b1\u03c2",
-        "\u03a0.\u0393.\u0394. \u039c\u03b1\u03ba\u03b5\u03b4\u03bf\u03bd\u03af\u03b1\u03c2",
-        "\u0392\u03cc\u03c1\u03b5\u03b9\u03b1 \u039c\u03b1\u03ba\u03b5\u03b4\u03bf\u03bd\u03af\u03b1"
+        "\u03a0.\u0393.\u0394. \u039c\u03b1\u03ba\u03b5\u03b4\u03bf\u03bd\u03af\u03b1\u03c2"
     ],
     "name:ell_x_preferred":[
         "\u0392\u03cc\u03c1\u03b5\u03b9\u03b1 \u039c\u03b1\u03ba\u03b5\u03b4\u03bf\u03bd\u03af\u03b1"
@@ -400,8 +318,7 @@
         "The FYR of Macedonia",
         "The Former Yugoslav Republic of Macedonia",
         "Macedonia (FYR)",
-        "Macedonia, The Former Yugoslav Republic Of",
-        "North Macedonia"
+        "Macedonia, The Former Yugoslav Republic Of"
     ],
     "name:eng_x_preferred":[
         "North Macedonia"
@@ -413,16 +330,14 @@
     "name:epo_x_historical":[
         "Makedonio",
         "Makedonujo",
-        "Respubliko Makedonio",
-        "Nord-Makedonio"
+        "Respubliko Makedonio"
     ],
     "name:epo_x_preferred":[
         "Nord-Makedonio"
     ],
     "name:est_x_historical":[
         "Makedoonia Vabariik",
-        "Makedoonia",
-        "P\u00f5hja-Makedoonia"
+        "Makedoonia"
     ],
     "name:est_x_preferred":[
         "P\u00f5hja-Makedoonia"
@@ -430,8 +345,7 @@
     "name:eus_x_historical":[
         "Mazedonia (argipena)",
         "Mazedonia",
-        "Mazedoniako Errepublika",
-        "Ipar Mazedonia"
+        "Mazedoniako Errepublika"
     ],
     "name:eus_x_preferred":[
         "Ipar Mazedonia"
@@ -446,16 +360,14 @@
         "Maced\u00f3nia del Norti"
     ],
     "name:fao_x_historical":[
-        "Maked\u00f3nia",
-        "L\u00fd\u00f0veldi\u00f0 Maked\u00f3nia"
+        "Maked\u00f3nia"
     ],
     "name:fao_x_preferred":[
         "L\u00fd\u00f0veldi\u00f0 Maked\u00f3nia"
     ],
     "name:fas_x_historical":[
         "\u0645\u0642\u062f\u0648\u0646\u06cc\u0647",
-        "\u0645\u06a9\u062f\u0648\u0646\u06cc\u0627",
-        "\u0645\u0642\u062f\u0648\u0646\u06cc\u0647 \u0634\u0645\u0627\u0644\u06cc"
+        "\u0645\u06a9\u062f\u0648\u0646\u06cc\u0627"
     ],
     "name:fas_x_preferred":[
         "\u0645\u0642\u062f\u0648\u0646\u06cc\u0647 \u0634\u0645\u0627\u0644\u06cc"
@@ -465,8 +377,7 @@
         "Macedonia (t\u00e4smennyssivu)",
         "Entinen Jugoslavian tasavalta Makedonia",
         "Makedonian tasavalta",
-        "Makedonian valtakunta",
-        "Pohjois-Makedonia"
+        "Makedonian valtakunta"
     ],
     "name:fin_x_preferred":[
         "Pohjois-Makedonia"
@@ -488,22 +399,17 @@
     "name:frp_x_preferred":[
         "Mac\u00e8donie du Nord"
     ],
-    "name:frr_x_historical":[
-        "Nuurd-Matsedoonien"
-    ],
     "name:frr_x_preferred":[
         "Nuurd-Matsedoonien"
     ],
     "name:fry_x_historical":[
-        "Masedoanje",
-        "Noard-Masedoanje"
+        "Masedoanje"
     ],
     "name:fry_x_preferred":[
         "Noard-Masedoanje"
     ],
     "name:ful_x_historical":[
-        "Meceduwaan",
-        "Masedoniya"
+        "Meceduwaan"
     ],
     "name:ful_x_preferred":[
         "Masedoniya"
@@ -513,9 +419,6 @@
     ],
     "name:fur_x_preferred":[
         "Macedonie dal Nort"
-    ],
-    "name:gag_x_historical":[
-        "Poyraz Makedoniya"
     ],
     "name:gag_x_preferred":[
         "Poyraz Makedoniya"
@@ -532,45 +435,23 @@
     "name:gle_x_preferred":[
         "An Mhacad\u00f3in Thuaidh"
     ],
-    "name:glg_x_historical":[
-        "Macedonia",
-        "Rep\u00fablica de Macedonia"
-    ],
     "name:glv_x_preferred":[
         "Pobblaght y Vassadoan Hwoaie"
-    ],
-    "name:gom_x_historical":[
-        "\u092e\u0945\u0938\u093f\u0921\u094b\u0928\u093f\u092f\u093e"
     ],
     "name:gom_x_preferred":[
         "\u092e\u0945\u0938\u093f\u0921\u094b\u0928\u093f\u092f\u093e"
     ],
-    "name:got_x_historical":[
-        "\ud800\udf3c\ud800\udf30\ud800\udf3a\ud800\udf30\ud800\udf39\ud800\udf33\ud800\udf49\ud800\udf3d\ud800\udf3e\ud800\udf30"
-    ],
     "name:got_x_preferred":[
         "\ud800\udf3c\ud800\udf30\ud800\udf3a\ud800\udf30\ud800\udf39\ud800\udf33\ud800\udf49\ud800\udf3d\ud800\udf3e\ud800\udf30"
-    ],
-    "name:grn_x_historical":[
-        "Yvate Masendo\u00f1a"
     ],
     "name:grn_x_preferred":[
         "Yvate Masendo\u00f1a"
     ],
-    "name:gsw_x_historical":[
-        "Republik Mazedonie"
-    ],
     "name:gsw_x_preferred":[
         "Republik Mazedonie"
     ],
-    "name:guj_x_historical":[
-        "\u0aae\u0ac7\u0ab8\u0ac7\u0aa1\u0acb\u0aa8\u0abf\u0aaf\u0abe"
-    ],
     "name:guj_x_preferred":[
         "\u0aae\u0ac7\u0ab8\u0ac7\u0aa1\u0acb\u0aa8\u0abf\u0aaf\u0abe"
-    ],
-    "name:hak_x_historical":[
-        "Pet Macedonia"
     ],
     "name:hak_x_preferred":[
         "Pet Macedonia"
@@ -587,14 +468,9 @@
     "name:haw_x_preferred":[
         "Repupalika o \u2018\u0100kau Masedonia"
     ],
-    "name:hbs_x_historical":[
-        "Masidonija",
-        "Republika Makedonija"
-    ],
     "name:heb_x_historical":[
         "\u05de\u05e7\u05d3\u05d5\u05e0\u05d9\u05d4 (\u05e4\u05d9\u05e8\u05d5\u05e9\u05d5\u05e0\u05d9\u05dd)",
-        "\u05de\u05e7\u05d3\u05d5\u05e0\u05d9\u05d4",
-        "\u05de\u05e7\u05d3\u05d5\u05e0\u05d9\u05d4 \u05d4\u05e6\u05e4\u05d5\u05e0\u05d9\u05ea"
+        "\u05de\u05e7\u05d3\u05d5\u05e0\u05d9\u05d4"
     ],
     "name:heb_x_preferred":[
         "\u05de\u05e7\u05d3\u05d5\u05e0\u05d9\u05d4 \u05d4\u05e6\u05e4\u05d5\u05e0\u05d9\u05ea"
@@ -604,8 +480,7 @@
     ],
     "name:hin_x_historical":[
         "\u092e\u0948\u0938\u0947\u0921\u094b\u0928\u093f\u092f\u093e",
-        "\u092e\u0948\u0938\u093f\u0921\u094b\u0928\u093f\u092f\u093e",
-        "\u0909\u0924\u094d\u0924\u0930 \u092e\u0948\u0938\u093f\u0921\u094b\u0928\u093f\u092f\u093e"
+        "\u092e\u0948\u0938\u093f\u0921\u094b\u0928\u093f\u092f\u093e"
     ],
     "name:hin_x_preferred":[
         "\u0909\u0924\u094d\u0924\u0930 \u092e\u0948\u0938\u093f\u0921\u094b\u0928\u093f\u092f\u093e"
@@ -614,15 +489,13 @@
         "Makedonija (razdvojba)",
         "Makedonija, Republika",
         "Republika Makedonija",
-        "Makedonija",
-        "Sjeverna Makedonija"
+        "Makedonija"
     ],
     "name:hrv_x_preferred":[
         "Sjeverna Makedonija"
     ],
     "name:hsb_x_historical":[
-        "Makedonska",
-        "Sewjerna Makedonska"
+        "Makedonska"
     ],
     "name:hsb_x_preferred":[
         "Sewjerna Makedonska"
@@ -632,29 +505,23 @@
         "Macedonia (egy\u00e9rtelm\u0171s\u00edt\u0151 lap)",
         "Maced\u00f3n K\u00f6zt\u00e1rsas\u00e1g",
         "Maced\u00f3nia, K\u00f6zt\u00e1rsas\u00e1g",
-        "Maked\u00f3nia",
-        "\u00c9szak-Maced\u00f3nia"
+        "Maked\u00f3nia"
     ],
     "name:hun_x_preferred":[
         "\u00c9szak-Maced\u00f3nia"
     ],
     "name:hye_x_historical":[
         "\u0544\u0561\u056f\u0565\u0564\u0578\u0576\u056b\u0561 (\u0561\u0575\u056c \u056f\u056b\u0580\u0561\u057c\u0578\u0582\u0574\u0576\u0565\u0580)",
-        "\u0544\u0561\u056f\u0565\u0564\u0578\u0576\u056b\u0561",
-        "\u0540\u0575\u0578\u0582\u057d\u056b\u057d\u0561\u0575\u056b\u0576 \u0544\u0561\u056f\u0565\u0564\u0578\u0576\u056b\u0561"
+        "\u0544\u0561\u056f\u0565\u0564\u0578\u0576\u056b\u0561"
     ],
     "name:hye_x_preferred":[
         "\u0540\u0575\u0578\u0582\u057d\u056b\u057d\u0561\u0575\u056b\u0576 \u0544\u0561\u056f\u0565\u0564\u0578\u0576\u056b\u0561"
-    ],
-    "name:ibo_x_historical":[
-        "Macedonia"
     ],
     "name:ibo_x_preferred":[
         "Macedonia"
     ],
     "name:ido_x_historical":[
-        "Republiko Macedonia",
-        "Republiko Norda-Macedonia"
+        "Republiko Macedonia"
     ],
     "name:ido_x_preferred":[
         "Republiko Norda-Macedonia"
@@ -668,10 +535,6 @@
     "name:ilo_x_preferred":[
         "Amianan a Macedonia"
     ],
-    "name:ina_x_historical":[
-        "Macedonia (disambiguation)",
-        "Macedonia"
-    ],
     "name:ind_x_historical":[
         "Macedonia",
         "Republik Makedonia",
@@ -682,8 +545,7 @@
     ],
     "name:isl_x_historical":[
         "Maked\u00f3n\u00eda",
-        "L\u00fd\u00f0veldi\u00f0 Maked\u00f3n\u00eda",
-        "Nor\u00f0ur-Maked\u00f3n\u00eda"
+        "L\u00fd\u00f0veldi\u00f0 Maked\u00f3n\u00eda"
     ],
     "name:isl_x_preferred":[
         "Nor\u00f0ur-Maked\u00f3n\u00eda"
@@ -699,14 +561,10 @@
         "Macedonia del Nord"
     ],
     "name:jam_x_historical":[
-        "Ripoblik a Masiduonia",
         "Masiduonia"
     ],
     "name:jam_x_preferred":[
         "Ripoblik a Masiduonia"
-    ],
-    "name:jav_x_historical":[
-        "R\u00e9publik Makedonia"
     ],
     "name:jav_x_preferred":[
         "R\u00e9publik Makedonia"
@@ -715,20 +573,13 @@
         "\u30de\u30b1\u30c9\u30cb\u30a2",
         "\u30de\u30b1\u30c9\u30cb\u30a2 (\u66d6\u6627\u3055\u56de\u907f)",
         "\u30de\u30b1\u30c9\u30cb\u30a2\u5171\u548c\u56fd",
-        "\u30de\u30b1\u30c9\u30cb\u30a2\u65e7\u30e6\u30fc\u30b4\u30b9\u30e9\u30d3\u30a2\u5171\u548c\u56fd",
-        "\u5317\u30de\u30b1\u30c9\u30cb\u30a2"
+        "\u30de\u30b1\u30c9\u30cb\u30a2\u65e7\u30e6\u30fc\u30b4\u30b9\u30e9\u30d3\u30a2\u5171\u548c\u56fd"
     ],
     "name:jpn_x_preferred":[
         "\u5317\u30de\u30b1\u30c9\u30cb\u30a2"
     ],
-    "name:kaa_x_historical":[
-        "Makedoniya"
-    ],
     "name:kaa_x_preferred":[
         "Makedoniya"
-    ],
-    "name:kal_x_historical":[
-        "Makedonia"
     ],
     "name:kal_x_preferred":[
         "Makedonia"
@@ -742,8 +593,7 @@
     ],
     "name:kat_x_historical":[
         "\u10db\u10d0\u10d9\u10d4\u10d3\u10dd\u10dc\u10d8\u10d0 (\u10db\u10e0\u10d0\u10d5\u10d0\u10da\u10db\u10dc\u10d8\u10e8\u10d5\u10dc\u10d4\u10da\u10dd\u10d5\u10d0\u10dc\u10d8)",
-        "\u10db\u10d0\u10d9\u10d4\u10d3\u10dd\u10dc\u10d8\u10d0",
-        "\u10e9\u10e0\u10d3\u10d8\u10da\u10dd\u10d4\u10d7\u10d8 \u10db\u10d0\u10d9\u10d4\u10d3\u10dd\u10dc\u10d8\u10d0"
+        "\u10db\u10d0\u10d9\u10d4\u10d3\u10dd\u10dc\u10d8\u10d0"
     ],
     "name:kat_x_preferred":[
         "\u10e9\u10e0\u10d3\u10d8\u10da\u10dd\u10d4\u10d7\u10d8 \u10db\u10d0\u10d9\u10d4\u10d3\u10dd\u10dc\u10d8\u10d0"
@@ -754,30 +604,20 @@
     "name:kaz_x_preferred":[
         "\u0421\u043e\u043b\u0442\u04af\u0441\u0442\u0456\u043a \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f"
     ],
-    "name:kbd_x_historical":[
-        "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u044d \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044d"
-    ],
     "name:kbd_x_preferred":[
         "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u044d \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044d"
     ],
     "name:khm_x_historical":[
-        "\u1798\u17c9\u17b6\u179f\u17c1\u178a\u1793",
-        "\u1798\u17c9\u17b6\u179f\u17c1\u178a\u17bc\u1793\u17b6\u1781\u17b6\u1784\u178f\u17d2\u1794\u17bc\u1784"
+        "\u1798\u17c9\u17b6\u179f\u17c1\u178a\u1793"
     ],
     "name:khm_x_preferred":[
         "\u1798\u17c9\u17b6\u179f\u17c1\u178a\u17bc\u1793\u17b6\u1781\u17b6\u1784\u178f\u17d2\u1794\u17bc\u1784"
-    ],
-    "name:kik_x_historical":[
-        "Masedonia"
     ],
     "name:kin_x_historical":[
         "Masedoniya"
     ],
     "name:kin_x_preferred":[
         "Masedoniya ya Ruguru"
-    ],
-    "name:kir_x_historical":[
-        "\u0422\u04af\u043d\u0434\u04af\u043a \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f"
     ],
     "name:kir_x_preferred":[
         "\u0422\u04af\u043d\u0434\u04af\u043a \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f"
@@ -788,14 +628,8 @@
     "name:koi_x_preferred":[
         "\u041e\u0439\u0432\u044b\u0432 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f"
     ],
-    "name:kom_x_historical":[
-        "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430"
-    ],
     "name:kom_x_preferred":[
         "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430"
-    ],
-    "name:kon_x_historical":[
-        "Makedonia"
     ],
     "name:kon_x_preferred":[
         "Makedonia"
@@ -804,34 +638,25 @@
         "\ub9c8\ucf00\ub3c4\ub2c8\uc544 \uacf5\ud654\uad6d",
         "\ub9c8\ucf00\ub3c4\ub2c8\uc544",
         "\ub9c8\ucf00\ub3c4\ub2c8\uc544\uc5b4",
-        "\uc804 \uc720\uace0\uc2ac\ub77c\ube44\uc544 \ub9c8\ucf00\ub3c4\ub2c8\uc544",
-        "\ubd81\ub9c8\ucf00\ub3c4\ub2c8\uc544"
+        "\uc804 \uc720\uace0\uc2ac\ub77c\ube44\uc544 \ub9c8\ucf00\ub3c4\ub2c8\uc544"
     ],
     "name:kor_x_preferred":[
         "\ubd81\ub9c8\ucf00\ub3c4\ub2c8\uc544"
-    ],
-    "name:krc_x_historical":[
-        "\u0428\u0438\u043c\u0430\u043b \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f"
     ],
     "name:krc_x_preferred":[
         "\u0428\u0438\u043c\u0430\u043b \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f"
     ],
     "name:kur_x_historical":[
-        "Komara Makedonyay\u00ea",
-        "Makedonyaya Bakur"
+        "Komara Makedonyay\u00ea"
     ],
     "name:kur_x_preferred":[
         "Makedonyaya Bakur"
-    ],
-    "name:lad_x_historical":[
-        "Makedonia"
     ],
     "name:lad_x_preferred":[
         "Makedonia"
     ],
     "name:lao_x_historical":[
-        "\u0ec1\u0ea1\u0e8a\u0eb4\u0ec2\u0e84\u0ec0\u0e99\u0e8d",
-        "\u0ea1\u0eb2\u0e8a\u0eb4\u0ec2\u0e94\u0ec0\u0e99\u0e8d\u0ec0\u0edc\u0eb7\u0ead"
+        "\u0ec1\u0ea1\u0e8a\u0eb4\u0ec2\u0e84\u0ec0\u0e99\u0e8d"
     ],
     "name:lao_x_preferred":[
         "\u0ea1\u0eb2\u0e8a\u0eb4\u0ec2\u0e94\u0ec0\u0e99\u0e8d\u0ec0\u0edc\u0eb7\u0ead"
@@ -845,8 +670,7 @@
     ],
     "name:lav_x_historical":[
         "Ma\u0137edonija",
-        "Ma\u0137edonijas Republika",
-        "Zieme\u013cma\u0137edonija"
+        "Ma\u0137edonijas Republika"
     ],
     "name:lav_x_preferred":[
         "Zieme\u013cma\u0137edonija"
@@ -858,8 +682,7 @@
         "Macedonia Norde"
     ],
     "name:lim_x_historical":[
-        "Macedoni\u00eb",
-        "Noord-Macedoni\u00eb"
+        "Macedoni\u00eb"
     ],
     "name:lim_x_preferred":[
         "Noord-Macedoni\u00eb"
@@ -871,8 +694,7 @@
         "Masedoni ya Nola"
     ],
     "name:lit_x_historical":[
-        "Makedonija",
-        "\u0160iaur\u0117s Makedonija"
+        "Makedonija"
     ],
     "name:lit_x_preferred":[
         "\u0160iaur\u0117s Makedonija"
@@ -895,20 +717,8 @@
     "name:ltg_x_preferred":[
         "Z\u012bme\u013cmakedoneja"
     ],
-    "name:ltz_x_historical":[
-        "Nordmazedonien"
-    ],
     "name:ltz_x_preferred":[
         "Nordmazedonien"
-    ],
-    "name:lub_x_historical":[
-        "Masedwane"
-    ],
-    "name:lug_x_historical":[
-        "Masedoniya"
-    ],
-    "name:lzh_x_historical":[
-        "\u5317\u99ac\u5176\u9813"
     ],
     "name:lzh_x_preferred":[
         "\u5317\u99ac\u5176\u9813"
@@ -916,28 +726,20 @@
     "name:mad_x_preferred":[
         "Makedonia"
     ],
-    "name:mai_x_historical":[
-        "\u092e\u094d\u092f\u093e\u0938\u0947\u0921\u094b\u0928\u093f\u092f\u093e"
-    ],
     "name:mai_x_preferred":[
         "\u092e\u094d\u092f\u093e\u0938\u0947\u0921\u094b\u0928\u093f\u092f\u093e"
     ],
     "name:mal_x_historical":[
-        "\u0d2e\u0d3e\u0d38\u0d3f\u0d21\u0d4b\u0d23\u0d3f\u0d2f",
-        "\u0d28\u0d4b\u0d7c\u0d24\u0d4d\u0d24\u0d4d \u0d2e\u0d3e\u0d38\u0d3f\u0d21\u0d4b\u0d23\u0d3f\u0d2f"
+        "\u0d2e\u0d3e\u0d38\u0d3f\u0d21\u0d4b\u0d23\u0d3f\u0d2f"
     ],
     "name:mal_x_preferred":[
         "\u0d28\u0d4b\u0d7c\u0d24\u0d4d\u0d24\u0d4d \u0d2e\u0d3e\u0d38\u0d3f\u0d21\u0d4b\u0d23\u0d3f\u0d2f"
     ],
     "name:mar_x_historical":[
-        "\u092e\u0945\u0938\u0947\u0921\u094b\u0928\u093f\u092f\u093e",
-        "\u0909\u0924\u094d\u0924\u0930 \u092e\u0945\u0938\u093f\u0921\u094b\u0928\u093f\u092f\u093e"
+        "\u092e\u0945\u0938\u0947\u0921\u094b\u0928\u093f\u092f\u093e"
     ],
     "name:mar_x_preferred":[
         "\u0909\u0924\u094d\u0924\u0930 \u092e\u0945\u0938\u093f\u0921\u094b\u0928\u093f\u092f\u093e"
-    ],
-    "name:mdf_x_historical":[
-        "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u0435"
     ],
     "name:mdf_x_preferred":[
         "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u0435"
@@ -950,7 +752,6 @@
     ],
     "name:mkd_x_historical":[
         "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u0458\u0430 (\u043f\u043e\u0458\u0430\u0441\u043d\u0443\u0432\u0430\u045a\u0435)",
-        "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u0458\u0430",
         "\u0420\u0435\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u0458\u0430"
     ],
     "name:mkd_x_preferred":[
@@ -969,14 +770,8 @@
     "name:mlt_x_preferred":[
         "Ma\u010bedonja ta' Fuq"
     ],
-    "name:mon_x_historical":[
-        "\u0423\u043c\u0430\u0440\u0434 \u041c\u0430\u043a\u0435\u0434\u043e\u043d"
-    ],
     "name:mon_x_preferred":[
         "\u0423\u043c\u0430\u0440\u0434 \u041c\u0430\u043a\u0435\u0434\u043e\u043d"
-    ],
-    "name:mri_x_historical":[
-        "Maker\u014dnia"
     ],
     "name:mri_x_preferred":[
         "Maker\u014dnia"
@@ -988,69 +783,41 @@
     "name:msa_x_preferred":[
         "Makedonia Utara"
     ],
-    "name:mwl_x_historical":[
-        "Maced\u00f3nia"
-    ],
     "name:mya_x_historical":[
-        "\u1019\u102c\u1005\u102e\u1012\u102d\u102f\u1038\u1014\u102e\u1038\u101a\u102c\u1038",
-        "\u1019\u1000\u103a\u1005\u102e\u1012\u102d\u102f\u1038\u1014\u102e\u1038\u101a\u102c\u1038\u1014\u102d\u102f\u1004\u103a\u1004\u1036"
+        "\u1019\u102c\u1005\u102e\u1012\u102d\u102f\u1038\u1014\u102e\u1038\u101a\u102c\u1038"
     ],
     "name:mya_x_preferred":[
         "\u1019\u1000\u103a\u1005\u102e\u1012\u102d\u102f\u1038\u1014\u102e\u1038\u101a\u102c\u1038\u1014\u102d\u102f\u1004\u103a\u1004\u1036"
     ],
-    "name:myv_x_historical":[
-        "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f \u041c\u0430\u0441\u0442\u043e\u0440"
-    ],
     "name:myv_x_preferred":[
         "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f \u041c\u0430\u0441\u0442\u043e\u0440"
-    ],
-    "name:mzn_x_historical":[
-        "\u0645\u0642\u062f\u0648\u0646\u06cc\u0647"
     ],
     "name:mzn_x_preferred":[
         "\u0645\u0642\u062f\u0648\u0646\u06cc\u0647"
     ],
-    "name:nah_x_historical":[
-        "Tl\u0101catlahtohc\u0101y\u014dtl Macedonia"
-    ],
     "name:nah_x_preferred":[
         "Tl\u0101catlahtohc\u0101y\u014dtl Macedonia"
-    ],
-    "name:nan_x_historical":[
-        "Pak Macedonia"
     ],
     "name:nan_x_preferred":[
         "Pak Macedonia"
     ],
     "name:nau_x_historical":[
-        "Macedonia",
-        "Matedoniya"
+        "Macedonia"
     ],
     "name:nau_x_preferred":[
         "Matedoniya"
     ],
-    "name:nde_x_historical":[
-        "Macedonia"
-    ],
-    "name:nds_nld_x_historical":[
-        "Massedoni\u00eb"
-    ],
     "name:nds_x_historical":[
         "Makedonien",
-        "Republiek Makedonien",
-        "Noordmakedonien"
+        "Republiek Makedonien"
     ],
     "name:nds_x_preferred":[
         "Noordmakedonien"
     ],
     "name:nep_x_historical":[
-        "\u092e\u094d\u092f\u093e\u0938\u0947\u0921\u094b\u0928\u093f\u092f\u093e",
         "\u092e\u094d\u092f\u093e\u0915\u0947\u0921\u094b\u0928\u093f\u092f\u093e"
     ],
     "name:nep_x_preferred":[
-        "\u092e\u094d\u092f\u093e\u0938\u0947\u0921\u094b\u0928\u093f\u092f\u093e"
-    ],
-    "name:new_x_historical":[
         "\u092e\u094d\u092f\u093e\u0938\u0947\u0921\u094b\u0928\u093f\u092f\u093e"
     ],
     "name:new_x_preferred":[
@@ -1063,30 +830,23 @@
         "Macedonia",
         "Voormalige Joegoslavische Republiek Macedoni\u00eb",
         "Macedoni\u00eb, Republiek",
-        "Macedoni\u00eb",
-        "Noord-Macedoni\u00eb"
+        "Macedoni\u00eb"
     ],
     "name:nld_x_preferred":[
         "Noord-Macedoni\u00eb"
     ],
     "name:nno_x_historical":[
         "Makedonia",
-        "Republikken Makedonia",
-        "Nord-Makedonia"
+        "Republikken Makedonia"
     ],
     "name:nno_x_preferred":[
         "Nord-Makedonia"
     ],
     "name:nob_x_historical":[
-        "Makedonia",
-        "Nord-Makedonia"
+        "Makedonia"
     ],
     "name:nob_x_preferred":[
         "Nord-Makedonia"
-    ],
-    "name:nor_x_historical":[
-        "Republikken Makedonia",
-        "Makedonia"
     ],
     "name:oci_x_historical":[
         "Maced\u00f2nia",
@@ -1102,26 +862,16 @@
         "Pohjas-Makedounii"
     ],
     "name:ori_x_historical":[
-        "\u0b2e\u0b3e\u0b38\u0b47\u0b21\u0b4b\u0b28\u0b3f\u0b06",
-        "\u0b2e\u0b3e\u0b38\u0b3f\u0b21\u0b4b\u0b28\u0b3f\u0b06"
+        "\u0b2e\u0b3e\u0b38\u0b47\u0b21\u0b4b\u0b28\u0b3f\u0b06"
     ],
     "name:ori_x_preferred":[
         "\u0b2e\u0b3e\u0b38\u0b3f\u0b21\u0b4b\u0b28\u0b3f\u0b06"
     ],
-    "name:orm_x_historical":[
-        "Maqedooniyaa"
-    ],
     "name:orm_x_preferred":[
         "Maqedooniyaa"
     ],
-    "name:oss_x_historical":[
-        "\u0426\u00e6\u0433\u0430\u0442 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438"
-    ],
     "name:oss_x_preferred":[
         "\u0426\u00e6\u0433\u0430\u0442 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438"
-    ],
-    "name:pag_x_historical":[
-        "Masedoniya"
     ],
     "name:pag_x_preferred":[
         "Masedoniya"
@@ -1135,23 +885,14 @@
     "name:pan_x_preferred":[
         "\u0a30\u0a40\u0a2a\u0a2c\u0a32\u0a3f\u0a15 \u0a06\u0a2b \u0a28\u0a3e\u0a30\u0a25 \u0a2e\u0a15\u0a26\u0a42\u0a28\u0a40\u0a06"
     ],
-    "name:pap_x_historical":[
-        "Nort Macedonia"
-    ],
     "name:pap_x_preferred":[
         "Nort Macedonia"
-    ],
-    "name:pcd_x_historical":[
-        "Mach\u00e9do\u00e8ne"
     ],
     "name:pcd_x_preferred":[
         "Mach\u00e9do\u00e8ne"
     ],
     "name:pih_x_preferred":[
         "Repablik o' Masedoenya"
-    ],
-    "name:pli_x_historical":[
-        "\u092e\u0947\u0938\u0947\u0921\u094b\u0928\u093f\u092f\u093e"
     ],
     "name:pli_x_preferred":[
         "\u092e\u0947\u0938\u0947\u0921\u094b\u0928\u093f\u092f\u093e"
@@ -1162,14 +903,8 @@
     "name:pms_x_preferred":[
         "Maced\u00f2nia d\u00ebl N\u00f2rd"
     ],
-    "name:pnb_x_historical":[
-        "\u0645\u0642\u062f\u0648\u0646\u06cc\u06c1"
-    ],
     "name:pnb_x_preferred":[
         "\u0645\u0642\u062f\u0648\u0646\u06cc\u06c1"
-    ],
-    "name:pnt_x_historical":[
-        "\u0392\u03cc\u03c1\u03b5\u03b9\u03b1 \u039c\u03b1\u03ba\u03b5\u03b4\u03bf\u03bd\u03af\u03b1"
     ],
     "name:pnt_x_preferred":[
         "\u0392\u03cc\u03c1\u03b5\u03b9\u03b1 \u039c\u03b1\u03ba\u03b5\u03b4\u03bf\u03bd\u03af\u03b1"
@@ -1178,8 +913,7 @@
         "Macedonia (ujednoznacznienie)",
         "Macedonia, Republika",
         "Macedonia",
-        "By\u0142a Jugos\u0142owia\u0144ska Republika Macedonii",
-        "Macedonia P\u00f3\u0142nocna"
+        "By\u0142a Jugos\u0142owia\u0144ska Republika Macedonii"
     ],
     "name:pol_x_preferred":[
         "Macedonia P\u00f3\u0142nocna"
@@ -1187,28 +921,14 @@
     "name:por_x_colloquial":[
         "Antiga Republica jugoslava da Macedonia"
     ],
-    "name:por_x_historical":[
-        "Rep\u00fablica da Maced\u00f3nia",
-        "Maced\u00f3nia",
-        "Antiga Rep\u00fablica jugoslava da Maced\u00f3nia",
-        "Maced\u00f4nia, Rep\u00fablica da",
-        "Maced\u00f4nia"
-    ],
-    "name:pus_x_historical":[
-        "\u062f \u0645\u0642\u062f\u0648\u0646\u064a\u06d0 \u0648\u0644\u0633\u0645\u0634\u0631\u064a\u0632\u0647"
-    ],
     "name:pus_x_preferred":[
         "\u062f \u0645\u0642\u062f\u0648\u0646\u064a\u06d0 \u0648\u0644\u0633\u0645\u0634\u0631\u064a\u0632\u0647"
     ],
     "name:que_x_historical":[
-        "Makiduniya",
-        "Chinchay Masitunya"
+        "Makiduniya"
     ],
     "name:que_x_preferred":[
         "Chinchay Masitunya"
-    ],
-    "name:rmy_x_historical":[
-        "Republika Makedoniya"
     ],
     "name:rmy_x_preferred":[
         "Republika Makedoniya"
@@ -1219,70 +939,33 @@
     "name:roh_x_preferred":[
         "Macedonia dal Nord"
     ],
-    "name:ron_x_historical":[
-        "Macedonia",
-        "Republica Macedonia",
-        "Fosta Republic\u0103 Iugoslav\u0103 Macedonia"
-    ],
     "name:rue_x_historical":[
-        "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0456\u044f",
-        "\u0421\u0463\u0432\u0435\u0440\u043d\u0430 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0456\u044f"
+        "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0456\u044f"
     ],
     "name:rue_x_preferred":[
         "\u0421\u0463\u0432\u0435\u0440\u043d\u0430 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0456\u044f"
     ],
-    "name:rum_x_historical":[
-        "Fosta Republic\u0103 Iugoslav\u0103 Macedonia"
-    ],
-    "name:run_x_historical":[
-        "Masedoniya"
-    ],
-    "name:rup_x_historical":[
-        "Republica Machedonia"
-    ],
     "name:rus_x_historical":[
         "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f",
-        "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f",
-        "\u0421\u0435\u0432\u0435\u0440\u043d\u0430\u044f \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f"
+        "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f"
     ],
     "name:rus_x_preferred":[
         "\u0421\u0435\u0432\u0435\u0440\u043d\u0430\u044f \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f"
     ],
-    "name:sag_x_historical":[
-        "Masedu\u00e4ni"
-    ],
-    "name:sah_x_historical":[
-        "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430\u0442\u0430"
-    ],
     "name:sah_x_preferred":[
         "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430\u0442\u0430"
-    ],
-    "name:san_x_historical":[
-        "\u092e\u0947\u0938\u0947\u0921\u094b\u0928\u093f\u092f\u093e"
     ],
     "name:san_x_preferred":[
         "\u092e\u0947\u0938\u0947\u0921\u094b\u0928\u093f\u092f\u093e"
     ],
-    "name:sat_x_historical":[
-        "\u1c62\u1c5f\u1c65\u1c64\u1c70\u1c5a\u1c71\u1c64\u1c6d\u1c5f"
-    ],
     "name:sat_x_preferred":[
         "\u1c62\u1c5f\u1c65\u1c64\u1c70\u1c5a\u1c71\u1c64\u1c6d\u1c5f"
     ],
-    "name:scn_x_historical":[
-        "Macedonia",
-        "Macidonia",
-        "Rip\u00f9bblica di Macidonia"
-    ],
     "name:sco_x_historical":[
-        "Macedonie",
-        "North Macedonie"
+        "Macedonie"
     ],
     "name:sco_x_preferred":[
         "North Macedonie"
-    ],
-    "name:sgs_x_historical":[
-        "Makeduon\u0117j\u0117"
     ],
     "name:sgs_x_preferred":[
         "Makeduon\u0117j\u0117"
@@ -1290,32 +973,26 @@
     "name:shn_x_preferred":[
         "\u1019\u102d\u1030\u1004\u103a\u1038\u1019\u1085\u1010\u103a\u1087\u101e\u102e\u1087\u1010\u1030\u101d\u103a\u1038\u107c\u102e\u1038\u101a\u1083\u1038"
     ],
-    "name:sin_x_historical":[
-        "\u0d8b\u0dad\u0dd4\u0dbb\u0dd4 \u0db8\u0dd0\u0dc3\u0dd2\u0da9\u0ddd\u0db1\u0dd2\u0dba\u0dcf\u0dc0"
-    ],
     "name:sin_x_preferred":[
         "\u0d8b\u0dad\u0dd4\u0dbb\u0dd4 \u0db8\u0dd0\u0dc3\u0dd2\u0da9\u0ddd\u0db1\u0dd2\u0dba\u0dcf\u0dc0"
     ],
     "name:slk_x_historical":[
         "Maced\u00f3nsko, republika",
-        "Maced\u00f3nsko",
-        "Severn\u00e9 Maced\u00f3nsko"
+        "Maced\u00f3nsko"
     ],
     "name:slk_x_preferred":[
         "Severn\u00e9 Maced\u00f3nsko"
     ],
     "name:slv_x_historical":[
         "Republika Makedonija",
-        "Makedonija",
-        "Severna Makedonija"
+        "Makedonija"
     ],
     "name:slv_x_preferred":[
         "Severna Makedonija"
     ],
     "name:sme_x_historical":[
         "D\u00e1ssev\u00e1ldi Makedonia",
-        "Makedonia",
-        "Davvi-Makedonia"
+        "Makedonia"
     ],
     "name:sme_x_preferred":[
         "Davvi-Makedonia"
@@ -1328,9 +1005,6 @@
     ],
     "name:sms_x_preferred":[
         "T\u00e2\u02b9vv-Makedonia"
-    ],
-    "name:sna_x_historical":[
-        "Macedonia"
     ],
     "name:sna_x_preferred":[
         "Macedonia"
@@ -1363,20 +1037,13 @@
     "name:sqi_x_preferred":[
         "Maqedonia e Veriut"
     ],
-    "name:srd_x_historical":[
-        "Matzed\u00f2nia"
-    ],
-    "name:srn_x_historical":[
-        "Masedoniyakondre"
-    ],
     "name:srn_x_preferred":[
         "Masedoniyakondre"
     ],
     "name:srp_x_historical":[
         "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u0458\u0430 (\u0432\u0438\u0448\u0435\u0437\u043d\u0430\u0447\u043d\u0430 \u043e\u0434\u0440\u0435\u0434\u043d\u0438\u0446\u0430)",
         "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u0458\u0430",
-        "\u0420\u0435\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u0458\u0430",
-        "\u0421\u0435\u0432\u0435\u0440\u043d\u0430 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u0458\u0430"
+        "\u0420\u0435\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u0458\u0430"
     ],
     "name:srp_x_preferred":[
         "\u0421\u0435\u0432\u0435\u0440\u043d\u0430 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u0458\u0430"
@@ -1393,9 +1060,6 @@
     "name:stq_x_preferred":[
         "Noudmakedonien"
     ],
-    "name:sun_x_historical":[
-        "Mak\u00e9donia Kal\u00e9r"
-    ],
     "name:sun_x_preferred":[
         "Mak\u00e9donia Kal\u00e9r"
     ],
@@ -1410,14 +1074,10 @@
         "Makedonien",
         "Macedonia (olika betydelser)",
         "F.d. jugoslaviska republiken Makedonien",
-        "FYROM",
-        "Nordmakedonien"
+        "FYROM"
     ],
     "name:swe_x_preferred":[
         "Nordmakedonien"
-    ],
-    "name:szl_x_historical":[
-        "P\u016f\u0142nocno Maced\u016f\u0144ijo"
     ],
     "name:szl_x_preferred":[
         "P\u016f\u0142nocno Maced\u016f\u0144ijo"
@@ -1426,8 +1086,7 @@
         "Macedonia"
     ],
     "name:tam_x_historical":[
-        "\u0bae\u0bbe\u0b9a\u0bbf\u0b9f\u0bcb\u0ba9\u0bbf\u0baf\u0bbe",
-        "\u0bb5\u0b9f\u0b95\u0bcd\u0b95\u0bc1 \u0bae\u0bbe\u0b95\u0bcd\u0b95\u0b9f\u0bcb\u0ba9\u0bbf\u0baf\u0bbe"
+        "\u0bae\u0bbe\u0b9a\u0bbf\u0b9f\u0bcb\u0ba9\u0bbf\u0baf\u0bbe"
     ],
     "name:tam_x_preferred":[
         "\u0bb5\u0b9f\u0b95\u0bcd\u0b95\u0bc1 \u0bae\u0bbe\u0b95\u0bcd\u0b95\u0b9f\u0bcb\u0ba9\u0bbf\u0baf\u0bbe"
@@ -1439,46 +1098,35 @@
         "\u0422\u04e9\u043d\u044c\u044f\u043a \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f"
     ],
     "name:tel_x_historical":[
-        "\u0c2e\u0c47\u0c38\u0c46\u0c21\u0c4b\u0c28\u0c3f\u0c2f\u0c3e",
-        "\u0c09\u0c24\u0c4d\u0c24\u0c30 \u0c2e\u0c46\u0c38\u0c3f\u0c21\u0c4b\u0c28\u0c3f\u0c2f\u0c3e"
+        "\u0c2e\u0c47\u0c38\u0c46\u0c21\u0c4b\u0c28\u0c3f\u0c2f\u0c3e"
     ],
     "name:tel_x_preferred":[
         "\u0c09\u0c24\u0c4d\u0c24\u0c30 \u0c2e\u0c46\u0c38\u0c3f\u0c21\u0c4b\u0c28\u0c3f\u0c2f\u0c3e"
     ],
     "name:tet_x_historical":[
-        "Mased\u00f3nia",
-        "Mased\u00f3nia Norte"
+        "Mased\u00f3nia"
     ],
     "name:tet_x_preferred":[
         "Mased\u00f3nia Norte"
     ],
     "name:tgk_x_historical":[
-        "\u04b6\u0443\u043c\u04b3\u0443\u0440\u0438\u0438 \u041c\u0430\u049b\u0434\u0443\u043d\u0438\u044f",
-        "\u041c\u0430\u049b\u0434\u0443\u043d\u0438\u044f\u0438 \u0428\u0438\u043c\u043e\u043b\u04e3"
+        "\u04b6\u0443\u043c\u04b3\u0443\u0440\u0438\u0438 \u041c\u0430\u049b\u0434\u0443\u043d\u0438\u044f"
     ],
     "name:tgk_x_preferred":[
         "\u041c\u0430\u049b\u0434\u0443\u043d\u0438\u044f\u0438 \u0428\u0438\u043c\u043e\u043b\u04e3"
     ],
     "name:tgl_x_historical":[
-        "Republika ng Macedonia",
-        "Hilagang Macedonia"
+        "Republika ng Macedonia"
     ],
     "name:tgl_x_preferred":[
         "Hilagang Macedonia"
     ],
     "name:tha_x_historical":[
         "\u0e21\u0e32\u0e0b\u0e34\u0e42\u0e14\u0e40\u0e19\u0e35\u0e22",
-        "\u0e1b\u0e23\u0e30\u0e40\u0e17\u0e28\u0e21\u0e32\u0e0b\u0e34\u0e42\u0e14\u0e40\u0e19\u0e35\u0e22",
-        "\u0e1b\u0e23\u0e30\u0e40\u0e17\u0e28\u0e19\u0e2d\u0e23\u0e4c\u0e17\u0e21\u0e32\u0e0b\u0e34\u0e42\u0e14\u0e40\u0e19\u0e35\u0e22"
+        "\u0e1b\u0e23\u0e30\u0e40\u0e17\u0e28\u0e21\u0e32\u0e0b\u0e34\u0e42\u0e14\u0e40\u0e19\u0e35\u0e22"
     ],
     "name:tha_x_preferred":[
         "\u0e1b\u0e23\u0e30\u0e40\u0e17\u0e28\u0e19\u0e2d\u0e23\u0e4c\u0e17\u0e21\u0e32\u0e0b\u0e34\u0e42\u0e14\u0e40\u0e19\u0e35\u0e22"
-    ],
-    "name:tir_x_historical":[
-        "\u121b\u12a8\u12f6\u1292\u12eb"
-    ],
-    "name:ton_x_historical":[
-        "Masit\u014dnia"
     ],
     "name:tpi_x_preferred":[
         "Republic of Macedonia"
@@ -1489,36 +1137,20 @@
     "name:tso_x_preferred":[
         "Republic of Macedonia"
     ],
-    "name:tuk_x_historical":[
-        "Demirgazyk Makedoni\u00fda"
-    ],
     "name:tuk_x_preferred":[
         "Demirgazyk Makedoni\u00fda"
     ],
-    "name:tum_x_historical":[
-        "Macedonia"
-    ],
     "name:tur_x_historical":[
-        "Makedonya",
-        "Kuzey Makedonya"
+        "Makedonya"
     ],
     "name:tur_x_preferred":[
         "Kuzey Makedonya"
     ],
-    "name:twi_x_historical":[
-        "Masidonia"
-    ],
     "name:twi_x_preferred":[
         "Masidonia"
     ],
-    "name:udm_x_historical":[
-        "\u0423\u0439\u043f\u0430\u043b \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f"
-    ],
     "name:udm_x_preferred":[
         "\u0423\u0439\u043f\u0430\u043b \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f"
-    ],
-    "name:uig_x_historical":[
-        "\u0645\u0627\u0643\u06d0\u062f\u0648\u0646\u0649\u064a\u06d5"
     ],
     "name:uig_x_preferred":[
         "\u0645\u0627\u0643\u06d0\u062f\u0648\u0646\u0649\u064a\u06d5"
@@ -1526,8 +1158,7 @@
     "name:ukr_x_historical":[
         "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0456\u044f",
         "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0456\u043a\u0430 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0456\u044f",
-        "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0456\u044f, \u043a\u043e\u043b\u0438\u0448\u043d\u044f \u042e\u0433\u043e\u0441\u043b\u0430\u0432\u0441\u044c\u043a\u0430 \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0456\u043a\u0430",
-        "\u041f\u0456\u0432\u043d\u0456\u0447\u043d\u0430 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0456\u044f"
+        "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0456\u044f, \u043a\u043e\u043b\u0438\u0448\u043d\u044f \u042e\u0433\u043e\u0441\u043b\u0430\u0432\u0441\u044c\u043a\u0430 \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0456\u043a\u0430"
     ],
     "name:ukr_x_preferred":[
         "\u041f\u0456\u0432\u043d\u0456\u0447\u043d\u0430 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0456\u044f"
@@ -1545,8 +1176,7 @@
         "Peoples Republic of Macedonia"
     ],
     "name:urd_x_historical":[
-        "\u0645\u0642\u062f\u0648\u0646\u06cc\u06c1",
-        "\u0634\u0645\u0627\u0644\u06cc \u0645\u0642\u062f\u0648\u0646\u06cc\u06c1"
+        "\u0645\u0642\u062f\u0648\u0646\u06cc\u06c1"
     ],
     "name:urd_x_preferred":[
         "\u0634\u0645\u0627\u0644\u06cc \u0645\u0642\u062f\u0648\u0646\u06cc\u06c1"
@@ -1563,17 +1193,13 @@
     "name:vec_x_preferred":[
         "Maced\u00f2nia del Nord"
     ],
-    "name:vep_x_historical":[
-        "Pohjoi\u017emakedonii"
-    ],
     "name:vep_x_preferred":[
         "Pohjoi\u017emakedonii"
     ],
     "name:vie_x_historical":[
         "Macedonia (\u0111\u1ecbnh h\u01b0\u1edbng)",
         "Ma-x\u00ea-\u0111\u00f4-ni-a",
-        "Ma-x\u00ea-\u0111\u00f4-ni-a (Macedonia)",
-        "B\u1eafc Macedonia"
+        "Ma-x\u00ea-\u0111\u00f4-ni-a (Macedonia)"
     ],
     "name:vie_x_preferred":[
         "B\u1eafc Macedonia"
@@ -1587,14 +1213,10 @@
     "name:vol_x_historical":[
         "Macedonia",
         "Makedon\u00e4n",
-        "Makedoniy\u00e4n",
-        "Nol\u00fcda-Makedoniy\u00e4n"
+        "Makedoniy\u00e4n"
     ],
     "name:vol_x_preferred":[
         "Nol\u00fcda-Makedoniy\u00e4n"
-    ],
-    "name:vro_x_historical":[
-        "Mak\u00f5doonia Vabariik"
     ],
     "name:vro_x_preferred":[
         "Mak\u00f5doonia Vabariik"
@@ -1605,26 +1227,14 @@
     "name:war_x_preferred":[
         "Norte nga Macedonia"
     ],
-    "name:wol_x_historical":[
-        "R\u00e9ewum Maseduwaan"
-    ],
     "name:wol_x_preferred":[
         "R\u00e9ewum Maseduwaan"
-    ],
-    "name:wuu_x_historical":[
-        "\u9a6c\u5176\u987f"
     ],
     "name:wuu_x_preferred":[
         "\u9a6c\u5176\u987f"
     ],
-    "name:xal_x_historical":[
-        "\u041c\u0430\u0441\u0438\u0434\u0438\u043d \u041e\u0440\u043d"
-    ],
     "name:xal_x_preferred":[
         "\u041c\u0430\u0441\u0438\u0434\u0438\u043d \u041e\u0440\u043d"
-    ],
-    "name:xmf_x_historical":[
-        "\u10dd\u10dd\u10e0\u10e3\u10d4 \u10db\u10d0\u10d9\u10d4\u10d3\u10dd\u10dc\u10d8\u10d0"
     ],
     "name:xmf_x_preferred":[
         "\u10dd\u10dd\u10e0\u10e3\u10d4 \u10db\u10d0\u10d9\u10d4\u10d3\u10dd\u10dc\u10d8\u10d0"
@@ -1638,20 +1248,11 @@
     "name:yor_x_preferred":[
         "Or\u00edl\u1eb9\u0300-\u00e8d\u00e8 Ol\u00f3m\u00ecnira il\u1eb9\u0300 Mak\u1eb9d\u00f3n\u00ed\u00e0"
     ],
-    "name:yue_x_historical":[
-        "\u5317\u99ac\u5176\u9813\u5171\u548c\u570b"
-    ],
     "name:yue_x_preferred":[
         "\u5317\u99ac\u5176\u9813\u5171\u548c\u570b"
     ],
-    "name:zea_x_historical":[
-        "Noord-Macedoni\u00eb"
-    ],
     "name:zea_x_preferred":[
         "Noord-Macedoni\u00eb"
-    ],
-    "name:zha_x_historical":[
-        "Baek Macedonia"
     ],
     "name:zha_x_preferred":[
         "Baek Macedonia"
@@ -1661,8 +1262,7 @@
         "\u99ac\u5176\u9813",
         "\u9a6c\u5176\u987f\u738b\u56fd",
         "\u99ac\u5176\u9813\u5171\u548c\u570b",
-        "\u524d\u5357\u65af\u62c9\u592b\u9a6c\u5176\u987f\u5171\u548c\u56fd",
-        "\u5317\u9a6c\u5176\u987f"
+        "\u524d\u5357\u65af\u62c9\u592b\u9a6c\u5176\u987f\u5171\u548c\u56fd"
     ],
     "name:zho_x_preferred":[
         "\u5317\u9a6c\u5176\u987f"
@@ -1820,7 +1420,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1631221601,
+    "wof:lastmodified":1631222187,
     "wof:name":"North Macedonia",
     "wof:parent_id":102191581,
     "wof:placetype":"country",

--- a/data/856/323/73/85632373.geojson
+++ b/data/856/323/73/85632373.geojson
@@ -35,10 +35,19 @@
     "name:abk_x_historical":[
         "\u0410\u04a9\u0430\u0434\u0430\u0442\u04d9\u0438 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u0430"
     ],
+    "name:abk_x_preferred":[
+        "\u0410\u04a9\u0430\u0434\u0430\u0442\u04d9\u0438 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u0430"
+    ],
     "name:ace_x_historical":[
         "Mak\u00e8donia Utara"
     ],
+    "name:ace_x_preferred":[
+        "Mak\u00e8donia Utara"
+    ],
     "name:ady_x_historical":[
+        "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u044d\u0443 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u0435"
+    ],
+    "name:ady_x_preferred":[
         "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u044d\u0443 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u0435"
     ],
     "name:afr_x_historical":[
@@ -46,8 +55,14 @@
         "Macedoni\u00eb",
         "Republiek Noord-Masedoni\u00eb"
     ],
+    "name:afr_x_preferred":[
+        "Republiek Noord-Masedoni\u00eb"
+    ],
     "name:aka_x_historical":[
         "Masedonia"
+    ],
+    "name:aka_x_preferred":[
+        "Republic of Macedonia"
     ],
     "name:als_x_historical":[
         "Mazedonien (Begriffskl\u00e4rung)"
@@ -56,7 +71,13 @@
         "\u121b\u12a8\u12f6\u1292\u12eb",
         "\u12e8\u1218\u1244\u12f6\u1295\u12eb \u122c\u1351\u1265\u120a\u12ad"
     ],
+    "name:amh_x_preferred":[
+        "\u12e8\u1218\u1244\u12f6\u1295\u12eb \u122c\u1351\u1265\u120a\u12ad"
+    ],
     "name:ang_x_historical":[
+        "Cynew\u012bse Macedonia"
+    ],
+    "name:ang_x_preferred":[
         "Cynew\u012bse Macedonia"
     ],
     "name:ara_x_historical":[
@@ -64,42 +85,87 @@
         "\u0645\u0642\u062f\u0648\u0646\u064a\u0627",
         "\u0645\u0642\u062f\u0648\u0646\u064a\u0627 \u0627\u0644\u0634\u0645\u0627\u0644\u064a\u0629"
     ],
+    "name:ara_x_preferred":[
+        "\u0645\u0642\u062f\u0648\u0646\u064a\u0627 \u0627\u0644\u0634\u0645\u0627\u0644\u064a\u0629"
+    ],
     "name:arc_x_historical":[
         "\u0721\u0729\u0715\u0718\u0722\u071d\u0710",
+        "\u0729\u0718\u071b\u0722\u071d\u0718\u072c\u0710 \u0715\u0721\u0729\u0715\u0718\u0722\u071d\u0710"
+    ],
+    "name:arc_x_preferred":[
         "\u0729\u0718\u071b\u0722\u071d\u0718\u072c\u0710 \u0715\u0721\u0729\u0715\u0718\u0722\u071d\u0710"
     ],
     "name:arg_x_historical":[
         "Macedonia"
     ],
+    "name:arg_x_preferred":[
+        "Macedonia d'o Norte"
+    ],
+    "name:ary_x_preferred":[
+        "\u0634\u0645\u0627\u0644 \u0645\u0642\u062f\u0648\u0646\u064a\u0627"
+    ],
     "name:arz_x_historical":[
         "\u0645\u0642\u062f\u0648\u0646\u064a\u0627",
+        "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0645\u0642\u062f\u0648\u0646\u064a\u0627"
+    ],
+    "name:arz_x_preferred":[
         "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0645\u0642\u062f\u0648\u0646\u064a\u0627"
     ],
     "name:ast_x_historical":[
         "Macedonia (dixebra)",
         "Rep\u00fablica de Macedonia"
     ],
+    "name:ast_x_preferred":[
+        "Macedonia del Norte"
+    ],
     "name:ava_x_historical":[
         "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f"
+    ],
+    "name:ava_x_preferred":[
+        "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f"
+    ],
+    "name:avk_x_preferred":[
+        "Makedonia"
+    ],
+    "name:awa_x_preferred":[
+        "\u0909\u0924\u094d\u0924\u0930 \u092e\u0948\u0938\u093f\u0921\u094b\u0928\u093f\u092f\u093e"
     ],
     "name:azb_x_historical":[
         "\u0645\u0642\u062f\u0648\u0646\u06cc\u0647",
         "\u0645\u0648\u0644\u062f\u0627\u0648\u06cc"
+    ],
+    "name:azb_x_preferred":[
+        "\u0634\u0648\u0645\u0627\u0644\u06cc \u0645\u0642\u062f\u0648\u0646\u06cc\u0647"
     ],
     "name:aze_x_historical":[
         "Makedoniya",
         "Masedoniya",
         "\u015eimali Makedoniya"
     ],
+    "name:aze_x_preferred":[
+        "\u015eimali Makedoniya"
+    ],
     "name:bak_x_historical":[
+        "\u0422\u04e9\u043d\u044c\u044f\u04a1 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f"
+    ],
+    "name:bak_x_preferred":[
         "\u0422\u04e9\u043d\u044c\u044f\u04a1 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f"
     ],
     "name:bam_x_historical":[
         "Maced\u0254ni"
     ],
+    "name:ban_x_preferred":[
+        "Macedonia Utara"
+    ],
     "name:bar_x_historical":[
         "Mazedonien (Begriffskl\u00e4rung)",
         "Noadmazedonien"
+    ],
+    "name:bar_x_preferred":[
+        "Noadmazedonien"
+    ],
+    "name:bcl_x_preferred":[
+        "Republika kan Masedonya"
     ],
     "name:bel_x_historical":[
         "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0456\u044f, \u0437\u043d\u0430\u0447\u044d\u043d\u043d\u0456",
@@ -108,17 +174,32 @@
         "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0456\u044f, \u0411\u042e\u0420",
         "\u041f\u0430\u045e\u043d\u043e\u0447\u043d\u0430\u044f \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0456\u044f"
     ],
+    "name:bel_x_preferred":[
+        "\u041f\u0430\u045e\u043d\u043e\u0447\u043d\u0430\u044f \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0456\u044f"
+    ],
     "name:ben_x_historical":[
         "\u09ae\u09cd\u09af\u09be\u09b8\u09be\u09a1\u09cb\u09a8\u09bf\u09af\u09bc\u09be",
         "\u0989\u09a4\u09cd\u09a4\u09b0 \u09ae\u09cd\u09af\u09be\u09b8\u09c7\u09a1\u09cb\u09a8\u09bf\u09af\u09bc\u09be"
     ],
+    "name:ben_x_preferred":[
+        "\u0989\u09a4\u09cd\u09a4\u09b0 \u09ae\u09c7\u09b8\u09bf\u09a1\u09cb\u09a8\u09bf\u09af\u09bc\u09be"
+    ],
     "name:bho_x_historical":[
+        "\u092e\u0947\u0938\u0940\u0921\u094b\u0928\u093f\u092f\u093e"
+    ],
+    "name:bho_x_preferred":[
         "\u092e\u0947\u0938\u0940\u0921\u094b\u0928\u093f\u092f\u093e"
     ],
     "name:bis_x_historical":[
         "Not Macedonia"
     ],
+    "name:bis_x_preferred":[
+        "Not Macedonia"
+    ],
     "name:bod_x_historical":[
+        "\u0f58\u0f0b\u0f66\u0f7a\u0f0b\u0f4c\u0f7c\u0f0b\u0f53\u0f72\u0f61\u0f0d"
+    ],
+    "name:bod_x_preferred":[
         "\u0f58\u0f0b\u0f66\u0f7a\u0f0b\u0f4c\u0f7c\u0f0b\u0f53\u0f72\u0f61\u0f0d"
     ],
     "name:bos_x_historical":[
@@ -126,12 +207,21 @@
         "Republika Makedonija",
         "Makedonija"
     ],
+    "name:bos_x_preferred":[
+        "Sjeverna Makedonija"
+    ],
     "name:bpy_x_historical":[
+        "\u09ae\u09c7\u09b8\u09bf\u09a1\u09cb\u09a8\u09bf\u09af\u09bc\u09be"
+    ],
+    "name:bpy_x_preferred":[
         "\u09ae\u09c7\u09b8\u09bf\u09a1\u09cb\u09a8\u09bf\u09af\u09bc\u09be"
     ],
     "name:bre_x_historical":[
         "Republik Makedonia",
         "Makedonia"
+    ],
+    "name:bre_x_preferred":[
+        "Makedonia an Norzh"
     ],
     "name:bul_x_historical":[
         "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f",
@@ -139,18 +229,33 @@
         "\u0420\u0435\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f",
         "\u0421\u0435\u0432\u0435\u0440\u043d\u0430 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f"
     ],
+    "name:bul_x_preferred":[
+        "\u0421\u0435\u0432\u0435\u0440\u043d\u0430 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f"
+    ],
     "name:bxr_x_historical":[
+        "\u0425\u043e\u0439\u0442\u043e \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438"
+    ],
+    "name:bxr_x_preferred":[
         "\u0425\u043e\u0439\u0442\u043e \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438"
     ],
     "name:cat_x_historical":[
         "Maced\u00f2nia",
         "Rep\u00fablica de Maced\u00f2nia"
     ],
+    "name:cat_x_preferred":[
+        "Maced\u00f2nia del Nord"
+    ],
     "name:cdo_x_historical":[
+        "B\u00e1e\u0324k M\u0101-g\u00ec-d\u00f3ng"
+    ],
+    "name:cdo_x_preferred":[
         "B\u00e1e\u0324k M\u0101-g\u00ec-d\u00f3ng"
     ],
     "name:ceb_x_historical":[
         "Macedonia (pagklaro)"
+    ],
+    "name:ceb_x_preferred":[
+        "Republika sa Amihanan Makedoniya"
     ],
     "name:ces_x_historical":[
         "Makedonie (rozcestn\u00edk)",
@@ -159,35 +264,65 @@
         "Makedonie",
         "Severn\u00ed Makedonie"
     ],
+    "name:ces_x_preferred":[
+        "Severn\u00ed Makedonie"
+    ],
     "name:che_x_historical":[
         "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438"
     ],
+    "name:che_x_preferred":[
+        "\u041a\u044a\u0438\u043b\u0431\u0430\u0441\u0435\u0434\u0430 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438"
+    ],
     "name:chr_x_historical":[
+        "\u13b9\u13ce\u13d9\u13c2\u13ef"
+    ],
+    "name:chr_x_preferred":[
         "\u13b9\u13ce\u13d9\u13c2\u13ef"
     ],
     "name:chu_x_historical":[
         "\u041c\u0430\u043a\u0454\u0434\u043e\u043d\u0457\ua657 \u00b7 \u0441\u044a\u043c\ua651\u0441\u043b\u0438",
         "\u0421\u0463\u0432\u0454\u0440\u044c\u043d\u0430 \u041c\u0430\u043a\u0454\u0434\u043e\u043d\u0457\ua657"
     ],
+    "name:chu_x_preferred":[
+        "\u0421\u0463\u0432\u0454\u0440\u044c\u043d\u0430 \u041c\u0430\u043a\u0454\u0434\u043e\u043d\u0457\ua657"
+    ],
     "name:chv_x_historical":[
         "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438 \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0438"
+    ],
+    "name:chv_x_preferred":[
+        "\u00c7\u0443\u0440\u00e7\u0115\u0440 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438"
     ],
     "name:ckb_x_historical":[
         "\u06a9\u06c6\u0645\u0627\u0631\u06cc \u0645\u06d5\u0642\u062f\u0648\u0648\u0646\u06cc\u0627"
     ],
+    "name:ckb_x_preferred":[
+        "\u06a9\u06c6\u0645\u0627\u0631\u06cc \u0645\u06d5\u0642\u062f\u0648\u0648\u0646\u06cc\u0627"
+    ],
     "name:cor_x_historical":[
+        "Repoblek Makedoni"
+    ],
+    "name:cor_x_preferred":[
         "Repoblek Makedoni"
     ],
     "name:crh_x_historical":[
         "Makedoniya",
         "\u015eimaliy Makedoniya"
     ],
+    "name:crh_x_preferred":[
+        "\u015eimaliy Makedoniya"
+    ],
     "name:csb_x_historical":[
+        "Nordow\u00f4 Macedo\u0144sk\u00f4"
+    ],
+    "name:csb_x_preferred":[
         "Nordow\u00f4 Macedo\u0144sk\u00f4"
     ],
     "name:cym_x_historical":[
         "Macedonia",
         "Gweriniaeth Macedonia",
+        "Gogledd Macedonia"
+    ],
+    "name:cym_x_preferred":[
         "Gogledd Macedonia"
     ],
     "name:cze_x_historical":[
@@ -200,6 +335,9 @@
         "Tidligere Jugoslaviske Republik Makedonien",
         "Nordmakedonien"
     ],
+    "name:dan_x_preferred":[
+        "Nordmakedonien"
+    ],
     "name:deu_x_historical":[
         "Mazedonien (Begriffskl\u00e4rung)",
         "Mazedonien",
@@ -207,16 +345,31 @@
         "Ehemalige jugoslawische Republik Mazedonien",
         "Nordmazedonien"
     ],
+    "name:deu_x_preferred":[
+        "Nordmazedonien"
+    ],
     "name:diq_x_historical":[
         "Cumur\u00eat\u00ea Makedonya"
     ],
+    "name:diq_x_preferred":[
+        "Makedonya Z\u0131mey"
+    ],
     "name:div_x_historical":[
+        "\u0789\u07ac\u0790\u07ac\u0791\u07af\u0782\u07a8\u0787\u07a7"
+    ],
+    "name:div_x_preferred":[
         "\u0789\u07ac\u0790\u07ac\u0791\u07af\u0782\u07a8\u0787\u07a7"
     ],
     "name:dsb_x_historical":[
         "Makedo\u0144ska"
     ],
+    "name:dsb_x_preferred":[
+        "P\u00f3dpo\u0142nocna Makedo\u0144ska"
+    ],
     "name:dty_x_historical":[
+        "\u092e\u094d\u092f\u093e\u0938\u0947\u0921\u094b\u0928\u093f\u092f\u093e"
+    ],
+    "name:dty_x_preferred":[
         "\u092e\u094d\u092f\u093e\u0938\u0947\u0921\u094b\u0928\u093f\u092f\u093e"
     ],
     "name:efi_x_historical":[
@@ -227,6 +380,9 @@
         "\u03a0\u0393\u0394 \u039c\u03b1\u03ba\u03b5\u03b4\u03bf\u03bd\u03af\u03b1\u03c2",
         "\u03a0\u03c1\u03ce\u03b7\u03bd \u0393\u03b9\u03bf\u03c5\u03b3\u03ba\u03bf\u03c3\u03bb\u03b1\u03b2\u03b9\u03ba\u03ae \u0394\u03b7\u03bc\u03bf\u03ba\u03c1\u03b1\u03c4\u03af\u03b1 \u03c4\u03b7\u03c2 \u039c\u03b1\u03ba\u03b5\u03b4\u03bf\u03bd\u03af\u03b1\u03c2",
         "\u03a0.\u0393.\u0394. \u039c\u03b1\u03ba\u03b5\u03b4\u03bf\u03bd\u03af\u03b1\u03c2",
+        "\u0392\u03cc\u03c1\u03b5\u03b9\u03b1 \u039c\u03b1\u03ba\u03b5\u03b4\u03bf\u03bd\u03af\u03b1"
+    ],
+    "name:ell_x_preferred":[
         "\u0392\u03cc\u03c1\u03b5\u03b9\u03b1 \u039c\u03b1\u03ba\u03b5\u03b4\u03bf\u03bd\u03af\u03b1"
     ],
     "name:eng_x_colloquial":[
@@ -247,6 +403,9 @@
         "Macedonia, The Former Yugoslav Republic Of",
         "North Macedonia"
     ],
+    "name:eng_x_preferred":[
+        "North Macedonia"
+    ],
     "name:eng_x_unknown":[
         "MK",
         "MKD"
@@ -257,9 +416,15 @@
         "Respubliko Makedonio",
         "Nord-Makedonio"
     ],
+    "name:epo_x_preferred":[
+        "Nord-Makedonio"
+    ],
     "name:est_x_historical":[
         "Makedoonia Vabariik",
         "Makedoonia",
+        "P\u00f5hja-Makedoonia"
+    ],
+    "name:est_x_preferred":[
         "P\u00f5hja-Makedoonia"
     ],
     "name:eus_x_historical":[
@@ -268,16 +433,31 @@
         "Mazedoniako Errepublika",
         "Ipar Mazedonia"
     ],
+    "name:eus_x_preferred":[
+        "Ipar Mazedonia"
+    ],
     "name:ewe_x_historical":[
         "Makedonia nutome"
+    ],
+    "name:ewe_x_preferred":[
+        "North Macedonia"
+    ],
+    "name:ext_x_preferred":[
+        "Maced\u00f3nia del Norti"
     ],
     "name:fao_x_historical":[
         "Maked\u00f3nia",
         "L\u00fd\u00f0veldi\u00f0 Maked\u00f3nia"
     ],
+    "name:fao_x_preferred":[
+        "L\u00fd\u00f0veldi\u00f0 Maked\u00f3nia"
+    ],
     "name:fas_x_historical":[
         "\u0645\u0642\u062f\u0648\u0646\u06cc\u0647",
         "\u0645\u06a9\u062f\u0648\u0646\u06cc\u0627",
+        "\u0645\u0642\u062f\u0648\u0646\u06cc\u0647 \u0634\u0645\u0627\u0644\u06cc"
+    ],
+    "name:fas_x_preferred":[
         "\u0645\u0642\u062f\u0648\u0646\u06cc\u0647 \u0634\u0645\u0627\u0644\u06cc"
     ],
     "name:fin_x_historical":[
@@ -288,6 +468,9 @@
         "Makedonian valtakunta",
         "Pohjois-Makedonia"
     ],
+    "name:fin_x_preferred":[
+        "Pohjois-Makedonia"
+    ],
     "name:fra_x_colloquial":[
         "Macedoine"
     ],
@@ -296,53 +479,113 @@
         "Ancienne r\u00e9publique yougoslave de Mac\u00e9doine",
         "Mac\u00e9doine"
     ],
+    "name:fra_x_preferred":[
+        "Mac\u00e9doine du Nord"
+    ],
     "name:frp_x_historical":[
         "R\u00e8publica de Mac\u00e8donie"
     ],
+    "name:frp_x_preferred":[
+        "Mac\u00e8donie du Nord"
+    ],
     "name:frr_x_historical":[
+        "Nuurd-Matsedoonien"
+    ],
+    "name:frr_x_preferred":[
         "Nuurd-Matsedoonien"
     ],
     "name:fry_x_historical":[
         "Masedoanje",
         "Noard-Masedoanje"
     ],
+    "name:fry_x_preferred":[
+        "Noard-Masedoanje"
+    ],
     "name:ful_x_historical":[
         "Meceduwaan",
+        "Masedoniya"
+    ],
+    "name:ful_x_preferred":[
         "Masedoniya"
     ],
     "name:fur_x_historical":[
         "Macedonie"
     ],
+    "name:fur_x_preferred":[
+        "Macedonie dal Nort"
+    ],
     "name:gag_x_historical":[
         "Poyraz Makedoniya"
     ],
+    "name:gag_x_preferred":[
+        "Poyraz Makedoniya"
+    ],
+    "name:gcr_x_preferred":[
+        "Mas\u00e9dwann"
+    ],
+    "name:gla_x_preferred":[
+        "Poblachd na Masadoine"
+    ],
     "name:gle_x_historical":[
         "An Mhacad\u00f3in"
+    ],
+    "name:gle_x_preferred":[
+        "An Mhacad\u00f3in Thuaidh"
     ],
     "name:glg_x_historical":[
         "Macedonia",
         "Rep\u00fablica de Macedonia"
     ],
+    "name:glv_x_preferred":[
+        "Pobblaght y Vassadoan Hwoaie"
+    ],
     "name:gom_x_historical":[
+        "\u092e\u0945\u0938\u093f\u0921\u094b\u0928\u093f\u092f\u093e"
+    ],
+    "name:gom_x_preferred":[
         "\u092e\u0945\u0938\u093f\u0921\u094b\u0928\u093f\u092f\u093e"
     ],
     "name:got_x_historical":[
         "\ud800\udf3c\ud800\udf30\ud800\udf3a\ud800\udf30\ud800\udf39\ud800\udf33\ud800\udf49\ud800\udf3d\ud800\udf3e\ud800\udf30"
     ],
+    "name:got_x_preferred":[
+        "\ud800\udf3c\ud800\udf30\ud800\udf3a\ud800\udf30\ud800\udf39\ud800\udf33\ud800\udf49\ud800\udf3d\ud800\udf3e\ud800\udf30"
+    ],
     "name:grn_x_historical":[
+        "Yvate Masendo\u00f1a"
+    ],
+    "name:grn_x_preferred":[
         "Yvate Masendo\u00f1a"
     ],
     "name:gsw_x_historical":[
         "Republik Mazedonie"
     ],
+    "name:gsw_x_preferred":[
+        "Republik Mazedonie"
+    ],
     "name:guj_x_historical":[
+        "\u0aae\u0ac7\u0ab8\u0ac7\u0aa1\u0acb\u0aa8\u0abf\u0aaf\u0abe"
+    ],
+    "name:guj_x_preferred":[
         "\u0aae\u0ac7\u0ab8\u0ac7\u0aa1\u0acb\u0aa8\u0abf\u0aaf\u0abe"
     ],
     "name:hak_x_historical":[
         "Pet Macedonia"
     ],
+    "name:hak_x_preferred":[
+        "Pet Macedonia"
+    ],
+    "name:hat_x_preferred":[
+        "Repiblik d Masedoni"
+    ],
     "name:hau_x_historical":[
         "Masedoniya"
+    ],
+    "name:hau_x_preferred":[
+        "Masadoiniya ta Arewa"
+    ],
+    "name:haw_x_preferred":[
+        "Repupalika o \u2018\u0100kau Masedonia"
     ],
     "name:hbs_x_historical":[
         "Masidonija",
@@ -353,9 +596,18 @@
         "\u05de\u05e7\u05d3\u05d5\u05e0\u05d9\u05d4",
         "\u05de\u05e7\u05d3\u05d5\u05e0\u05d9\u05d4 \u05d4\u05e6\u05e4\u05d5\u05e0\u05d9\u05ea"
     ],
+    "name:heb_x_preferred":[
+        "\u05de\u05e7\u05d3\u05d5\u05e0\u05d9\u05d4 \u05d4\u05e6\u05e4\u05d5\u05e0\u05d9\u05ea"
+    ],
+    "name:hif_x_preferred":[
+        "Republic of Macedonia"
+    ],
     "name:hin_x_historical":[
         "\u092e\u0948\u0938\u0947\u0921\u094b\u0928\u093f\u092f\u093e",
         "\u092e\u0948\u0938\u093f\u0921\u094b\u0928\u093f\u092f\u093e",
+        "\u0909\u0924\u094d\u0924\u0930 \u092e\u0948\u0938\u093f\u0921\u094b\u0928\u093f\u092f\u093e"
+    ],
+    "name:hin_x_preferred":[
         "\u0909\u0924\u094d\u0924\u0930 \u092e\u0948\u0938\u093f\u0921\u094b\u0928\u093f\u092f\u093e"
     ],
     "name:hrv_x_historical":[
@@ -365,8 +617,14 @@
         "Makedonija",
         "Sjeverna Makedonija"
     ],
+    "name:hrv_x_preferred":[
+        "Sjeverna Makedonija"
+    ],
     "name:hsb_x_historical":[
         "Makedonska",
+        "Sewjerna Makedonska"
+    ],
+    "name:hsb_x_preferred":[
         "Sewjerna Makedonska"
     ],
     "name:hun_x_historical":[
@@ -377,20 +635,38 @@
         "Maked\u00f3nia",
         "\u00c9szak-Maced\u00f3nia"
     ],
+    "name:hun_x_preferred":[
+        "\u00c9szak-Maced\u00f3nia"
+    ],
     "name:hye_x_historical":[
         "\u0544\u0561\u056f\u0565\u0564\u0578\u0576\u056b\u0561 (\u0561\u0575\u056c \u056f\u056b\u0580\u0561\u057c\u0578\u0582\u0574\u0576\u0565\u0580)",
         "\u0544\u0561\u056f\u0565\u0564\u0578\u0576\u056b\u0561",
         "\u0540\u0575\u0578\u0582\u057d\u056b\u057d\u0561\u0575\u056b\u0576 \u0544\u0561\u056f\u0565\u0564\u0578\u0576\u056b\u0561"
     ],
+    "name:hye_x_preferred":[
+        "\u0540\u0575\u0578\u0582\u057d\u056b\u057d\u0561\u0575\u056b\u0576 \u0544\u0561\u056f\u0565\u0564\u0578\u0576\u056b\u0561"
+    ],
     "name:ibo_x_historical":[
+        "Macedonia"
+    ],
+    "name:ibo_x_preferred":[
         "Macedonia"
     ],
     "name:ido_x_historical":[
         "Republiko Macedonia",
         "Republiko Norda-Macedonia"
     ],
+    "name:ido_x_preferred":[
+        "Republiko Norda-Macedonia"
+    ],
     "name:ile_x_historical":[
         "Macedonia"
+    ],
+    "name:ile_x_preferred":[
+        "Nord-Macedonia"
+    ],
+    "name:ilo_x_preferred":[
+        "Amianan a Macedonia"
     ],
     "name:ina_x_historical":[
         "Macedonia (disambiguation)",
@@ -401,9 +677,15 @@
         "Republik Makedonia",
         "Makedonia"
     ],
+    "name:ind_x_preferred":[
+        "Republik Makedonia Utara"
+    ],
     "name:isl_x_historical":[
         "Maked\u00f3n\u00eda",
         "L\u00fd\u00f0veldi\u00f0 Maked\u00f3n\u00eda",
+        "Nor\u00f0ur-Maked\u00f3n\u00eda"
+    ],
+    "name:isl_x_preferred":[
         "Nor\u00f0ur-Maked\u00f3n\u00eda"
     ],
     "name:ita_x_historical":[
@@ -413,11 +695,20 @@
         "Macedonia, Repubblica",
         "Ex Repubblica Jugoslava di Macedonia"
     ],
+    "name:ita_x_preferred":[
+        "Macedonia del Nord"
+    ],
     "name:jam_x_historical":[
         "Ripoblik a Masiduonia",
         "Masiduonia"
     ],
+    "name:jam_x_preferred":[
+        "Ripoblik a Masiduonia"
+    ],
     "name:jav_x_historical":[
+        "R\u00e9publik Makedonia"
+    ],
+    "name:jav_x_preferred":[
         "R\u00e9publik Makedonia"
     ],
     "name:jpn_x_historical":[
@@ -427,29 +718,53 @@
         "\u30de\u30b1\u30c9\u30cb\u30a2\u65e7\u30e6\u30fc\u30b4\u30b9\u30e9\u30d3\u30a2\u5171\u548c\u56fd",
         "\u5317\u30de\u30b1\u30c9\u30cb\u30a2"
     ],
+    "name:jpn_x_preferred":[
+        "\u5317\u30de\u30b1\u30c9\u30cb\u30a2"
+    ],
     "name:kaa_x_historical":[
         "Makedoniya"
     ],
+    "name:kaa_x_preferred":[
+        "Makedoniya"
+    ],
     "name:kal_x_historical":[
+        "Makedonia"
+    ],
+    "name:kal_x_preferred":[
         "Makedonia"
     ],
     "name:kan_x_historical":[
         "\u0cae\u0ccd\u0caf\u0cbe\u0cb8\u0cbf\u0ca1\u0ccb\u0ca8\u0cbf\u0caf\u0cbe",
         "\u0cae\u0ccd\u0caf\u0cbe\u0cb8\u0cc6\u0ca1\u0cca\u0ca8\u0cbf\u0caf \u0c97\u0ca3\u0cb0\u0cbe\u0c9c\u0ccd\u0caf"
     ],
+    "name:kan_x_preferred":[
+        "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0 \u0cae\u0ccd\u0caf\u0cbe\u0cb8\u0cc6\u0ca1\u0cca\u0ca8\u0cbf\u0caf"
+    ],
     "name:kat_x_historical":[
         "\u10db\u10d0\u10d9\u10d4\u10d3\u10dd\u10dc\u10d8\u10d0 (\u10db\u10e0\u10d0\u10d5\u10d0\u10da\u10db\u10dc\u10d8\u10e8\u10d5\u10dc\u10d4\u10da\u10dd\u10d5\u10d0\u10dc\u10d8)",
         "\u10db\u10d0\u10d9\u10d4\u10d3\u10dd\u10dc\u10d8\u10d0",
         "\u10e9\u10e0\u10d3\u10d8\u10da\u10dd\u10d4\u10d7\u10d8 \u10db\u10d0\u10d9\u10d4\u10d3\u10dd\u10dc\u10d8\u10d0"
     ],
+    "name:kat_x_preferred":[
+        "\u10e9\u10e0\u10d3\u10d8\u10da\u10dd\u10d4\u10d7\u10d8 \u10db\u10d0\u10d9\u10d4\u10d3\u10dd\u10dc\u10d8\u10d0"
+    ],
     "name:kaz_x_historical":[
         "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430\u0441\u044b"
+    ],
+    "name:kaz_x_preferred":[
+        "\u0421\u043e\u043b\u0442\u04af\u0441\u0442\u0456\u043a \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f"
     ],
     "name:kbd_x_historical":[
         "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u044d \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044d"
     ],
+    "name:kbd_x_preferred":[
+        "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u044d \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044d"
+    ],
     "name:khm_x_historical":[
         "\u1798\u17c9\u17b6\u179f\u17c1\u178a\u1793",
+        "\u1798\u17c9\u17b6\u179f\u17c1\u178a\u17bc\u1793\u17b6\u1781\u17b6\u1784\u178f\u17d2\u1794\u17bc\u1784"
+    ],
+    "name:khm_x_preferred":[
         "\u1798\u17c9\u17b6\u179f\u17c1\u178a\u17bc\u1793\u17b6\u1781\u17b6\u1784\u178f\u17d2\u1794\u17bc\u1784"
     ],
     "name:kik_x_historical":[
@@ -458,16 +773,31 @@
     "name:kin_x_historical":[
         "Masedoniya"
     ],
+    "name:kin_x_preferred":[
+        "Masedoniya ya Ruguru"
+    ],
     "name:kir_x_historical":[
+        "\u0422\u04af\u043d\u0434\u04af\u043a \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f"
+    ],
+    "name:kir_x_preferred":[
         "\u0422\u04af\u043d\u0434\u04af\u043a \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f"
     ],
     "name:koi_x_historical":[
         "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f"
     ],
+    "name:koi_x_preferred":[
+        "\u041e\u0439\u0432\u044b\u0432 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f"
+    ],
     "name:kom_x_historical":[
         "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430"
     ],
+    "name:kom_x_preferred":[
+        "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430"
+    ],
     "name:kon_x_historical":[
+        "Makedonia"
+    ],
+    "name:kon_x_preferred":[
         "Makedonia"
     ],
     "name:kor_x_historical":[
@@ -477,50 +807,98 @@
         "\uc804 \uc720\uace0\uc2ac\ub77c\ube44\uc544 \ub9c8\ucf00\ub3c4\ub2c8\uc544",
         "\ubd81\ub9c8\ucf00\ub3c4\ub2c8\uc544"
     ],
+    "name:kor_x_preferred":[
+        "\ubd81\ub9c8\ucf00\ub3c4\ub2c8\uc544"
+    ],
     "name:krc_x_historical":[
+        "\u0428\u0438\u043c\u0430\u043b \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f"
+    ],
+    "name:krc_x_preferred":[
         "\u0428\u0438\u043c\u0430\u043b \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f"
     ],
     "name:kur_x_historical":[
         "Komara Makedonyay\u00ea",
         "Makedonyaya Bakur"
     ],
+    "name:kur_x_preferred":[
+        "Makedonyaya Bakur"
+    ],
     "name:lad_x_historical":[
+        "Makedonia"
+    ],
+    "name:lad_x_preferred":[
         "Makedonia"
     ],
     "name:lao_x_historical":[
         "\u0ec1\u0ea1\u0e8a\u0eb4\u0ec2\u0e84\u0ec0\u0e99\u0e8d",
         "\u0ea1\u0eb2\u0e8a\u0eb4\u0ec2\u0e94\u0ec0\u0e99\u0e8d\u0ec0\u0edc\u0eb7\u0ead"
     ],
+    "name:lao_x_preferred":[
+        "\u0ea1\u0eb2\u0e8a\u0eb4\u0ec2\u0e94\u0ec0\u0e99\u0e8d\u0ec0\u0edc\u0eb7\u0ead"
+    ],
     "name:lat_x_historical":[
         "Macedonia",
         "Res publica Macedonica"
+    ],
+    "name:lat_x_preferred":[
+        "Macedonia Septentrionalis"
     ],
     "name:lav_x_historical":[
         "Ma\u0137edonija",
         "Ma\u0137edonijas Republika",
         "Zieme\u013cma\u0137edonija"
     ],
+    "name:lav_x_preferred":[
+        "Zieme\u013cma\u0137edonija"
+    ],
     "name:lfn_x_historical":[
         "Macedonia"
+    ],
+    "name:lfn_x_preferred":[
+        "Macedonia Norde"
     ],
     "name:lim_x_historical":[
         "Macedoni\u00eb",
         "Noord-Macedoni\u00eb"
     ],
+    "name:lim_x_preferred":[
+        "Noord-Macedoni\u00eb"
+    ],
     "name:lin_x_historical":[
         "Masedwan\u025b"
+    ],
+    "name:lin_x_preferred":[
+        "Masedoni ya Nola"
     ],
     "name:lit_x_historical":[
         "Makedonija",
         "\u0160iaur\u0117s Makedonija"
     ],
+    "name:lit_x_preferred":[
+        "\u0160iaur\u0117s Makedonija"
+    ],
+    "name:lld_x_preferred":[
+        "Macedonia dl Nort"
+    ],
     "name:lmo_x_historical":[
         "Macedonia"
+    ],
+    "name:lmo_x_preferred":[
+        "Macedonia del Nord"
+    ],
+    "name:lrc_x_preferred":[
+        "\u0645\u0671\u0642\u062f\u06ca\u0646\u06cc\u0671"
     ],
     "name:ltg_x_historical":[
         "Makedonejis Republika"
     ],
+    "name:ltg_x_preferred":[
+        "Z\u012bme\u013cmakedoneja"
+    ],
     "name:ltz_x_historical":[
+        "Nordmazedonien"
+    ],
+    "name:ltz_x_preferred":[
         "Nordmazedonien"
     ],
     "name:lub_x_historical":[
@@ -532,44 +910,83 @@
     "name:lzh_x_historical":[
         "\u5317\u99ac\u5176\u9813"
     ],
+    "name:lzh_x_preferred":[
+        "\u5317\u99ac\u5176\u9813"
+    ],
+    "name:mad_x_preferred":[
+        "Makedonia"
+    ],
     "name:mai_x_historical":[
+        "\u092e\u094d\u092f\u093e\u0938\u0947\u0921\u094b\u0928\u093f\u092f\u093e"
+    ],
+    "name:mai_x_preferred":[
         "\u092e\u094d\u092f\u093e\u0938\u0947\u0921\u094b\u0928\u093f\u092f\u093e"
     ],
     "name:mal_x_historical":[
         "\u0d2e\u0d3e\u0d38\u0d3f\u0d21\u0d4b\u0d23\u0d3f\u0d2f",
         "\u0d28\u0d4b\u0d7c\u0d24\u0d4d\u0d24\u0d4d \u0d2e\u0d3e\u0d38\u0d3f\u0d21\u0d4b\u0d23\u0d3f\u0d2f"
     ],
+    "name:mal_x_preferred":[
+        "\u0d28\u0d4b\u0d7c\u0d24\u0d4d\u0d24\u0d4d \u0d2e\u0d3e\u0d38\u0d3f\u0d21\u0d4b\u0d23\u0d3f\u0d2f"
+    ],
     "name:mar_x_historical":[
         "\u092e\u0945\u0938\u0947\u0921\u094b\u0928\u093f\u092f\u093e",
+        "\u0909\u0924\u094d\u0924\u0930 \u092e\u0945\u0938\u093f\u0921\u094b\u0928\u093f\u092f\u093e"
+    ],
+    "name:mar_x_preferred":[
         "\u0909\u0924\u094d\u0924\u0930 \u092e\u0945\u0938\u093f\u0921\u094b\u0928\u093f\u092f\u093e"
     ],
     "name:mdf_x_historical":[
         "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u0435"
     ],
+    "name:mdf_x_preferred":[
+        "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u0435"
+    ],
     "name:mhr_x_historical":[
         "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u0439"
+    ],
+    "name:mhr_x_preferred":[
+        "\u0419\u04f1\u0434\u0432\u0435\u043b \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u0439"
     ],
     "name:mkd_x_historical":[
         "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u0458\u0430 (\u043f\u043e\u0458\u0430\u0441\u043d\u0443\u0432\u0430\u045a\u0435)",
         "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u0458\u0430",
         "\u0420\u0435\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u0458\u0430"
     ],
+    "name:mkd_x_preferred":[
+        "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u0458\u0430"
+    ],
     "name:mlg_x_historical":[
         "Makedonia",
         "Masedonia"
     ],
+    "name:mlg_x_preferred":[
+        "Mased\u00f4nia Avaratra"
+    ],
     "name:mlt_x_historical":[
         "Ma\u010bedonja"
     ],
+    "name:mlt_x_preferred":[
+        "Ma\u010bedonja ta' Fuq"
+    ],
     "name:mon_x_historical":[
+        "\u0423\u043c\u0430\u0440\u0434 \u041c\u0430\u043a\u0435\u0434\u043e\u043d"
+    ],
+    "name:mon_x_preferred":[
         "\u0423\u043c\u0430\u0440\u0434 \u041c\u0430\u043a\u0435\u0434\u043e\u043d"
     ],
     "name:mri_x_historical":[
         "Maker\u014dnia"
     ],
+    "name:mri_x_preferred":[
+        "Maker\u014dnia"
+    ],
     "name:msa_x_historical":[
         "Macedonia",
         "Republik Macedonia"
+    ],
+    "name:msa_x_preferred":[
+        "Makedonia Utara"
     ],
     "name:mwl_x_historical":[
         "Maced\u00f3nia"
@@ -578,20 +995,38 @@
         "\u1019\u102c\u1005\u102e\u1012\u102d\u102f\u1038\u1014\u102e\u1038\u101a\u102c\u1038",
         "\u1019\u1000\u103a\u1005\u102e\u1012\u102d\u102f\u1038\u1014\u102e\u1038\u101a\u102c\u1038\u1014\u102d\u102f\u1004\u103a\u1004\u1036"
     ],
+    "name:mya_x_preferred":[
+        "\u1019\u1000\u103a\u1005\u102e\u1012\u102d\u102f\u1038\u1014\u102e\u1038\u101a\u102c\u1038\u1014\u102d\u102f\u1004\u103a\u1004\u1036"
+    ],
     "name:myv_x_historical":[
+        "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f \u041c\u0430\u0441\u0442\u043e\u0440"
+    ],
+    "name:myv_x_preferred":[
         "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f \u041c\u0430\u0441\u0442\u043e\u0440"
     ],
     "name:mzn_x_historical":[
         "\u0645\u0642\u062f\u0648\u0646\u06cc\u0647"
     ],
+    "name:mzn_x_preferred":[
+        "\u0645\u0642\u062f\u0648\u0646\u06cc\u0647"
+    ],
     "name:nah_x_historical":[
+        "Tl\u0101catlahtohc\u0101y\u014dtl Macedonia"
+    ],
+    "name:nah_x_preferred":[
         "Tl\u0101catlahtohc\u0101y\u014dtl Macedonia"
     ],
     "name:nan_x_historical":[
         "Pak Macedonia"
     ],
+    "name:nan_x_preferred":[
+        "Pak Macedonia"
+    ],
     "name:nau_x_historical":[
         "Macedonia",
+        "Matedoniya"
+    ],
+    "name:nau_x_preferred":[
         "Matedoniya"
     ],
     "name:nde_x_historical":[
@@ -605,11 +1040,20 @@
         "Republiek Makedonien",
         "Noordmakedonien"
     ],
+    "name:nds_x_preferred":[
+        "Noordmakedonien"
+    ],
     "name:nep_x_historical":[
         "\u092e\u094d\u092f\u093e\u0938\u0947\u0921\u094b\u0928\u093f\u092f\u093e",
         "\u092e\u094d\u092f\u093e\u0915\u0947\u0921\u094b\u0928\u093f\u092f\u093e"
     ],
+    "name:nep_x_preferred":[
+        "\u092e\u094d\u092f\u093e\u0938\u0947\u0921\u094b\u0928\u093f\u092f\u093e"
+    ],
     "name:new_x_historical":[
+        "\u092e\u094d\u092f\u093e\u0938\u0947\u0921\u094b\u0928\u093f\u092f\u093e"
+    ],
+    "name:new_x_preferred":[
         "\u092e\u094d\u092f\u093e\u0938\u0947\u0921\u094b\u0928\u093f\u092f\u093e"
     ],
     "name:nld_x_colloquial":[
@@ -622,13 +1066,22 @@
         "Macedoni\u00eb",
         "Noord-Macedoni\u00eb"
     ],
+    "name:nld_x_preferred":[
+        "Noord-Macedoni\u00eb"
+    ],
     "name:nno_x_historical":[
         "Makedonia",
         "Republikken Makedonia",
         "Nord-Makedonia"
     ],
+    "name:nno_x_preferred":[
+        "Nord-Makedonia"
+    ],
     "name:nob_x_historical":[
         "Makedonia",
+        "Nord-Makedonia"
+    ],
+    "name:nob_x_preferred":[
         "Nord-Makedonia"
     ],
     "name:nor_x_historical":[
@@ -639,41 +1092,86 @@
         "Maced\u00f2nia",
         "Republica de Maced\u00f2nia"
     ],
+    "name:oci_x_preferred":[
+        "Maced\u00f2nia del N\u00f2rd"
+    ],
     "name:olo_x_historical":[
         "Makedounii"
+    ],
+    "name:olo_x_preferred":[
+        "Pohjas-Makedounii"
     ],
     "name:ori_x_historical":[
         "\u0b2e\u0b3e\u0b38\u0b47\u0b21\u0b4b\u0b28\u0b3f\u0b06",
         "\u0b2e\u0b3e\u0b38\u0b3f\u0b21\u0b4b\u0b28\u0b3f\u0b06"
     ],
+    "name:ori_x_preferred":[
+        "\u0b2e\u0b3e\u0b38\u0b3f\u0b21\u0b4b\u0b28\u0b3f\u0b06"
+    ],
     "name:orm_x_historical":[
+        "Maqedooniyaa"
+    ],
+    "name:orm_x_preferred":[
         "Maqedooniyaa"
     ],
     "name:oss_x_historical":[
         "\u0426\u00e6\u0433\u0430\u0442 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438"
     ],
+    "name:oss_x_preferred":[
+        "\u0426\u00e6\u0433\u0430\u0442 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438"
+    ],
     "name:pag_x_historical":[
+        "Masedoniya"
+    ],
+    "name:pag_x_preferred":[
         "Masedoniya"
     ],
     "name:pam_x_historical":[
         "Republika ning Makedonia"
     ],
+    "name:pam_x_preferred":[
+        "Pangulung Makedonia"
+    ],
+    "name:pan_x_preferred":[
+        "\u0a30\u0a40\u0a2a\u0a2c\u0a32\u0a3f\u0a15 \u0a06\u0a2b \u0a28\u0a3e\u0a30\u0a25 \u0a2e\u0a15\u0a26\u0a42\u0a28\u0a40\u0a06"
+    ],
     "name:pap_x_historical":[
+        "Nort Macedonia"
+    ],
+    "name:pap_x_preferred":[
         "Nort Macedonia"
     ],
     "name:pcd_x_historical":[
         "Mach\u00e9do\u00e8ne"
     ],
+    "name:pcd_x_preferred":[
+        "Mach\u00e9do\u00e8ne"
+    ],
+    "name:pih_x_preferred":[
+        "Repablik o' Masedoenya"
+    ],
     "name:pli_x_historical":[
+        "\u092e\u0947\u0938\u0947\u0921\u094b\u0928\u093f\u092f\u093e"
+    ],
+    "name:pli_x_preferred":[
         "\u092e\u0947\u0938\u0947\u0921\u094b\u0928\u093f\u092f\u093e"
     ],
     "name:pms_x_historical":[
         "Maced\u00f2nia"
     ],
+    "name:pms_x_preferred":[
+        "Maced\u00f2nia d\u00ebl N\u00f2rd"
+    ],
     "name:pnb_x_historical":[
         "\u0645\u0642\u062f\u0648\u0646\u06cc\u06c1"
     ],
+    "name:pnb_x_preferred":[
+        "\u0645\u0642\u062f\u0648\u0646\u06cc\u06c1"
+    ],
     "name:pnt_x_historical":[
+        "\u0392\u03cc\u03c1\u03b5\u03b9\u03b1 \u039c\u03b1\u03ba\u03b5\u03b4\u03bf\u03bd\u03af\u03b1"
+    ],
+    "name:pnt_x_preferred":[
         "\u0392\u03cc\u03c1\u03b5\u03b9\u03b1 \u039c\u03b1\u03ba\u03b5\u03b4\u03bf\u03bd\u03af\u03b1"
     ],
     "name:pol_x_historical":[
@@ -681,6 +1179,9 @@
         "Macedonia, Republika",
         "Macedonia",
         "By\u0142a Jugos\u0142owia\u0144ska Republika Macedonii",
+        "Macedonia P\u00f3\u0142nocna"
+    ],
+    "name:pol_x_preferred":[
         "Macedonia P\u00f3\u0142nocna"
     ],
     "name:por_x_colloquial":[
@@ -696,15 +1197,27 @@
     "name:pus_x_historical":[
         "\u062f \u0645\u0642\u062f\u0648\u0646\u064a\u06d0 \u0648\u0644\u0633\u0645\u0634\u0631\u064a\u0632\u0647"
     ],
+    "name:pus_x_preferred":[
+        "\u062f \u0645\u0642\u062f\u0648\u0646\u064a\u06d0 \u0648\u0644\u0633\u0645\u0634\u0631\u064a\u0632\u0647"
+    ],
     "name:que_x_historical":[
         "Makiduniya",
+        "Chinchay Masitunya"
+    ],
+    "name:que_x_preferred":[
         "Chinchay Masitunya"
     ],
     "name:rmy_x_historical":[
         "Republika Makedoniya"
     ],
+    "name:rmy_x_preferred":[
+        "Republika Makedoniya"
+    ],
     "name:roh_x_historical":[
         "Macedonia"
+    ],
+    "name:roh_x_preferred":[
+        "Macedonia dal Nord"
     ],
     "name:ron_x_historical":[
         "Macedonia",
@@ -713,6 +1226,9 @@
     ],
     "name:rue_x_historical":[
         "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0456\u044f",
+        "\u0421\u0463\u0432\u0435\u0440\u043d\u0430 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0456\u044f"
+    ],
+    "name:rue_x_preferred":[
         "\u0421\u0463\u0432\u0435\u0440\u043d\u0430 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0456\u044f"
     ],
     "name:rum_x_historical":[
@@ -729,16 +1245,28 @@
         "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f",
         "\u0421\u0435\u0432\u0435\u0440\u043d\u0430\u044f \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f"
     ],
+    "name:rus_x_preferred":[
+        "\u0421\u0435\u0432\u0435\u0440\u043d\u0430\u044f \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f"
+    ],
     "name:sag_x_historical":[
         "Masedu\u00e4ni"
     ],
     "name:sah_x_historical":[
         "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430\u0442\u0430"
     ],
+    "name:sah_x_preferred":[
+        "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430\u0442\u0430"
+    ],
     "name:san_x_historical":[
         "\u092e\u0947\u0938\u0947\u0921\u094b\u0928\u093f\u092f\u093e"
     ],
+    "name:san_x_preferred":[
+        "\u092e\u0947\u0938\u0947\u0921\u094b\u0928\u093f\u092f\u093e"
+    ],
     "name:sat_x_historical":[
+        "\u1c62\u1c5f\u1c65\u1c64\u1c70\u1c5a\u1c71\u1c64\u1c6d\u1c5f"
+    ],
+    "name:sat_x_preferred":[
         "\u1c62\u1c5f\u1c65\u1c64\u1c70\u1c5a\u1c71\u1c64\u1c6d\u1c5f"
     ],
     "name:scn_x_historical":[
@@ -750,10 +1278,22 @@
         "Macedonie",
         "North Macedonie"
     ],
+    "name:sco_x_preferred":[
+        "North Macedonie"
+    ],
     "name:sgs_x_historical":[
         "Makeduon\u0117j\u0117"
     ],
+    "name:sgs_x_preferred":[
+        "Makeduon\u0117j\u0117"
+    ],
+    "name:shn_x_preferred":[
+        "\u1019\u102d\u1030\u1004\u103a\u1038\u1019\u1085\u1010\u103a\u1087\u101e\u102e\u1087\u1010\u1030\u101d\u103a\u1038\u107c\u102e\u1038\u101a\u1083\u1038"
+    ],
     "name:sin_x_historical":[
+        "\u0d8b\u0dad\u0dd4\u0dbb\u0dd4 \u0db8\u0dd0\u0dc3\u0dd2\u0da9\u0ddd\u0db1\u0dd2\u0dba\u0dcf\u0dc0"
+    ],
+    "name:sin_x_preferred":[
         "\u0d8b\u0dad\u0dd4\u0dbb\u0dd4 \u0db8\u0dd0\u0dc3\u0dd2\u0da9\u0ddd\u0db1\u0dd2\u0dba\u0dcf\u0dc0"
     ],
     "name:slk_x_historical":[
@@ -761,9 +1301,15 @@
         "Maced\u00f3nsko",
         "Severn\u00e9 Maced\u00f3nsko"
     ],
+    "name:slk_x_preferred":[
+        "Severn\u00e9 Maced\u00f3nsko"
+    ],
     "name:slv_x_historical":[
         "Republika Makedonija",
         "Makedonija",
+        "Severna Makedonija"
+    ],
+    "name:slv_x_preferred":[
         "Severna Makedonija"
     ],
     "name:sme_x_historical":[
@@ -771,11 +1317,29 @@
         "Makedonia",
         "Davvi-Makedonia"
     ],
+    "name:sme_x_preferred":[
+        "Davvi-Makedonia"
+    ],
+    "name:smn_x_preferred":[
+        "Tave-Makedonia"
+    ],
+    "name:smo_x_preferred":[
+        "Ripapelika o Maketonia"
+    ],
+    "name:sms_x_preferred":[
+        "T\u00e2\u02b9vv-Makedonia"
+    ],
     "name:sna_x_historical":[
+        "Macedonia"
+    ],
+    "name:sna_x_preferred":[
         "Macedonia"
     ],
     "name:som_x_historical":[
         "Makadooniya"
+    ],
+    "name:som_x_preferred":[
+        "Jamhuuriyada Waqooyiga Macedonia"
     ],
     "name:spa_x_colloquial":[
         "Antigua Republica Yugoslava de Macedonia",
@@ -788,15 +1352,24 @@
         "Ex Rep\u00fablica Yugoslava de Macedonia",
         "Macedonia, Antigua Rep\u00fablica Yugoslava"
     ],
+    "name:spa_x_preferred":[
+        "Macedonia del Norte"
+    ],
     "name:sqi_x_historical":[
         "Maqedonia (kthjellim)",
         "Maqedoni",
         "Republika e Maqedonis\u00eb"
     ],
+    "name:sqi_x_preferred":[
+        "Maqedonia e Veriut"
+    ],
     "name:srd_x_historical":[
         "Matzed\u00f2nia"
     ],
     "name:srn_x_historical":[
+        "Masedoniyakondre"
+    ],
+    "name:srn_x_preferred":[
         "Masedoniyakondre"
     ],
     "name:srp_x_historical":[
@@ -805,18 +1378,33 @@
         "\u0420\u0435\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u0458\u0430",
         "\u0421\u0435\u0432\u0435\u0440\u043d\u0430 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u0458\u0430"
     ],
+    "name:srp_x_preferred":[
+        "\u0421\u0435\u0432\u0435\u0440\u043d\u0430 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u0458\u0430"
+    ],
     "name:ssw_x_historical":[
         "IMakhedoniya"
+    ],
+    "name:ssw_x_preferred":[
+        "iMakhedoniya leseNyakatfo"
     ],
     "name:stq_x_historical":[
         "Makedonien"
     ],
+    "name:stq_x_preferred":[
+        "Noudmakedonien"
+    ],
     "name:sun_x_historical":[
+        "Mak\u00e9donia Kal\u00e9r"
+    ],
+    "name:sun_x_preferred":[
         "Mak\u00e9donia Kal\u00e9r"
     ],
     "name:swa_x_historical":[
         "Jamhuri ya Masedonia",
         "Masedonia"
+    ],
+    "name:swa_x_preferred":[
+        "Masedonia ya Kaskazini"
     ],
     "name:swe_x_historical":[
         "Makedonien",
@@ -825,35 +1413,65 @@
         "FYROM",
         "Nordmakedonien"
     ],
+    "name:swe_x_preferred":[
+        "Nordmakedonien"
+    ],
     "name:szl_x_historical":[
         "P\u016f\u0142nocno Maced\u016f\u0144ijo"
+    ],
+    "name:szl_x_preferred":[
+        "P\u016f\u0142nocno Maced\u016f\u0144ijo"
+    ],
+    "name:szy_x_preferred":[
+        "Macedonia"
     ],
     "name:tam_x_historical":[
         "\u0bae\u0bbe\u0b9a\u0bbf\u0b9f\u0bcb\u0ba9\u0bbf\u0baf\u0bbe",
         "\u0bb5\u0b9f\u0b95\u0bcd\u0b95\u0bc1 \u0bae\u0bbe\u0b95\u0bcd\u0b95\u0b9f\u0bcb\u0ba9\u0bbf\u0baf\u0bbe"
     ],
+    "name:tam_x_preferred":[
+        "\u0bb5\u0b9f\u0b95\u0bcd\u0b95\u0bc1 \u0bae\u0bbe\u0b95\u0bcd\u0b95\u0b9f\u0bcb\u0ba9\u0bbf\u0baf\u0bbe"
+    ],
     "name:tat_x_historical":[
         "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f \u0496\u04e9\u043c\u04bb\u04af\u0440\u0438\u044f\u0442\u0435"
     ],
+    "name:tat_x_preferred":[
+        "\u0422\u04e9\u043d\u044c\u044f\u043a \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f"
+    ],
     "name:tel_x_historical":[
         "\u0c2e\u0c47\u0c38\u0c46\u0c21\u0c4b\u0c28\u0c3f\u0c2f\u0c3e",
+        "\u0c09\u0c24\u0c4d\u0c24\u0c30 \u0c2e\u0c46\u0c38\u0c3f\u0c21\u0c4b\u0c28\u0c3f\u0c2f\u0c3e"
+    ],
+    "name:tel_x_preferred":[
         "\u0c09\u0c24\u0c4d\u0c24\u0c30 \u0c2e\u0c46\u0c38\u0c3f\u0c21\u0c4b\u0c28\u0c3f\u0c2f\u0c3e"
     ],
     "name:tet_x_historical":[
         "Mased\u00f3nia",
         "Mased\u00f3nia Norte"
     ],
+    "name:tet_x_preferred":[
+        "Mased\u00f3nia Norte"
+    ],
     "name:tgk_x_historical":[
         "\u04b6\u0443\u043c\u04b3\u0443\u0440\u0438\u0438 \u041c\u0430\u049b\u0434\u0443\u043d\u0438\u044f",
+        "\u041c\u0430\u049b\u0434\u0443\u043d\u0438\u044f\u0438 \u0428\u0438\u043c\u043e\u043b\u04e3"
+    ],
+    "name:tgk_x_preferred":[
         "\u041c\u0430\u049b\u0434\u0443\u043d\u0438\u044f\u0438 \u0428\u0438\u043c\u043e\u043b\u04e3"
     ],
     "name:tgl_x_historical":[
         "Republika ng Macedonia",
         "Hilagang Macedonia"
     ],
+    "name:tgl_x_preferred":[
+        "Hilagang Macedonia"
+    ],
     "name:tha_x_historical":[
         "\u0e21\u0e32\u0e0b\u0e34\u0e42\u0e14\u0e40\u0e19\u0e35\u0e22",
         "\u0e1b\u0e23\u0e30\u0e40\u0e17\u0e28\u0e21\u0e32\u0e0b\u0e34\u0e42\u0e14\u0e40\u0e19\u0e35\u0e22",
+        "\u0e1b\u0e23\u0e30\u0e40\u0e17\u0e28\u0e19\u0e2d\u0e23\u0e4c\u0e17\u0e21\u0e32\u0e0b\u0e34\u0e42\u0e14\u0e40\u0e19\u0e35\u0e22"
+    ],
+    "name:tha_x_preferred":[
         "\u0e1b\u0e23\u0e30\u0e40\u0e17\u0e28\u0e19\u0e2d\u0e23\u0e4c\u0e17\u0e21\u0e32\u0e0b\u0e34\u0e42\u0e14\u0e40\u0e19\u0e35\u0e22"
     ],
     "name:tir_x_historical":[
@@ -862,7 +1480,19 @@
     "name:ton_x_historical":[
         "Masit\u014dnia"
     ],
+    "name:tpi_x_preferred":[
+        "Republic of Macedonia"
+    ],
+    "name:trv_x_preferred":[
+        "Macedonia"
+    ],
+    "name:tso_x_preferred":[
+        "Republic of Macedonia"
+    ],
     "name:tuk_x_historical":[
+        "Demirgazyk Makedoni\u00fda"
+    ],
+    "name:tuk_x_preferred":[
         "Demirgazyk Makedoni\u00fda"
     ],
     "name:tum_x_historical":[
@@ -872,19 +1502,34 @@
         "Makedonya",
         "Kuzey Makedonya"
     ],
+    "name:tur_x_preferred":[
+        "Kuzey Makedonya"
+    ],
     "name:twi_x_historical":[
+        "Masidonia"
+    ],
+    "name:twi_x_preferred":[
         "Masidonia"
     ],
     "name:udm_x_historical":[
         "\u0423\u0439\u043f\u0430\u043b \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f"
     ],
+    "name:udm_x_preferred":[
+        "\u0423\u0439\u043f\u0430\u043b \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f"
+    ],
     "name:uig_x_historical":[
+        "\u0645\u0627\u0643\u06d0\u062f\u0648\u0646\u0649\u064a\u06d5"
+    ],
+    "name:uig_x_preferred":[
         "\u0645\u0627\u0643\u06d0\u062f\u0648\u0646\u0649\u064a\u06d5"
     ],
     "name:ukr_x_historical":[
         "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0456\u044f",
         "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0456\u043a\u0430 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0456\u044f",
         "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0456\u044f, \u043a\u043e\u043b\u0438\u0448\u043d\u044f \u042e\u0433\u043e\u0441\u043b\u0430\u0432\u0441\u044c\u043a\u0430 \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0456\u043a\u0430",
+        "\u041f\u0456\u0432\u043d\u0456\u0447\u043d\u0430 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0456\u044f"
+    ],
+    "name:ukr_x_preferred":[
         "\u041f\u0456\u0432\u043d\u0456\u0447\u043d\u0430 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0456\u044f"
     ],
     "name:und_x_colloquial":[
@@ -903,13 +1548,25 @@
         "\u0645\u0642\u062f\u0648\u0646\u06cc\u06c1",
         "\u0634\u0645\u0627\u0644\u06cc \u0645\u0642\u062f\u0648\u0646\u06cc\u06c1"
     ],
+    "name:urd_x_preferred":[
+        "\u0634\u0645\u0627\u0644\u06cc \u0645\u0642\u062f\u0648\u0646\u06cc\u06c1"
+    ],
     "name:uzb_x_historical":[
         "Makedoniya"
+    ],
+    "name:uzb_x_preferred":[
+        "Shimoliy Makedoniya"
     ],
     "name:vec_x_historical":[
         "Macedonia"
     ],
+    "name:vec_x_preferred":[
+        "Maced\u00f2nia del Nord"
+    ],
     "name:vep_x_historical":[
+        "Pohjoi\u017emakedonii"
+    ],
+    "name:vep_x_preferred":[
         "Pohjoi\u017emakedonii"
     ],
     "name:vie_x_historical":[
@@ -918,8 +1575,14 @@
         "Ma-x\u00ea-\u0111\u00f4-ni-a (Macedonia)",
         "B\u1eafc Macedonia"
     ],
+    "name:vie_x_preferred":[
+        "B\u1eafc Macedonia"
+    ],
     "name:vls_x_historical":[
         "Macedoni\u00eb"
+    ],
+    "name:vls_x_preferred":[
+        "Noord-Macedoni\u00eb"
     ],
     "name:vol_x_historical":[
         "Macedonia",
@@ -927,34 +1590,70 @@
         "Makedoniy\u00e4n",
         "Nol\u00fcda-Makedoniy\u00e4n"
     ],
+    "name:vol_x_preferred":[
+        "Nol\u00fcda-Makedoniy\u00e4n"
+    ],
     "name:vro_x_historical":[
+        "Mak\u00f5doonia Vabariik"
+    ],
+    "name:vro_x_preferred":[
         "Mak\u00f5doonia Vabariik"
     ],
     "name:war_x_historical":[
         "Republika han Macedonia"
     ],
+    "name:war_x_preferred":[
+        "Norte nga Macedonia"
+    ],
     "name:wol_x_historical":[
+        "R\u00e9ewum Maseduwaan"
+    ],
+    "name:wol_x_preferred":[
         "R\u00e9ewum Maseduwaan"
     ],
     "name:wuu_x_historical":[
         "\u9a6c\u5176\u987f"
     ],
+    "name:wuu_x_preferred":[
+        "\u9a6c\u5176\u987f"
+    ],
     "name:xal_x_historical":[
+        "\u041c\u0430\u0441\u0438\u0434\u0438\u043d \u041e\u0440\u043d"
+    ],
+    "name:xal_x_preferred":[
         "\u041c\u0430\u0441\u0438\u0434\u0438\u043d \u041e\u0440\u043d"
     ],
     "name:xmf_x_historical":[
         "\u10dd\u10dd\u10e0\u10e3\u10d4 \u10db\u10d0\u10d9\u10d4\u10d3\u10dd\u10dc\u10d8\u10d0"
     ],
+    "name:xmf_x_preferred":[
+        "\u10dd\u10dd\u10e0\u10e3\u10d4 \u10db\u10d0\u10d9\u10d4\u10d3\u10dd\u10dc\u10d8\u10d0"
+    ],
+    "name:yid_x_preferred":[
+        "\u05e6\u05e4\u05d5\u05df-\u05de\u05d0\u05e7\u05e2\u05d3\u05d0\u05e0\u05d9\u05e2"
+    ],
     "name:yor_x_historical":[
         "Or\u00edl\u1eb9\u0301\u00e8de Masidonia"
     ],
+    "name:yor_x_preferred":[
+        "Or\u00edl\u1eb9\u0300-\u00e8d\u00e8 Ol\u00f3m\u00ecnira il\u1eb9\u0300 Mak\u1eb9d\u00f3n\u00ed\u00e0"
+    ],
     "name:yue_x_historical":[
+        "\u5317\u99ac\u5176\u9813\u5171\u548c\u570b"
+    ],
+    "name:yue_x_preferred":[
         "\u5317\u99ac\u5176\u9813\u5171\u548c\u570b"
     ],
     "name:zea_x_historical":[
         "Noord-Macedoni\u00eb"
     ],
+    "name:zea_x_preferred":[
+        "Noord-Macedoni\u00eb"
+    ],
     "name:zha_x_historical":[
+        "Baek Macedonia"
+    ],
+    "name:zha_x_preferred":[
         "Baek Macedonia"
     ],
     "name:zho_x_historical":[
@@ -965,9 +1664,15 @@
         "\u524d\u5357\u65af\u62c9\u592b\u9a6c\u5176\u987f\u5171\u548c\u56fd",
         "\u5317\u9a6c\u5176\u987f"
     ],
+    "name:zho_x_preferred":[
+        "\u5317\u9a6c\u5176\u987f"
+    ],
     "name:zul_x_historical":[
         "I-Macedonia",
         "IMakedoniya"
+    ],
+    "name:zul_x_preferred":[
+        "INyakatho Masedoniya"
     ],
     "ne:abbrev":"Mkd.",
     "ne:abbrev_len":4,
@@ -1115,7 +1820,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1631221520,
+    "wof:lastmodified":1631221601,
     "wof:name":"North Macedonia",
     "wof:parent_id":102191581,
     "wof:placetype":"country",

--- a/data/856/323/73/85632373.geojson
+++ b/data/856/323/73/85632373.geojson
@@ -32,242 +32,198 @@
     "mz:is_current":1,
     "mz:max_zoom":10.0,
     "mz:min_zoom":5.0,
-    "name:abk_x_preferred":[
+    "name:abk_x_historical":[
         "\u0410\u04a9\u0430\u0434\u0430\u0442\u04d9\u0438 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u0430"
     ],
-    "name:ace_x_preferred":[
+    "name:ace_x_historical":[
         "Mak\u00e8donia Utara"
     ],
-    "name:ady_x_preferred":[
+    "name:ady_x_historical":[
         "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u044d\u0443 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u0435"
     ],
-    "name:afr_x_preferred":[
-        "Masedoni\u00eb (dubbelsinnig)"
-    ],
-    "name:afr_x_variant":[
+    "name:afr_x_historical":[
+        "Masedoni\u00eb (dubbelsinnig)",
         "Macedoni\u00eb",
         "Republiek Noord-Masedoni\u00eb"
     ],
-    "name:aka_x_preferred":[
+    "name:aka_x_historical":[
         "Masedonia"
     ],
-    "name:als_x_preferred":[
+    "name:als_x_historical":[
         "Mazedonien (Begriffskl\u00e4rung)"
     ],
-    "name:amh_x_preferred":[
-        "\u121b\u12a8\u12f6\u1292\u12eb"
-    ],
-    "name:amh_x_variant":[
+    "name:amh_x_historical":[
+        "\u121b\u12a8\u12f6\u1292\u12eb",
         "\u12e8\u1218\u1244\u12f6\u1295\u12eb \u122c\u1351\u1265\u120a\u12ad"
     ],
-    "name:ang_x_preferred":[
+    "name:ang_x_historical":[
         "Cynew\u012bse Macedonia"
     ],
-    "name:ara_x_preferred":[
-        "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0645\u0642\u062f\u0648\u0646\u064a\u0627"
-    ],
-    "name:ara_x_variant":[
+    "name:ara_x_historical":[
+        "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0645\u0642\u062f\u0648\u0646\u064a\u0627",
         "\u0645\u0642\u062f\u0648\u0646\u064a\u0627",
         "\u0645\u0642\u062f\u0648\u0646\u064a\u0627 \u0627\u0644\u0634\u0645\u0627\u0644\u064a\u0629"
     ],
-    "name:arc_x_preferred":[
-        "\u0721\u0729\u0715\u0718\u0722\u071d\u0710"
-    ],
-    "name:arc_x_variant":[
+    "name:arc_x_historical":[
+        "\u0721\u0729\u0715\u0718\u0722\u071d\u0710",
         "\u0729\u0718\u071b\u0722\u071d\u0718\u072c\u0710 \u0715\u0721\u0729\u0715\u0718\u0722\u071d\u0710"
     ],
-    "name:arg_x_preferred":[
+    "name:arg_x_historical":[
         "Macedonia"
     ],
-    "name:arz_x_preferred":[
-        "\u0645\u0642\u062f\u0648\u0646\u064a\u0627"
-    ],
-    "name:arz_x_variant":[
+    "name:arz_x_historical":[
+        "\u0645\u0642\u062f\u0648\u0646\u064a\u0627",
         "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0645\u0642\u062f\u0648\u0646\u064a\u0627"
     ],
-    "name:ast_x_preferred":[
-        "Macedonia (dixebra)"
-    ],
-    "name:ast_x_variant":[
+    "name:ast_x_historical":[
+        "Macedonia (dixebra)",
         "Rep\u00fablica de Macedonia"
     ],
-    "name:ava_x_preferred":[
+    "name:ava_x_historical":[
         "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f"
     ],
-    "name:azb_x_preferred":[
-        "\u0645\u0642\u062f\u0648\u0646\u06cc\u0647"
-    ],
-    "name:azb_x_variant":[
+    "name:azb_x_historical":[
+        "\u0645\u0642\u062f\u0648\u0646\u06cc\u0647",
         "\u0645\u0648\u0644\u062f\u0627\u0648\u06cc"
     ],
-    "name:aze_x_preferred":[
-        "Makedoniya"
-    ],
-    "name:aze_x_variant":[
+    "name:aze_x_historical":[
+        "Makedoniya",
         "Masedoniya",
         "\u015eimali Makedoniya"
     ],
-    "name:bak_x_preferred":[
+    "name:bak_x_historical":[
         "\u0422\u04e9\u043d\u044c\u044f\u04a1 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f"
     ],
-    "name:bam_x_preferred":[
+    "name:bam_x_historical":[
         "Maced\u0254ni"
     ],
-    "name:bar_x_preferred":[
-        "Mazedonien (Begriffskl\u00e4rung)"
-    ],
-    "name:bar_x_variant":[
+    "name:bar_x_historical":[
+        "Mazedonien (Begriffskl\u00e4rung)",
         "Noadmazedonien"
     ],
-    "name:bel_x_preferred":[
-        "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0456\u044f, \u0437\u043d\u0430\u0447\u044d\u043d\u043d\u0456"
-    ],
-    "name:bel_x_variant":[
+    "name:bel_x_historical":[
+        "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0456\u044f, \u0437\u043d\u0430\u0447\u044d\u043d\u043d\u0456",
         "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0456\u044f",
         "\u0420\u044d\u0441\u043f\u0443\u0431\u043b\u0456\u043a\u0430 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0456\u044f",
         "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0456\u044f, \u0411\u042e\u0420",
         "\u041f\u0430\u045e\u043d\u043e\u0447\u043d\u0430\u044f \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0456\u044f"
     ],
-    "name:ben_x_preferred":[
-        "\u09ae\u09cd\u09af\u09be\u09b8\u09be\u09a1\u09cb\u09a8\u09bf\u09af\u09bc\u09be"
-    ],
-    "name:ben_x_variant":[
+    "name:ben_x_historical":[
+        "\u09ae\u09cd\u09af\u09be\u09b8\u09be\u09a1\u09cb\u09a8\u09bf\u09af\u09bc\u09be",
         "\u0989\u09a4\u09cd\u09a4\u09b0 \u09ae\u09cd\u09af\u09be\u09b8\u09c7\u09a1\u09cb\u09a8\u09bf\u09af\u09bc\u09be"
     ],
-    "name:bho_x_preferred":[
+    "name:bho_x_historical":[
         "\u092e\u0947\u0938\u0940\u0921\u094b\u0928\u093f\u092f\u093e"
     ],
-    "name:bis_x_preferred":[
+    "name:bis_x_historical":[
         "Not Macedonia"
     ],
-    "name:bod_x_preferred":[
+    "name:bod_x_historical":[
         "\u0f58\u0f0b\u0f66\u0f7a\u0f0b\u0f4c\u0f7c\u0f0b\u0f53\u0f72\u0f61\u0f0d"
     ],
-    "name:bos_x_preferred":[
-        "Makedonija (\u010dvor)"
-    ],
-    "name:bos_x_variant":[
+    "name:bos_x_historical":[
+        "Makedonija (\u010dvor)",
         "Republika Makedonija",
         "Makedonija"
     ],
-    "name:bpy_x_preferred":[
+    "name:bpy_x_historical":[
         "\u09ae\u09c7\u09b8\u09bf\u09a1\u09cb\u09a8\u09bf\u09af\u09bc\u09be"
     ],
-    "name:bre_x_preferred":[
-        "Republik Makedonia"
-    ],
-    "name:bre_x_variant":[
+    "name:bre_x_historical":[
+        "Republik Makedonia",
         "Makedonia"
     ],
-    "name:bul_x_preferred":[
-        "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f"
-    ],
-    "name:bul_x_variant":[
+    "name:bul_x_historical":[
+        "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f",
         "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f, \u0420\u0435\u043f\u0443\u0431\u043b\u0438\u043a\u0430",
         "\u0420\u0435\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f",
         "\u0421\u0435\u0432\u0435\u0440\u043d\u0430 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f"
     ],
-    "name:bxr_x_preferred":[
+    "name:bxr_x_historical":[
         "\u0425\u043e\u0439\u0442\u043e \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438"
     ],
-    "name:cat_x_preferred":[
-        "Maced\u00f2nia"
-    ],
-    "name:cat_x_variant":[
+    "name:cat_x_historical":[
+        "Maced\u00f2nia",
         "Rep\u00fablica de Maced\u00f2nia"
     ],
-    "name:cdo_x_preferred":[
+    "name:cdo_x_historical":[
         "B\u00e1e\u0324k M\u0101-g\u00ec-d\u00f3ng"
     ],
-    "name:ceb_x_preferred":[
+    "name:ceb_x_historical":[
         "Macedonia (pagklaro)"
     ],
-    "name:ces_x_preferred":[
-        "Makedonie (rozcestn\u00edk)"
-    ],
-    "name:ces_x_variant":[
+    "name:ces_x_historical":[
+        "Makedonie (rozcestn\u00edk)",
         "Macedonia",
         "Republika Makedonie",
         "Makedonie",
         "Severn\u00ed Makedonie"
     ],
-    "name:che_x_preferred":[
+    "name:che_x_historical":[
         "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438"
     ],
-    "name:chr_x_preferred":[
+    "name:chr_x_historical":[
         "\u13b9\u13ce\u13d9\u13c2\u13ef"
     ],
-    "name:chu_x_preferred":[
-        "\u041c\u0430\u043a\u0454\u0434\u043e\u043d\u0457\ua657 \u00b7 \u0441\u044a\u043c\ua651\u0441\u043b\u0438"
-    ],
-    "name:chu_x_variant":[
+    "name:chu_x_historical":[
+        "\u041c\u0430\u043a\u0454\u0434\u043e\u043d\u0457\ua657 \u00b7 \u0441\u044a\u043c\ua651\u0441\u043b\u0438",
         "\u0421\u0463\u0432\u0454\u0440\u044c\u043d\u0430 \u041c\u0430\u043a\u0454\u0434\u043e\u043d\u0457\ua657"
     ],
-    "name:chv_x_preferred":[
+    "name:chv_x_historical":[
         "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438 \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0438"
     ],
-    "name:ckb_x_preferred":[
+    "name:ckb_x_historical":[
         "\u06a9\u06c6\u0645\u0627\u0631\u06cc \u0645\u06d5\u0642\u062f\u0648\u0648\u0646\u06cc\u0627"
     ],
-    "name:cor_x_preferred":[
+    "name:cor_x_historical":[
         "Repoblek Makedoni"
     ],
-    "name:crh_x_preferred":[
-        "Makedoniya"
-    ],
-    "name:crh_x_variant":[
+    "name:crh_x_historical":[
+        "Makedoniya",
         "\u015eimaliy Makedoniya"
     ],
-    "name:csb_x_preferred":[
+    "name:csb_x_historical":[
         "Nordow\u00f4 Macedo\u0144sk\u00f4"
     ],
-    "name:cym_x_preferred":[
-        "Macedonia"
-    ],
-    "name:cym_x_variant":[
+    "name:cym_x_historical":[
+        "Macedonia",
         "Gweriniaeth Macedonia",
         "Gogledd Macedonia"
     ],
-    "name:cze_x_variant":[
+    "name:cze_x_historical":[
         "Republika Makedonie"
     ],
-    "name:dan_x_preferred":[
-        "Makedonien"
-    ],
-    "name:dan_x_variant":[
+    "name:dan_x_historical":[
+        "Makedonien",
         "Republikken Makedonien",
         "Tidligere jugoslaviske republik Makedonien",
         "Tidligere Jugoslaviske Republik Makedonien",
         "Nordmakedonien"
     ],
-    "name:deu_x_preferred":[
-        "Mazedonien (Begriffskl\u00e4rung)"
-    ],
-    "name:deu_x_variant":[
+    "name:deu_x_historical":[
+        "Mazedonien (Begriffskl\u00e4rung)",
         "Mazedonien",
         "Ehemalige Jugoslawische Republik Mazedonien",
         "Ehemalige jugoslawische Republik Mazedonien",
         "Nordmazedonien"
     ],
-    "name:diq_x_preferred":[
+    "name:diq_x_historical":[
         "Cumur\u00eat\u00ea Makedonya"
     ],
-    "name:div_x_preferred":[
+    "name:div_x_historical":[
         "\u0789\u07ac\u0790\u07ac\u0791\u07af\u0782\u07a8\u0787\u07a7"
     ],
-    "name:dsb_x_preferred":[
+    "name:dsb_x_historical":[
         "Makedo\u0144ska"
     ],
-    "name:dty_x_preferred":[
+    "name:dty_x_historical":[
         "\u092e\u094d\u092f\u093e\u0938\u0947\u0921\u094b\u0928\u093f\u092f\u093e"
     ],
-    "name:efi_x_preferred":[
+    "name:efi_x_historical":[
         "Macedonia"
     ],
-    "name:ell_x_preferred":[
-        "\u039c\u03b1\u03ba\u03b5\u03b4\u03bf\u03bd\u03af\u03b1 (\u03b1\u03c0\u03bf\u03c3\u03b1\u03c6\u03ae\u03bd\u03b9\u03c3\u03b7)"
-    ],
-    "name:ell_x_variant":[
+    "name:ell_x_historical":[
+        "\u039c\u03b1\u03ba\u03b5\u03b4\u03bf\u03bd\u03af\u03b1 (\u03b1\u03c0\u03bf\u03c3\u03b1\u03c6\u03ae\u03bd\u03b9\u03c3\u03b7)",
         "\u03a0\u0393\u0394 \u039c\u03b1\u03ba\u03b5\u03b4\u03bf\u03bd\u03af\u03b1\u03c2",
         "\u03a0\u03c1\u03ce\u03b7\u03bd \u0393\u03b9\u03bf\u03c5\u03b3\u03ba\u03bf\u03c3\u03bb\u03b1\u03b2\u03b9\u03ba\u03ae \u0394\u03b7\u03bc\u03bf\u03ba\u03c1\u03b1\u03c4\u03af\u03b1 \u03c4\u03b7\u03c2 \u039c\u03b1\u03ba\u03b5\u03b4\u03bf\u03bd\u03af\u03b1\u03c2",
         "\u03a0.\u0393.\u0394. \u039c\u03b1\u03ba\u03b5\u03b4\u03bf\u03bd\u03af\u03b1\u03c2",
@@ -277,14 +233,8 @@
         "Macedonia (FYR)",
         "Macedonia, The Former Yugoslav Republic Of"
     ],
-    "name:eng_x_preferred":[
-        "Macedonia"
-    ],
-    "name:eng_x_unknown":[
-        "MK",
-        "MKD"
-    ],
-    "name:eng_x_variant":[
+    "name:eng_x_historical":[
+        "Macedonia",
         "F.Y.R.O. Macedonia",
         "FYR of Macedonia",
         "Former Yugoslav Republic of Macedonia",
@@ -297,50 +247,42 @@
         "Macedonia, The Former Yugoslav Republic Of",
         "North Macedonia"
     ],
-    "name:epo_x_preferred":[
-        "Makedonio"
+    "name:eng_x_unknown":[
+        "MK",
+        "MKD"
     ],
-    "name:epo_x_variant":[
+    "name:epo_x_historical":[
+        "Makedonio",
         "Makedonujo",
         "Respubliko Makedonio",
         "Nord-Makedonio"
     ],
-    "name:est_x_preferred":[
-        "Makedoonia Vabariik"
-    ],
-    "name:est_x_variant":[
+    "name:est_x_historical":[
+        "Makedoonia Vabariik",
         "Makedoonia",
         "P\u00f5hja-Makedoonia"
     ],
-    "name:eus_x_preferred":[
-        "Mazedonia (argipena)"
-    ],
-    "name:eus_x_variant":[
+    "name:eus_x_historical":[
+        "Mazedonia (argipena)",
         "Mazedonia",
         "Mazedoniako Errepublika",
         "Ipar Mazedonia"
     ],
-    "name:ewe_x_preferred":[
+    "name:ewe_x_historical":[
         "Makedonia nutome"
     ],
-    "name:fao_x_preferred":[
-        "Maked\u00f3nia"
-    ],
-    "name:fao_x_variant":[
+    "name:fao_x_historical":[
+        "Maked\u00f3nia",
         "L\u00fd\u00f0veldi\u00f0 Maked\u00f3nia"
     ],
-    "name:fas_x_preferred":[
-        "\u0645\u0642\u062f\u0648\u0646\u06cc\u0647"
-    ],
-    "name:fas_x_variant":[
+    "name:fas_x_historical":[
+        "\u0645\u0642\u062f\u0648\u0646\u06cc\u0647",
         "\u0645\u06a9\u062f\u0648\u0646\u06cc\u0627",
         "\u0645\u0642\u062f\u0648\u0646\u06cc\u0647 \u0634\u0645\u0627\u0644\u06cc"
     ],
-    "name:fin_x_preferred":[
+    "name:fin_x_historical":[
         "Makedonia",
-        "Macedonia (t\u00e4smennyssivu)"
-    ],
-    "name:fin_x_variant":[
+        "Macedonia (t\u00e4smennyssivu)",
         "Entinen Jugoslavian tasavalta Makedonia",
         "Makedonian tasavalta",
         "Makedonian valtakunta",
@@ -349,481 +291,393 @@
     "name:fra_x_colloquial":[
         "Macedoine"
     ],
-    "name:fra_x_preferred":[
-        "Macedonia"
-    ],
-    "name:fra_x_variant":[
+    "name:fra_x_historical":[
+        "Macedonia",
         "Ancienne r\u00e9publique yougoslave de Mac\u00e9doine",
         "Mac\u00e9doine"
     ],
-    "name:frp_x_preferred":[
+    "name:frp_x_historical":[
         "R\u00e8publica de Mac\u00e8donie"
     ],
-    "name:frr_x_preferred":[
+    "name:frr_x_historical":[
         "Nuurd-Matsedoonien"
     ],
-    "name:fry_x_preferred":[
-        "Masedoanje"
-    ],
-    "name:fry_x_variant":[
+    "name:fry_x_historical":[
+        "Masedoanje",
         "Noard-Masedoanje"
     ],
-    "name:ful_x_preferred":[
-        "Meceduwaan"
-    ],
-    "name:ful_x_variant":[
+    "name:ful_x_historical":[
+        "Meceduwaan",
         "Masedoniya"
     ],
-    "name:fur_x_preferred":[
+    "name:fur_x_historical":[
         "Macedonie"
     ],
-    "name:gag_x_preferred":[
+    "name:gag_x_historical":[
         "Poyraz Makedoniya"
     ],
-    "name:gle_x_preferred":[
+    "name:gle_x_historical":[
         "An Mhacad\u00f3in"
     ],
-    "name:glg_x_preferred":[
-        "Macedonia"
-    ],
-    "name:glg_x_variant":[
+    "name:glg_x_historical":[
+        "Macedonia",
         "Rep\u00fablica de Macedonia"
     ],
-    "name:gom_x_preferred":[
+    "name:gom_x_historical":[
         "\u092e\u0945\u0938\u093f\u0921\u094b\u0928\u093f\u092f\u093e"
     ],
-    "name:got_x_preferred":[
+    "name:got_x_historical":[
         "\ud800\udf3c\ud800\udf30\ud800\udf3a\ud800\udf30\ud800\udf39\ud800\udf33\ud800\udf49\ud800\udf3d\ud800\udf3e\ud800\udf30"
     ],
-    "name:grn_x_preferred":[
+    "name:grn_x_historical":[
         "Yvate Masendo\u00f1a"
     ],
-    "name:gsw_x_preferred":[
+    "name:gsw_x_historical":[
         "Republik Mazedonie"
     ],
-    "name:guj_x_preferred":[
+    "name:guj_x_historical":[
         "\u0aae\u0ac7\u0ab8\u0ac7\u0aa1\u0acb\u0aa8\u0abf\u0aaf\u0abe"
     ],
-    "name:hak_x_preferred":[
+    "name:hak_x_historical":[
         "Pet Macedonia"
     ],
-    "name:hau_x_preferred":[
+    "name:hau_x_historical":[
         "Masedoniya"
     ],
-    "name:hbs_x_preferred":[
-        "Masidonija"
-    ],
-    "name:hbs_x_variant":[
+    "name:hbs_x_historical":[
+        "Masidonija",
         "Republika Makedonija"
     ],
-    "name:heb_x_preferred":[
-        "\u05de\u05e7\u05d3\u05d5\u05e0\u05d9\u05d4 (\u05e4\u05d9\u05e8\u05d5\u05e9\u05d5\u05e0\u05d9\u05dd)"
-    ],
-    "name:heb_x_variant":[
+    "name:heb_x_historical":[
+        "\u05de\u05e7\u05d3\u05d5\u05e0\u05d9\u05d4 (\u05e4\u05d9\u05e8\u05d5\u05e9\u05d5\u05e0\u05d9\u05dd)",
         "\u05de\u05e7\u05d3\u05d5\u05e0\u05d9\u05d4",
         "\u05de\u05e7\u05d3\u05d5\u05e0\u05d9\u05d4 \u05d4\u05e6\u05e4\u05d5\u05e0\u05d9\u05ea"
     ],
-    "name:hin_x_preferred":[
-        "\u092e\u0948\u0938\u0947\u0921\u094b\u0928\u093f\u092f\u093e"
-    ],
-    "name:hin_x_variant":[
+    "name:hin_x_historical":[
+        "\u092e\u0948\u0938\u0947\u0921\u094b\u0928\u093f\u092f\u093e",
         "\u092e\u0948\u0938\u093f\u0921\u094b\u0928\u093f\u092f\u093e",
         "\u0909\u0924\u094d\u0924\u0930 \u092e\u0948\u0938\u093f\u0921\u094b\u0928\u093f\u092f\u093e"
     ],
-    "name:hrv_x_preferred":[
-        "Makedonija (razdvojba)"
-    ],
-    "name:hrv_x_variant":[
+    "name:hrv_x_historical":[
+        "Makedonija (razdvojba)",
         "Makedonija, Republika",
         "Republika Makedonija",
         "Makedonija",
         "Sjeverna Makedonija"
     ],
-    "name:hsb_x_preferred":[
-        "Makedonska"
-    ],
-    "name:hsb_x_variant":[
+    "name:hsb_x_historical":[
+        "Makedonska",
         "Sewjerna Makedonska"
     ],
-    "name:hun_x_preferred":[
+    "name:hun_x_historical":[
         "Maced\u00f3nia",
-        "Macedonia (egy\u00e9rtelm\u0171s\u00edt\u0151 lap)"
-    ],
-    "name:hun_x_variant":[
+        "Macedonia (egy\u00e9rtelm\u0171s\u00edt\u0151 lap)",
         "Maced\u00f3n K\u00f6zt\u00e1rsas\u00e1g",
         "Maced\u00f3nia, K\u00f6zt\u00e1rsas\u00e1g",
         "Maked\u00f3nia",
         "\u00c9szak-Maced\u00f3nia"
     ],
-    "name:hye_x_preferred":[
-        "\u0544\u0561\u056f\u0565\u0564\u0578\u0576\u056b\u0561 (\u0561\u0575\u056c \u056f\u056b\u0580\u0561\u057c\u0578\u0582\u0574\u0576\u0565\u0580)"
-    ],
-    "name:hye_x_variant":[
+    "name:hye_x_historical":[
+        "\u0544\u0561\u056f\u0565\u0564\u0578\u0576\u056b\u0561 (\u0561\u0575\u056c \u056f\u056b\u0580\u0561\u057c\u0578\u0582\u0574\u0576\u0565\u0580)",
         "\u0544\u0561\u056f\u0565\u0564\u0578\u0576\u056b\u0561",
         "\u0540\u0575\u0578\u0582\u057d\u056b\u057d\u0561\u0575\u056b\u0576 \u0544\u0561\u056f\u0565\u0564\u0578\u0576\u056b\u0561"
     ],
-    "name:ibo_x_preferred":[
+    "name:ibo_x_historical":[
         "Macedonia"
     ],
-    "name:ido_x_preferred":[
-        "Republiko Macedonia"
-    ],
-    "name:ido_x_variant":[
+    "name:ido_x_historical":[
+        "Republiko Macedonia",
         "Republiko Norda-Macedonia"
     ],
-    "name:ile_x_preferred":[
+    "name:ile_x_historical":[
         "Macedonia"
     ],
-    "name:ina_x_preferred":[
-        "Macedonia (disambiguation)"
-    ],
-    "name:ina_x_variant":[
+    "name:ina_x_historical":[
+        "Macedonia (disambiguation)",
         "Macedonia"
     ],
-    "name:ind_x_preferred":[
-        "Macedonia"
-    ],
-    "name:ind_x_variant":[
+    "name:ind_x_historical":[
+        "Macedonia",
         "Republik Makedonia",
         "Makedonia"
     ],
-    "name:isl_x_preferred":[
-        "Maked\u00f3n\u00eda"
-    ],
-    "name:isl_x_variant":[
+    "name:isl_x_historical":[
+        "Maked\u00f3n\u00eda",
         "L\u00fd\u00f0veldi\u00f0 Maked\u00f3n\u00eda",
         "Nor\u00f0ur-Maked\u00f3n\u00eda"
     ],
-    "name:ita_x_preferred":[
+    "name:ita_x_historical":[
         "Repubblica di Macedonia",
-        "Macedonia"
-    ],
-    "name:ita_x_variant":[
+        "Macedonia",
         "Macedonia, Ex Repubblica Jugoslava",
         "Macedonia, Repubblica",
         "Ex Repubblica Jugoslava di Macedonia"
     ],
-    "name:jam_x_preferred":[
-        "Ripoblik a Masiduonia"
-    ],
-    "name:jam_x_variant":[
+    "name:jam_x_historical":[
+        "Ripoblik a Masiduonia",
         "Masiduonia"
     ],
-    "name:jav_x_preferred":[
+    "name:jav_x_historical":[
         "R\u00e9publik Makedonia"
     ],
-    "name:jpn_x_preferred":[
+    "name:jpn_x_historical":[
         "\u30de\u30b1\u30c9\u30cb\u30a2",
-        "\u30de\u30b1\u30c9\u30cb\u30a2 (\u66d6\u6627\u3055\u56de\u907f)"
-    ],
-    "name:jpn_x_variant":[
+        "\u30de\u30b1\u30c9\u30cb\u30a2 (\u66d6\u6627\u3055\u56de\u907f)",
         "\u30de\u30b1\u30c9\u30cb\u30a2\u5171\u548c\u56fd",
         "\u30de\u30b1\u30c9\u30cb\u30a2\u65e7\u30e6\u30fc\u30b4\u30b9\u30e9\u30d3\u30a2\u5171\u548c\u56fd",
         "\u5317\u30de\u30b1\u30c9\u30cb\u30a2"
     ],
-    "name:kaa_x_preferred":[
+    "name:kaa_x_historical":[
         "Makedoniya"
     ],
-    "name:kal_x_preferred":[
+    "name:kal_x_historical":[
         "Makedonia"
     ],
-    "name:kan_x_preferred":[
-        "\u0cae\u0ccd\u0caf\u0cbe\u0cb8\u0cbf\u0ca1\u0ccb\u0ca8\u0cbf\u0caf\u0cbe"
-    ],
-    "name:kan_x_variant":[
+    "name:kan_x_historical":[
+        "\u0cae\u0ccd\u0caf\u0cbe\u0cb8\u0cbf\u0ca1\u0ccb\u0ca8\u0cbf\u0caf\u0cbe",
         "\u0cae\u0ccd\u0caf\u0cbe\u0cb8\u0cc6\u0ca1\u0cca\u0ca8\u0cbf\u0caf \u0c97\u0ca3\u0cb0\u0cbe\u0c9c\u0ccd\u0caf"
     ],
-    "name:kat_x_preferred":[
-        "\u10db\u10d0\u10d9\u10d4\u10d3\u10dd\u10dc\u10d8\u10d0 (\u10db\u10e0\u10d0\u10d5\u10d0\u10da\u10db\u10dc\u10d8\u10e8\u10d5\u10dc\u10d4\u10da\u10dd\u10d5\u10d0\u10dc\u10d8)"
-    ],
-    "name:kat_x_variant":[
+    "name:kat_x_historical":[
+        "\u10db\u10d0\u10d9\u10d4\u10d3\u10dd\u10dc\u10d8\u10d0 (\u10db\u10e0\u10d0\u10d5\u10d0\u10da\u10db\u10dc\u10d8\u10e8\u10d5\u10dc\u10d4\u10da\u10dd\u10d5\u10d0\u10dc\u10d8)",
         "\u10db\u10d0\u10d9\u10d4\u10d3\u10dd\u10dc\u10d8\u10d0",
         "\u10e9\u10e0\u10d3\u10d8\u10da\u10dd\u10d4\u10d7\u10d8 \u10db\u10d0\u10d9\u10d4\u10d3\u10dd\u10dc\u10d8\u10d0"
     ],
-    "name:kaz_x_preferred":[
+    "name:kaz_x_historical":[
         "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430\u0441\u044b"
     ],
-    "name:kbd_x_preferred":[
+    "name:kbd_x_historical":[
         "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u044d \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044d"
     ],
-    "name:khm_x_preferred":[
-        "\u1798\u17c9\u17b6\u179f\u17c1\u178a\u1793"
-    ],
-    "name:khm_x_variant":[
+    "name:khm_x_historical":[
+        "\u1798\u17c9\u17b6\u179f\u17c1\u178a\u1793",
         "\u1798\u17c9\u17b6\u179f\u17c1\u178a\u17bc\u1793\u17b6\u1781\u17b6\u1784\u178f\u17d2\u1794\u17bc\u1784"
     ],
-    "name:kik_x_preferred":[
+    "name:kik_x_historical":[
         "Masedonia"
     ],
-    "name:kin_x_preferred":[
+    "name:kin_x_historical":[
         "Masedoniya"
     ],
-    "name:kir_x_preferred":[
+    "name:kir_x_historical":[
         "\u0422\u04af\u043d\u0434\u04af\u043a \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f"
     ],
-    "name:koi_x_preferred":[
+    "name:koi_x_historical":[
         "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f"
     ],
-    "name:kom_x_preferred":[
+    "name:kom_x_historical":[
         "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430"
     ],
-    "name:kon_x_preferred":[
+    "name:kon_x_historical":[
         "Makedonia"
     ],
-    "name:kor_x_preferred":[
+    "name:kor_x_historical":[
         "\ub9c8\ucf00\ub3c4\ub2c8\uc544 \uacf5\ud654\uad6d",
-        "\ub9c8\ucf00\ub3c4\ub2c8\uc544"
-    ],
-    "name:kor_x_variant":[
+        "\ub9c8\ucf00\ub3c4\ub2c8\uc544",
         "\ub9c8\ucf00\ub3c4\ub2c8\uc544\uc5b4",
         "\uc804 \uc720\uace0\uc2ac\ub77c\ube44\uc544 \ub9c8\ucf00\ub3c4\ub2c8\uc544",
         "\ubd81\ub9c8\ucf00\ub3c4\ub2c8\uc544"
     ],
-    "name:krc_x_preferred":[
+    "name:krc_x_historical":[
         "\u0428\u0438\u043c\u0430\u043b \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f"
     ],
-    "name:kur_x_preferred":[
-        "Komara Makedonyay\u00ea"
-    ],
-    "name:kur_x_variant":[
+    "name:kur_x_historical":[
+        "Komara Makedonyay\u00ea",
         "Makedonyaya Bakur"
     ],
-    "name:lad_x_preferred":[
+    "name:lad_x_historical":[
         "Makedonia"
     ],
-    "name:lao_x_preferred":[
-        "\u0ec1\u0ea1\u0e8a\u0eb4\u0ec2\u0e84\u0ec0\u0e99\u0e8d"
-    ],
-    "name:lao_x_variant":[
+    "name:lao_x_historical":[
+        "\u0ec1\u0ea1\u0e8a\u0eb4\u0ec2\u0e84\u0ec0\u0e99\u0e8d",
         "\u0ea1\u0eb2\u0e8a\u0eb4\u0ec2\u0e94\u0ec0\u0e99\u0e8d\u0ec0\u0edc\u0eb7\u0ead"
     ],
-    "name:lat_x_preferred":[
-        "Macedonia"
-    ],
-    "name:lat_x_variant":[
+    "name:lat_x_historical":[
+        "Macedonia",
         "Res publica Macedonica"
     ],
-    "name:lav_x_preferred":[
-        "Ma\u0137edonija"
-    ],
-    "name:lav_x_variant":[
+    "name:lav_x_historical":[
+        "Ma\u0137edonija",
         "Ma\u0137edonijas Republika",
         "Zieme\u013cma\u0137edonija"
     ],
-    "name:lfn_x_preferred":[
+    "name:lfn_x_historical":[
         "Macedonia"
     ],
-    "name:lim_x_preferred":[
-        "Macedoni\u00eb"
-    ],
-    "name:lim_x_variant":[
+    "name:lim_x_historical":[
+        "Macedoni\u00eb",
         "Noord-Macedoni\u00eb"
     ],
-    "name:lin_x_preferred":[
+    "name:lin_x_historical":[
         "Masedwan\u025b"
     ],
-    "name:lit_x_preferred":[
-        "Makedonija"
-    ],
-    "name:lit_x_variant":[
+    "name:lit_x_historical":[
+        "Makedonija",
         "\u0160iaur\u0117s Makedonija"
     ],
-    "name:lmo_x_preferred":[
+    "name:lmo_x_historical":[
         "Macedonia"
     ],
-    "name:ltg_x_preferred":[
+    "name:ltg_x_historical":[
         "Makedonejis Republika"
     ],
-    "name:ltz_x_preferred":[
+    "name:ltz_x_historical":[
         "Nordmazedonien"
     ],
-    "name:lub_x_preferred":[
+    "name:lub_x_historical":[
         "Masedwane"
     ],
-    "name:lug_x_preferred":[
+    "name:lug_x_historical":[
         "Masedoniya"
     ],
-    "name:lzh_x_preferred":[
+    "name:lzh_x_historical":[
         "\u5317\u99ac\u5176\u9813"
     ],
-    "name:mai_x_preferred":[
+    "name:mai_x_historical":[
         "\u092e\u094d\u092f\u093e\u0938\u0947\u0921\u094b\u0928\u093f\u092f\u093e"
     ],
-    "name:mal_x_preferred":[
-        "\u0d2e\u0d3e\u0d38\u0d3f\u0d21\u0d4b\u0d23\u0d3f\u0d2f"
-    ],
-    "name:mal_x_variant":[
+    "name:mal_x_historical":[
+        "\u0d2e\u0d3e\u0d38\u0d3f\u0d21\u0d4b\u0d23\u0d3f\u0d2f",
         "\u0d28\u0d4b\u0d7c\u0d24\u0d4d\u0d24\u0d4d \u0d2e\u0d3e\u0d38\u0d3f\u0d21\u0d4b\u0d23\u0d3f\u0d2f"
     ],
-    "name:mar_x_preferred":[
-        "\u092e\u0945\u0938\u0947\u0921\u094b\u0928\u093f\u092f\u093e"
-    ],
-    "name:mar_x_variant":[
+    "name:mar_x_historical":[
+        "\u092e\u0945\u0938\u0947\u0921\u094b\u0928\u093f\u092f\u093e",
         "\u0909\u0924\u094d\u0924\u0930 \u092e\u0945\u0938\u093f\u0921\u094b\u0928\u093f\u092f\u093e"
     ],
-    "name:mdf_x_preferred":[
+    "name:mdf_x_historical":[
         "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u0435"
     ],
-    "name:mhr_x_preferred":[
+    "name:mhr_x_historical":[
         "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u0439"
     ],
-    "name:mkd_x_preferred":[
-        "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u0458\u0430 (\u043f\u043e\u0458\u0430\u0441\u043d\u0443\u0432\u0430\u045a\u0435)"
-    ],
-    "name:mkd_x_variant":[
+    "name:mkd_x_historical":[
+        "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u0458\u0430 (\u043f\u043e\u0458\u0430\u0441\u043d\u0443\u0432\u0430\u045a\u0435)",
         "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u0458\u0430",
         "\u0420\u0435\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u0458\u0430"
     ],
-    "name:mlg_x_preferred":[
-        "Makedonia"
-    ],
-    "name:mlg_x_variant":[
+    "name:mlg_x_historical":[
+        "Makedonia",
         "Masedonia"
     ],
-    "name:mlt_x_preferred":[
+    "name:mlt_x_historical":[
         "Ma\u010bedonja"
     ],
-    "name:mon_x_preferred":[
+    "name:mon_x_historical":[
         "\u0423\u043c\u0430\u0440\u0434 \u041c\u0430\u043a\u0435\u0434\u043e\u043d"
     ],
-    "name:mri_x_preferred":[
+    "name:mri_x_historical":[
         "Maker\u014dnia"
     ],
-    "name:msa_x_preferred":[
-        "Macedonia"
-    ],
-    "name:msa_x_variant":[
+    "name:msa_x_historical":[
+        "Macedonia",
         "Republik Macedonia"
     ],
-    "name:mwl_x_preferred":[
+    "name:mwl_x_historical":[
         "Maced\u00f3nia"
     ],
-    "name:mya_x_preferred":[
-        "\u1019\u102c\u1005\u102e\u1012\u102d\u102f\u1038\u1014\u102e\u1038\u101a\u102c\u1038"
-    ],
-    "name:mya_x_variant":[
+    "name:mya_x_historical":[
+        "\u1019\u102c\u1005\u102e\u1012\u102d\u102f\u1038\u1014\u102e\u1038\u101a\u102c\u1038",
         "\u1019\u1000\u103a\u1005\u102e\u1012\u102d\u102f\u1038\u1014\u102e\u1038\u101a\u102c\u1038\u1014\u102d\u102f\u1004\u103a\u1004\u1036"
     ],
-    "name:myv_x_preferred":[
+    "name:myv_x_historical":[
         "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f \u041c\u0430\u0441\u0442\u043e\u0440"
     ],
-    "name:mzn_x_preferred":[
+    "name:mzn_x_historical":[
         "\u0645\u0642\u062f\u0648\u0646\u06cc\u0647"
     ],
-    "name:nah_x_preferred":[
+    "name:nah_x_historical":[
         "Tl\u0101catlahtohc\u0101y\u014dtl Macedonia"
     ],
-    "name:nan_x_preferred":[
+    "name:nan_x_historical":[
         "Pak Macedonia"
     ],
-    "name:nau_x_preferred":[
-        "Macedonia"
-    ],
-    "name:nau_x_variant":[
+    "name:nau_x_historical":[
+        "Macedonia",
         "Matedoniya"
     ],
-    "name:nde_x_preferred":[
+    "name:nde_x_historical":[
         "Macedonia"
     ],
-    "name:nds_nld_x_preferred":[
+    "name:nds_nld_x_historical":[
         "Massedoni\u00eb"
     ],
-    "name:nds_x_preferred":[
-        "Makedonien"
-    ],
-    "name:nds_x_variant":[
+    "name:nds_x_historical":[
+        "Makedonien",
         "Republiek Makedonien",
         "Noordmakedonien"
     ],
-    "name:nep_x_preferred":[
-        "\u092e\u094d\u092f\u093e\u0938\u0947\u0921\u094b\u0928\u093f\u092f\u093e"
-    ],
-    "name:nep_x_variant":[
+    "name:nep_x_historical":[
+        "\u092e\u094d\u092f\u093e\u0938\u0947\u0921\u094b\u0928\u093f\u092f\u093e",
         "\u092e\u094d\u092f\u093e\u0915\u0947\u0921\u094b\u0928\u093f\u092f\u093e"
     ],
-    "name:new_x_preferred":[
+    "name:new_x_historical":[
         "\u092e\u094d\u092f\u093e\u0938\u0947\u0921\u094b\u0928\u093f\u092f\u093e"
     ],
     "name:nld_x_colloquial":[
         "Macedonie"
     ],
-    "name:nld_x_preferred":[
-        "Macedonia"
-    ],
-    "name:nld_x_variant":[
+    "name:nld_x_historical":[
+        "Macedonia",
         "Voormalige Joegoslavische Republiek Macedoni\u00eb",
         "Macedoni\u00eb, Republiek",
         "Macedoni\u00eb",
         "Noord-Macedoni\u00eb"
     ],
-    "name:nno_x_preferred":[
-        "Makedonia"
-    ],
-    "name:nno_x_variant":[
+    "name:nno_x_historical":[
+        "Makedonia",
         "Republikken Makedonia",
         "Nord-Makedonia"
     ],
-    "name:nob_x_preferred":[
-        "Makedonia"
-    ],
-    "name:nob_x_variant":[
+    "name:nob_x_historical":[
+        "Makedonia",
         "Nord-Makedonia"
     ],
-    "name:nor_x_preferred":[
-        "Republikken Makedonia"
-    ],
-    "name:nor_x_variant":[
+    "name:nor_x_historical":[
+        "Republikken Makedonia",
         "Makedonia"
     ],
-    "name:oci_x_preferred":[
-        "Maced\u00f2nia"
-    ],
-    "name:oci_x_variant":[
+    "name:oci_x_historical":[
+        "Maced\u00f2nia",
         "Republica de Maced\u00f2nia"
     ],
-    "name:olo_x_preferred":[
+    "name:olo_x_historical":[
         "Makedounii"
     ],
-    "name:ori_x_preferred":[
-        "\u0b2e\u0b3e\u0b38\u0b47\u0b21\u0b4b\u0b28\u0b3f\u0b06"
-    ],
-    "name:ori_x_variant":[
+    "name:ori_x_historical":[
+        "\u0b2e\u0b3e\u0b38\u0b47\u0b21\u0b4b\u0b28\u0b3f\u0b06",
         "\u0b2e\u0b3e\u0b38\u0b3f\u0b21\u0b4b\u0b28\u0b3f\u0b06"
     ],
-    "name:orm_x_preferred":[
+    "name:orm_x_historical":[
         "Maqedooniyaa"
     ],
-    "name:oss_x_preferred":[
+    "name:oss_x_historical":[
         "\u0426\u00e6\u0433\u0430\u0442 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438"
     ],
-    "name:pag_x_preferred":[
+    "name:pag_x_historical":[
         "Masedoniya"
     ],
-    "name:pam_x_preferred":[
+    "name:pam_x_historical":[
         "Republika ning Makedonia"
     ],
-    "name:pap_x_preferred":[
+    "name:pap_x_historical":[
         "Nort Macedonia"
     ],
-    "name:pcd_x_preferred":[
+    "name:pcd_x_historical":[
         "Mach\u00e9do\u00e8ne"
     ],
-    "name:pli_x_preferred":[
+    "name:pli_x_historical":[
         "\u092e\u0947\u0938\u0947\u0921\u094b\u0928\u093f\u092f\u093e"
     ],
-    "name:pms_x_preferred":[
+    "name:pms_x_historical":[
         "Maced\u00f2nia"
     ],
-    "name:pnb_x_preferred":[
+    "name:pnb_x_historical":[
         "\u0645\u0642\u062f\u0648\u0646\u06cc\u06c1"
     ],
-    "name:pnt_x_preferred":[
+    "name:pnt_x_historical":[
         "\u0392\u03cc\u03c1\u03b5\u03b9\u03b1 \u039c\u03b1\u03ba\u03b5\u03b4\u03bf\u03bd\u03af\u03b1"
     ],
-    "name:pol_x_preferred":[
-        "Macedonia (ujednoznacznienie)"
-    ],
-    "name:pol_x_variant":[
+    "name:pol_x_historical":[
+        "Macedonia (ujednoznacznienie)",
         "Macedonia, Republika",
         "Macedonia",
         "By\u0142a Jugos\u0142owia\u0144ska Republika Macedonii",
@@ -832,249 +686,203 @@
     "name:por_x_colloquial":[
         "Antiga Republica jugoslava da Macedonia"
     ],
-    "name:por_x_preferred":[
+    "name:por_x_historical":[
         "Rep\u00fablica da Maced\u00f3nia",
-        "Maced\u00f3nia"
-    ],
-    "name:por_x_variant":[
+        "Maced\u00f3nia",
         "Antiga Rep\u00fablica jugoslava da Maced\u00f3nia",
         "Maced\u00f4nia, Rep\u00fablica da",
         "Maced\u00f4nia"
     ],
-    "name:pus_x_preferred":[
+    "name:pus_x_historical":[
         "\u062f \u0645\u0642\u062f\u0648\u0646\u064a\u06d0 \u0648\u0644\u0633\u0645\u0634\u0631\u064a\u0632\u0647"
     ],
-    "name:que_x_preferred":[
-        "Makiduniya"
-    ],
-    "name:que_x_variant":[
+    "name:que_x_historical":[
+        "Makiduniya",
         "Chinchay Masitunya"
     ],
-    "name:rmy_x_preferred":[
+    "name:rmy_x_historical":[
         "Republika Makedoniya"
     ],
-    "name:roh_x_preferred":[
+    "name:roh_x_historical":[
         "Macedonia"
     ],
-    "name:ron_x_preferred":[
-        "Macedonia"
-    ],
-    "name:ron_x_variant":[
+    "name:ron_x_historical":[
+        "Macedonia",
         "Republica Macedonia",
         "Fosta Republic\u0103 Iugoslav\u0103 Macedonia"
     ],
-    "name:rue_x_preferred":[
-        "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0456\u044f"
-    ],
-    "name:rue_x_variant":[
+    "name:rue_x_historical":[
+        "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0456\u044f",
         "\u0421\u0463\u0432\u0435\u0440\u043d\u0430 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0456\u044f"
     ],
-    "name:rum_x_variant":[
+    "name:rum_x_historical":[
         "Fosta Republic\u0103 Iugoslav\u0103 Macedonia"
     ],
-    "name:run_x_preferred":[
+    "name:run_x_historical":[
         "Masedoniya"
     ],
-    "name:rup_x_preferred":[
+    "name:rup_x_historical":[
         "Republica Machedonia"
     ],
-    "name:rus_x_preferred":[
-        "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f"
-    ],
-    "name:rus_x_variant":[
+    "name:rus_x_historical":[
+        "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f",
         "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f",
         "\u0421\u0435\u0432\u0435\u0440\u043d\u0430\u044f \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f"
     ],
-    "name:sag_x_preferred":[
+    "name:sag_x_historical":[
         "Masedu\u00e4ni"
     ],
-    "name:sah_x_preferred":[
+    "name:sah_x_historical":[
         "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430\u0442\u0430"
     ],
-    "name:san_x_preferred":[
+    "name:san_x_historical":[
         "\u092e\u0947\u0938\u0947\u0921\u094b\u0928\u093f\u092f\u093e"
     ],
-    "name:sat_x_preferred":[
+    "name:sat_x_historical":[
         "\u1c62\u1c5f\u1c65\u1c64\u1c70\u1c5a\u1c71\u1c64\u1c6d\u1c5f"
     ],
-    "name:scn_x_preferred":[
-        "Macedonia"
-    ],
-    "name:scn_x_variant":[
+    "name:scn_x_historical":[
+        "Macedonia",
         "Macidonia",
         "Rip\u00f9bblica di Macidonia"
     ],
-    "name:sco_x_preferred":[
-        "Macedonie"
-    ],
-    "name:sco_x_variant":[
+    "name:sco_x_historical":[
+        "Macedonie",
         "North Macedonie"
     ],
-    "name:sgs_x_preferred":[
+    "name:sgs_x_historical":[
         "Makeduon\u0117j\u0117"
     ],
-    "name:sin_x_preferred":[
+    "name:sin_x_historical":[
         "\u0d8b\u0dad\u0dd4\u0dbb\u0dd4 \u0db8\u0dd0\u0dc3\u0dd2\u0da9\u0ddd\u0db1\u0dd2\u0dba\u0dcf\u0dc0"
     ],
-    "name:slk_x_preferred":[
-        "Maced\u00f3nsko, republika"
-    ],
-    "name:slk_x_variant":[
+    "name:slk_x_historical":[
+        "Maced\u00f3nsko, republika",
         "Maced\u00f3nsko",
         "Severn\u00e9 Maced\u00f3nsko"
     ],
-    "name:slv_x_preferred":[
-        "Republika Makedonija"
-    ],
-    "name:slv_x_variant":[
+    "name:slv_x_historical":[
+        "Republika Makedonija",
         "Makedonija",
         "Severna Makedonija"
     ],
-    "name:sme_x_preferred":[
-        "D\u00e1ssev\u00e1ldi Makedonia"
-    ],
-    "name:sme_x_variant":[
+    "name:sme_x_historical":[
+        "D\u00e1ssev\u00e1ldi Makedonia",
         "Makedonia",
         "Davvi-Makedonia"
     ],
-    "name:sna_x_preferred":[
+    "name:sna_x_historical":[
         "Macedonia"
     ],
-    "name:som_x_preferred":[
+    "name:som_x_historical":[
         "Makadooniya"
     ],
     "name:spa_x_colloquial":[
         "Antigua Republica Yugoslava de Macedonia",
         "Ex Republica Yugoslava de Macedonia"
     ],
-    "name:spa_x_preferred":[
+    "name:spa_x_historical":[
         "Rep\u00fablica de Macedonia",
-        "Macedonia"
-    ],
-    "name:spa_x_variant":[
+        "Macedonia",
         "Antigua Rep\u00fablica Yugoslava de Macedonia",
         "Ex Rep\u00fablica Yugoslava de Macedonia",
         "Macedonia, Antigua Rep\u00fablica Yugoslava"
     ],
-    "name:sqi_x_preferred":[
-        "Maqedonia (kthjellim)"
-    ],
-    "name:sqi_x_variant":[
+    "name:sqi_x_historical":[
+        "Maqedonia (kthjellim)",
         "Maqedoni",
         "Republika e Maqedonis\u00eb"
     ],
-    "name:srd_x_preferred":[
+    "name:srd_x_historical":[
         "Matzed\u00f2nia"
     ],
-    "name:srn_x_preferred":[
+    "name:srn_x_historical":[
         "Masedoniyakondre"
     ],
-    "name:srp_x_preferred":[
-        "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u0458\u0430 (\u0432\u0438\u0448\u0435\u0437\u043d\u0430\u0447\u043d\u0430 \u043e\u0434\u0440\u0435\u0434\u043d\u0438\u0446\u0430)"
-    ],
-    "name:srp_x_variant":[
+    "name:srp_x_historical":[
+        "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u0458\u0430 (\u0432\u0438\u0448\u0435\u0437\u043d\u0430\u0447\u043d\u0430 \u043e\u0434\u0440\u0435\u0434\u043d\u0438\u0446\u0430)",
         "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u0458\u0430",
         "\u0420\u0435\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u0458\u0430",
         "\u0421\u0435\u0432\u0435\u0440\u043d\u0430 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u0458\u0430"
     ],
-    "name:ssw_x_preferred":[
+    "name:ssw_x_historical":[
         "IMakhedoniya"
     ],
-    "name:stq_x_preferred":[
+    "name:stq_x_historical":[
         "Makedonien"
     ],
-    "name:sun_x_preferred":[
+    "name:sun_x_historical":[
         "Mak\u00e9donia Kal\u00e9r"
     ],
-    "name:swa_x_preferred":[
-        "Jamhuri ya Masedonia"
-    ],
-    "name:swa_x_variant":[
+    "name:swa_x_historical":[
+        "Jamhuri ya Masedonia",
         "Masedonia"
     ],
-    "name:swe_x_preferred":[
+    "name:swe_x_historical":[
         "Makedonien",
-        "Macedonia (olika betydelser)"
-    ],
-    "name:swe_x_variant":[
+        "Macedonia (olika betydelser)",
         "F.d. jugoslaviska republiken Makedonien",
         "FYROM",
         "Nordmakedonien"
     ],
-    "name:szl_x_preferred":[
+    "name:szl_x_historical":[
         "P\u016f\u0142nocno Maced\u016f\u0144ijo"
     ],
-    "name:tam_x_preferred":[
-        "\u0bae\u0bbe\u0b9a\u0bbf\u0b9f\u0bcb\u0ba9\u0bbf\u0baf\u0bbe"
-    ],
-    "name:tam_x_variant":[
+    "name:tam_x_historical":[
+        "\u0bae\u0bbe\u0b9a\u0bbf\u0b9f\u0bcb\u0ba9\u0bbf\u0baf\u0bbe",
         "\u0bb5\u0b9f\u0b95\u0bcd\u0b95\u0bc1 \u0bae\u0bbe\u0b95\u0bcd\u0b95\u0b9f\u0bcb\u0ba9\u0bbf\u0baf\u0bbe"
     ],
-    "name:tat_x_preferred":[
+    "name:tat_x_historical":[
         "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f \u0496\u04e9\u043c\u04bb\u04af\u0440\u0438\u044f\u0442\u0435"
     ],
-    "name:tel_x_preferred":[
-        "\u0c2e\u0c47\u0c38\u0c46\u0c21\u0c4b\u0c28\u0c3f\u0c2f\u0c3e"
-    ],
-    "name:tel_x_variant":[
+    "name:tel_x_historical":[
+        "\u0c2e\u0c47\u0c38\u0c46\u0c21\u0c4b\u0c28\u0c3f\u0c2f\u0c3e",
         "\u0c09\u0c24\u0c4d\u0c24\u0c30 \u0c2e\u0c46\u0c38\u0c3f\u0c21\u0c4b\u0c28\u0c3f\u0c2f\u0c3e"
     ],
-    "name:tet_x_preferred":[
-        "Mased\u00f3nia"
-    ],
-    "name:tet_x_variant":[
+    "name:tet_x_historical":[
+        "Mased\u00f3nia",
         "Mased\u00f3nia Norte"
     ],
-    "name:tgk_x_preferred":[
-        "\u04b6\u0443\u043c\u04b3\u0443\u0440\u0438\u0438 \u041c\u0430\u049b\u0434\u0443\u043d\u0438\u044f"
-    ],
-    "name:tgk_x_variant":[
+    "name:tgk_x_historical":[
+        "\u04b6\u0443\u043c\u04b3\u0443\u0440\u0438\u0438 \u041c\u0430\u049b\u0434\u0443\u043d\u0438\u044f",
         "\u041c\u0430\u049b\u0434\u0443\u043d\u0438\u044f\u0438 \u0428\u0438\u043c\u043e\u043b\u04e3"
     ],
-    "name:tgl_x_preferred":[
-        "Republika ng Macedonia"
-    ],
-    "name:tgl_x_variant":[
+    "name:tgl_x_historical":[
+        "Republika ng Macedonia",
         "Hilagang Macedonia"
     ],
-    "name:tha_x_preferred":[
-        "\u0e21\u0e32\u0e0b\u0e34\u0e42\u0e14\u0e40\u0e19\u0e35\u0e22"
-    ],
-    "name:tha_x_variant":[
+    "name:tha_x_historical":[
+        "\u0e21\u0e32\u0e0b\u0e34\u0e42\u0e14\u0e40\u0e19\u0e35\u0e22",
         "\u0e1b\u0e23\u0e30\u0e40\u0e17\u0e28\u0e21\u0e32\u0e0b\u0e34\u0e42\u0e14\u0e40\u0e19\u0e35\u0e22",
         "\u0e1b\u0e23\u0e30\u0e40\u0e17\u0e28\u0e19\u0e2d\u0e23\u0e4c\u0e17\u0e21\u0e32\u0e0b\u0e34\u0e42\u0e14\u0e40\u0e19\u0e35\u0e22"
     ],
-    "name:tir_x_preferred":[
+    "name:tir_x_historical":[
         "\u121b\u12a8\u12f6\u1292\u12eb"
     ],
-    "name:ton_x_preferred":[
+    "name:ton_x_historical":[
         "Masit\u014dnia"
     ],
-    "name:tuk_x_preferred":[
+    "name:tuk_x_historical":[
         "Demirgazyk Makedoni\u00fda"
     ],
-    "name:tum_x_preferred":[
+    "name:tum_x_historical":[
         "Macedonia"
     ],
-    "name:tur_x_preferred":[
-        "Makedonya"
-    ],
-    "name:tur_x_variant":[
+    "name:tur_x_historical":[
+        "Makedonya",
         "Kuzey Makedonya"
     ],
-    "name:twi_x_preferred":[
+    "name:twi_x_historical":[
         "Masidonia"
     ],
-    "name:udm_x_preferred":[
+    "name:udm_x_historical":[
         "\u0423\u0439\u043f\u0430\u043b \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f"
     ],
-    "name:uig_x_preferred":[
+    "name:uig_x_historical":[
         "\u0645\u0627\u0643\u06d0\u062f\u0648\u0646\u0649\u064a\u06d5"
     ],
-    "name:ukr_x_preferred":[
-        "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0456\u044f"
-    ],
-    "name:ukr_x_variant":[
+    "name:ukr_x_historical":[
+        "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0456\u044f",
         "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0456\u043a\u0430 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0456\u044f",
         "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0456\u044f, \u043a\u043e\u043b\u0438\u0448\u043d\u044f \u042e\u0433\u043e\u0441\u043b\u0430\u0432\u0441\u044c\u043a\u0430 \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0456\u043a\u0430",
         "\u041f\u0456\u0432\u043d\u0456\u0447\u043d\u0430 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0456\u044f"
@@ -1091,84 +899,74 @@
         "Pr\u00f3in Giougkoslavik\u00ed Dimokrat\u00eda tis Makedon\u00edas",
         "Peoples Republic of Macedonia"
     ],
-    "name:urd_x_preferred":[
-        "\u0645\u0642\u062f\u0648\u0646\u06cc\u06c1"
-    ],
-    "name:urd_x_variant":[
+    "name:urd_x_historical":[
+        "\u0645\u0642\u062f\u0648\u0646\u06cc\u06c1",
         "\u0634\u0645\u0627\u0644\u06cc \u0645\u0642\u062f\u0648\u0646\u06cc\u06c1"
     ],
-    "name:uzb_x_preferred":[
+    "name:uzb_x_historical":[
         "Makedoniya"
     ],
-    "name:vec_x_preferred":[
+    "name:vec_x_historical":[
         "Macedonia"
     ],
-    "name:vep_x_preferred":[
+    "name:vep_x_historical":[
         "Pohjoi\u017emakedonii"
     ],
-    "name:vie_x_preferred":[
-        "Macedonia (\u0111\u1ecbnh h\u01b0\u1edbng)"
-    ],
-    "name:vie_x_variant":[
+    "name:vie_x_historical":[
+        "Macedonia (\u0111\u1ecbnh h\u01b0\u1edbng)",
         "Ma-x\u00ea-\u0111\u00f4-ni-a",
         "Ma-x\u00ea-\u0111\u00f4-ni-a (Macedonia)",
         "B\u1eafc Macedonia"
     ],
-    "name:vls_x_preferred":[
+    "name:vls_x_historical":[
         "Macedoni\u00eb"
     ],
-    "name:vol_x_preferred":[
-        "Macedonia"
-    ],
-    "name:vol_x_variant":[
+    "name:vol_x_historical":[
+        "Macedonia",
         "Makedon\u00e4n",
         "Makedoniy\u00e4n",
         "Nol\u00fcda-Makedoniy\u00e4n"
     ],
-    "name:vro_x_preferred":[
+    "name:vro_x_historical":[
         "Mak\u00f5doonia Vabariik"
     ],
-    "name:war_x_preferred":[
+    "name:war_x_historical":[
         "Republika han Macedonia"
     ],
-    "name:wol_x_preferred":[
+    "name:wol_x_historical":[
         "R\u00e9ewum Maseduwaan"
     ],
-    "name:wuu_x_preferred":[
+    "name:wuu_x_historical":[
         "\u9a6c\u5176\u987f"
     ],
-    "name:xal_x_preferred":[
+    "name:xal_x_historical":[
         "\u041c\u0430\u0441\u0438\u0434\u0438\u043d \u041e\u0440\u043d"
     ],
-    "name:xmf_x_preferred":[
+    "name:xmf_x_historical":[
         "\u10dd\u10dd\u10e0\u10e3\u10d4 \u10db\u10d0\u10d9\u10d4\u10d3\u10dd\u10dc\u10d8\u10d0"
     ],
-    "name:yor_x_preferred":[
+    "name:yor_x_historical":[
         "Or\u00edl\u1eb9\u0301\u00e8de Masidonia"
     ],
-    "name:yue_x_preferred":[
+    "name:yue_x_historical":[
         "\u5317\u99ac\u5176\u9813\u5171\u548c\u570b"
     ],
-    "name:zea_x_preferred":[
+    "name:zea_x_historical":[
         "Noord-Macedoni\u00eb"
     ],
-    "name:zha_x_preferred":[
+    "name:zha_x_historical":[
         "Baek Macedonia"
     ],
-    "name:zho_x_preferred":[
-        "\u99ac\u5176\u9813 (\u6d88\u6b67\u7fa9)"
-    ],
-    "name:zho_x_variant":[
+    "name:zho_x_historical":[
+        "\u99ac\u5176\u9813 (\u6d88\u6b67\u7fa9)",
         "\u99ac\u5176\u9813",
         "\u9a6c\u5176\u987f\u738b\u56fd",
         "\u99ac\u5176\u9813\u5171\u548c\u570b",
         "\u524d\u5357\u65af\u62c9\u592b\u9a6c\u5176\u987f\u5171\u548c\u56fd",
         "\u5317\u9a6c\u5176\u987f"
     ],
-    "name:zul_x_preferred":[
-        "I-Macedonia"
-    ],
-    "name:zul_x_variant":[
+    "name:zul_x_historical":[
+        "I-Macedonia",
         "IMakedoniya"
     ],
     "ne:abbrev":"Mkd.",
@@ -1317,8 +1115,8 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1614895068,
-    "wof:name":"Macedonia",
+    "wof:lastmodified":1631221520,
+    "wof:name":"North Macedonia",
     "wof:parent_id":102191581,
     "wof:placetype":"country",
     "wof:population":2062294,


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1653.

This PR:
- Moves most existing name values to `historical` properties
- Imports new preferred names from Wikidata
- Scrubs all name properties to remove any duplicates

No PIP work needed, can merge once approved.