### PR TITLE
Update Place North Macedonia

### DIFF
--- a/data/856/323/73/85632373.geojson
+++ b/data/856/323/73/85632373.geojson
@@ -921,6 +921,9 @@
     "name:por_x_colloquial":[
         "Antiga Republica jugoslava da Macedonia"
     ],
+    "name:por_x_preferred":[
+        "Maced\u00f3nia do Norte"
+    ],
     "name:pus_x_preferred":[
         "\u062f \u0645\u0642\u062f\u0648\u0646\u064a\u06d0 \u0648\u0644\u0633\u0645\u0634\u0631\u064a\u0632\u0647"
     ],
@@ -938,6 +941,9 @@
     ],
     "name:roh_x_preferred":[
         "Macedonia dal Nord"
+    ],
+    "name:ron_x_preferred":[
+        "Macedonia de Nord"
     ],
     "name:rue_x_historical":[
         "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0456\u044f"
@@ -1482,7 +1488,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1634067101,
+    "wof:lastmodified":1678302856,
     "wof:name":"North Macedonia",
     "wof:parent_id":102191581,
     "wof:placetype":"country",


### PR DESCRIPTION
This PR adds Romanian and Portuguese name translations to the North Macedonia country record.

**Number of records updated**: 1