### PR TITLE
mk concordances, placetype local, and more

### DIFF
--- a/data/856/323/73/85632373.geojson
+++ b/data/856/323/73/85632373.geojson
@@ -1531,6 +1531,7 @@
         "hasc:id":"MK",
         "icao:code":"Z3",
         "ioc:id":"MKD",
+        "iso:code":"MK",
         "itu:id":"MKD",
         "m49:code":"807",
         "marc:id":"xn",
@@ -1544,6 +1545,7 @@
         "wk:page":"Republic of Macedonia",
         "wmo:id":"MJ"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:country_alpha3":"MKD",
     "wof:geom_alt":[
@@ -1566,7 +1568,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1694492263,
+    "wof:lastmodified":1695881376,
     "wof:name":"North Macedonia",
     "wof:parent_id":102191581,
     "wof:placetype":"country",

--- a/data/856/741/47/85674147.geojson
+++ b/data/856/741/47/85674147.geojson
@@ -330,17 +330,19 @@
         "gn:id":786339,
         "gp:id":24550855,
         "hasc:id":"MK.RE",
+        "iso:code":"MK-66",
         "iso:id":"MK-66",
         "qs_pg:id":1193220,
         "unlc:id":"MK-66",
         "wd:id":"Q740591",
         "wk:page":"Resen Municipality"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"571e1bf65757af04f062758fd678801b",
+    "wof:geomhash":"3926a63deb22f5f665cbd58887b516cf",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -356,7 +358,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939438,
+    "wof:lastmodified":1695885332,
     "wof:name":"Resen",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/741/51/85674151.geojson
+++ b/data/856/741/51/85674151.geojson
@@ -267,17 +267,19 @@
         "gn:id":863911,
         "gp:id":24550867,
         "hasc:id":"MK.VV",
+        "iso:code":"MK-12",
         "iso:id":"MK-12",
         "qs_pg:id":999056,
         "unlc:id":"MK-12",
         "wd:id":"Q2029825",
         "wk:page":"Vev\u010dani Municipality"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"be3284cc928557f378a4d85d611ee059",
+    "wof:geomhash":"eac91c8d75dfeba426048ad57ce5f93a",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -293,7 +295,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939436,
+    "wof:lastmodified":1695885332,
     "wof:name":"Vev\u010dani",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/741/57/85674157.geojson
+++ b/data/856/741/57/85674157.geojson
@@ -326,17 +326,19 @@
         "gn:id":863486,
         "gp:id":24550747,
         "hasc:id":"MK.TL",
+        "iso:code":"MK-04",
         "iso:id":"MK-04",
         "qs_pg:id":892957,
         "unlc:id":"MK-04",
         "wd:id":"Q159380",
         "wk:page":"Bitola Municipality"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3b8e95780a9b118dc0fcfed95cd05b28",
+    "wof:geomhash":"b194d5971f6f35079e8688f88538c1d6",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -352,7 +354,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939436,
+    "wof:lastmodified":1695885332,
     "wof:name":"Bitola",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/741/61/85674161.geojson
+++ b/data/856/741/61/85674161.geojson
@@ -272,17 +272,19 @@
         "gn:id":863846,
         "gp:id":24550759,
         "hasc:id":"MK.DM",
+        "iso:code":"MK-25",
         "iso:id":"MK-25",
         "qs_pg:id":1322884,
         "unlc:id":"MK-25",
         "wd:id":"Q856278",
         "wk:page":"Demir Hisar Municipality"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f464fe4d67b72415d2a3b6eea355a35c",
+    "wof:geomhash":"65e3622900898890df35ca2481ff6acf",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -298,7 +300,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939435,
+    "wof:lastmodified":1695885332,
     "wof:name":"Demir Hisar",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/741/65/85674165.geojson
+++ b/data/856/741/65/85674165.geojson
@@ -329,17 +329,19 @@
         "gn:id":863883,
         "gp:id":24550834,
         "hasc:id":"MK.OD",
+        "iso:code":"MK-58",
         "iso:id":"MK-58",
         "qs_pg:id":1193221,
         "unlc:id":"MK-58",
         "wd:id":"Q1125333",
         "wk:page":"Ohrid Municipality"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"934f9f706c3214ed34079634aea8dc6d",
+    "wof:geomhash":"d2990e1d42e32559d4ea6459a1e813d9",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -355,7 +357,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939437,
+    "wof:lastmodified":1695885332,
     "wof:name":"Ohrid",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/741/69/85674169.geojson
+++ b/data/856/741/69/85674169.geojson
@@ -318,17 +318,19 @@
         "gn:id":7056271,
         "gp:id":24550746,
         "hasc:id":"MK.DA",
+        "iso:code":"MK-22",
         "iso:id":"MK-22",
         "qs_pg:id":1193161,
         "unlc:id":"MK-22",
         "wd:id":"Q1323340",
         "wk:page":"Debarca Municipality"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7357082ccccda8d600ce10aa1db99ea3",
+    "wof:geomhash":"f86af3d9497120fe530a56468fbbeb4a",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -344,7 +346,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939436,
+    "wof:lastmodified":1695885332,
     "wof:name":"Debarca",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/741/73/85674173.geojson
+++ b/data/856/741/73/85674173.geojson
@@ -253,16 +253,18 @@
         "gn:id":863886,
         "gp:id":24550796,
         "hasc:id":"MK.PE",
+        "iso:code":"MK-59",
         "iso:id":"MK-59",
         "qs_pg:id":503464,
         "unlc:id":"MK-59",
         "wd:id":"Q1018191"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"cc1367acd120dedf326b1f28d0290af4",
+    "wof:geomhash":"92d7569c39d0cd4b459fe59d470832b7",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -278,7 +280,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939436,
+    "wof:lastmodified":1695885332,
     "wof:name":"Skopje",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/741/79/85674179.geojson
+++ b/data/856/741/79/85674179.geojson
@@ -322,17 +322,19 @@
         "gn:id":863887,
         "gp:id":24550797,
         "hasc:id":"MK.PN",
+        "iso:code":"MK-61",
         "iso:id":"MK-61",
         "qs_pg:id":59739,
         "unlc:id":"MK-61",
         "wd:id":"Q2018921",
         "wk:page":"Plasnica Municipality"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ec10d2fe31f293dd62565808bf4a06a8",
+    "wof:geomhash":"803545af3f453336d7d39ad45ae4b2a3",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -348,7 +350,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939438,
+    "wof:lastmodified":1695885332,
     "wof:name":"Plasnica",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/741/83/85674183.geojson
+++ b/data/856/741/83/85674183.geojson
@@ -329,17 +329,19 @@
         "gn:id":863888,
         "gp:id":24550799,
         "hasc:id":"MK.PP",
+        "iso:code":"MK-62",
         "iso:id":"MK-62",
         "qs_pg:id":224022,
         "unlc:id":"MK-62",
         "wd:id":"Q6312454",
         "wk:page":"Prilep Municipality"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6ec491d6c43b9834821a2667d3309a9a",
+    "wof:geomhash":"5c6f02b47d018901c44505576c48fe1c",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -355,7 +357,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939438,
+    "wof:lastmodified":1695885332,
     "wof:name":"Prilep",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/741/87/85674187.geojson
+++ b/data/856/741/87/85674187.geojson
@@ -324,17 +324,19 @@
         "gn:id":863889,
         "gp:id":24550800,
         "hasc:id":"MK.PT",
+        "iso:code":"MK-63",
         "iso:id":"MK-63",
         "qs_pg:id":1103579,
         "unlc:id":"MK-63",
         "wd:id":"Q2270414",
         "wk:page":"Probi\u0161tip Municipality"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6fc085d0da3b57862305b01fea0f32c1",
+    "wof:geomhash":"75274e1245d48940b7e24cbbfe0101d2",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -350,7 +352,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939437,
+    "wof:lastmodified":1695885332,
     "wof:name":"Probistip",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/741/91/85674191.geojson
+++ b/data/856/741/91/85674191.geojson
@@ -318,16 +318,18 @@
         "gn:id":863890,
         "gp:id":24550865,
         "hasc:id":"MK.RV",
+        "iso:code":"MK-64",
         "iso:id":"MK-64",
         "qs_pg:id":1103591,
         "unlc:id":"MK-64",
         "wd:id":"Q2738284"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c8e399e74721a648525594606d2a893c",
+    "wof:geomhash":"5762d5bed81723cd2d342182d8848ef2",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -343,7 +345,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939437,
+    "wof:lastmodified":1695885333,
     "wof:name":"Radovis",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/741/97/85674197.geojson
+++ b/data/856/741/97/85674197.geojson
@@ -316,17 +316,19 @@
         "gn:id":863869,
         "gp:id":24550831,
         "hasc:id":"MK.KZ",
+        "iso:code":"MK-44",
         "iso:id":"MK-44",
         "qs_pg:id":241637,
         "unlc:id":"MK-44",
         "wd:id":"Q1422453",
         "wk:page":"Kriva Palanka Municipality"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"497b87d973e1950984e0d14598bb9647",
+    "wof:geomhash":"566dbf48d2540ce30cf10bee15316271",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -342,7 +344,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939438,
+    "wof:lastmodified":1695885333,
     "wof:name":"Kriva Palanka",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/742/01/85674201.geojson
+++ b/data/856/742/01/85674201.geojson
@@ -256,17 +256,19 @@
         "gn:id":862973,
         "gp:id":24550801,
         "hasc:id":"MK.RM",
+        "iso:code":"MK-67",
         "iso:id":"MK-67",
         "qs_pg:id":1103584,
         "unlc:id":"MK-67",
         "wd:id":"Q2088585",
         "wk:page":"Rosoman Municipality"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"12dadaaf3d1a0519569483661036c842",
+    "wof:geomhash":"4ae9360888df2866e1898d75bf72cc2c",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -282,7 +284,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939456,
+    "wof:lastmodified":1695885333,
     "wof:name":"Vardar",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/742/05/85674205.geojson
+++ b/data/856/742/05/85674205.geojson
@@ -273,16 +273,18 @@
         "gn:id":863894,
         "gp:id":24550803,
         "hasc:id":"MK.AJ",
+        "iso:code":"MK-68",
         "iso:id":"MK-68",
         "qs_pg:id":1191297,
         "unlc:id":"MK-68",
         "wd:id":"Q1309481"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"843ce9029b9fa3e8f06147915669aabf",
+    "wof:geomhash":"885ecb50a86757169a5febdfa1c6e0c1",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -298,7 +300,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939453,
+    "wof:lastmodified":1695885333,
     "wof:name":"Saraj",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/742/09/85674209.geojson
+++ b/data/856/742/09/85674209.geojson
@@ -319,17 +319,19 @@
         "gn:id":863896,
         "gp:id":24550804,
         "hasc:id":"MK.SS",
+        "iso:code":"MK-70",
         "iso:id":"MK-70",
         "qs_pg:id":1193168,
         "unlc:id":"MK-70",
         "wd:id":"Q2282240",
         "wk:page":"Sopi\u0161te Municipality"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9c61509e501270eada12a26a2b9433f9",
+    "wof:geomhash":"89b06a086bbfa45a8a7c0be85ea03f5c",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -345,7 +347,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939455,
+    "wof:lastmodified":1695885333,
     "wof:name":"Sopiste",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/742/15/85674215.geojson
+++ b/data/856/742/15/85674215.geojson
@@ -221,17 +221,19 @@
         "gn:id":863899,
         "gp:id":24550856,
         "hasc:id":"MK.NA",
+        "iso:code":"MK-71",
         "iso:id":"MK-71",
         "qs_pg:id":1103590,
         "unlc:id":"MK-71",
         "wd:id":"Q2128903",
         "wk:page":"Staro Nagori\u010dane Municipality"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0d65d133ef3dbe044faa208a7df3b9a1",
+    "wof:geomhash":"4d4919a6205133b6c5a32f79432a79e9",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -247,7 +249,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939458,
+    "wof:lastmodified":1695885333,
     "wof:name":"Northeastern",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/742/19/85674219.geojson
+++ b/data/856/742/19/85674219.geojson
@@ -319,16 +319,18 @@
         "gn:id":863900,
         "gp:id":24550807,
         "hasc:id":"MK.ST",
+        "iso:code":"MK-83",
         "iso:id":"MK-83",
         "qs_pg:id":1193176,
         "unlc:id":"MK-83",
         "wd:id":"Q2423082"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4faa3284bacbcee254c222f5e057a19d",
+    "wof:geomhash":"4dd3d125e3a5ba67b8e5773b1e2e2350",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -344,7 +346,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939455,
+    "wof:lastmodified":1695885333,
     "wof:name":"\u0160tip",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/742/23/85674223.geojson
+++ b/data/856/742/23/85674223.geojson
@@ -324,17 +324,19 @@
         "gn:id":863903,
         "gp:id":24550809,
         "hasc:id":"MK.SU",
+        "iso:code":"MK-74",
         "iso:id":"MK-74",
         "qs_pg:id":1193175,
         "unlc:id":"MK-74",
         "wd:id":"Q2088034",
         "wk:page":"Studeni\u010dani Municipality"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4e16939e18acc0468f46a9a3e3188f7c",
+    "wof:geomhash":"01fb50b760fa0caaed9318263e48cb35",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -350,7 +352,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939457,
+    "wof:lastmodified":1695885333,
     "wof:name":"Sveti Nikole",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/742/27/85674227.geojson
+++ b/data/856/742/27/85674227.geojson
@@ -250,16 +250,18 @@
         "gn:id":863836,
         "gp:id":24550752,
         "hasc:id":"MK.CI",
+        "iso:code":"MK-79",
         "iso:id":"MK-79",
         "qs_pg:id":1191262,
         "unlc:id":"MK-79",
         "wd:id":"Q1419314"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"64eda2483b6a85916ca8df90b783dd6e",
+    "wof:geomhash":"f24c419f00416692d5f3199deb55c726",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -275,7 +277,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939453,
+    "wof:lastmodified":1695885333,
     "wof:name":"Cair",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/742/29/85674229.geojson
+++ b/data/856/742/29/85674229.geojson
@@ -323,17 +323,19 @@
         "gn:id":863905,
         "gp:id":24550811,
         "hasc:id":"MK.SL",
+        "iso:code":"MK-69",
         "iso:id":"MK-69",
         "qs_pg:id":1103586,
         "unlc:id":"MK-69",
         "wd:id":"Q2308277",
         "wk:page":"Sveti Nikole Municipality"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9d660638741ac328ceb23384a6b7185d",
+    "wof:geomhash":"aef16a09cca95a474e231d634b675fa1",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -349,7 +351,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939453,
+    "wof:lastmodified":1695885333,
     "wof:name":"Sveti Nikole",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/742/37/85674237.geojson
+++ b/data/856/742/37/85674237.geojson
@@ -285,16 +285,18 @@
         "gn:id":863909,
         "gp:id":24550815,
         "hasc:id":"MK.VE",
+        "iso:code":"MK-13",
         "iso:id":"MK-13",
         "qs_pg:id":1193204,
         "unlc:id":"MK-13",
         "wd:id":"Q2088561"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"dbe510cd4871183c095ae292149bde34",
+    "wof:geomhash":"66c569cde4f3e6af124997410589ea6a",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -310,7 +312,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939456,
+    "wof:lastmodified":1695885333,
     "wof:name":"Veles",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/742/41/85674241.geojson
+++ b/data/856/742/41/85674241.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011778,
-    "geom:area_square_m":109076299.371113,
+    "geom:area_square_m":109076279.505583,
     "geom:bbox":"20.959921,41.421389,21.135947,41.584554",
     "geom:latitude":41.498886,
     "geom:longitude":21.047524,
@@ -292,17 +292,19 @@
         "gn:id":863913,
         "gp:id":24550818,
         "hasc:id":"MK.VC",
+        "iso:code":"MK-15",
         "iso:id":"MK-15",
         "qs_pg:id":59749,
         "unlc:id":"MK-15",
         "wd:id":"Q1998500",
         "wk:page":"Vrane\u0161tica Municipality"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"366197e2d8340f67f035b41d328e06d0",
+    "wof:geomhash":"f1851ecc6b176bcf8c500c14bd3060bf",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -318,7 +320,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939457,
+    "wof:lastmodified":1695884521,
     "wof:name":"Vrane\u0161tica",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/742/45/85674245.geojson
+++ b/data/856/742/45/85674245.geojson
@@ -317,17 +317,19 @@
         "gn:id":863918,
         "gp:id":24550820,
         "hasc:id":"MK.ZK",
+        "iso:code":"MK-32",
         "iso:id":"MK-32",
         "qs_pg:id":999054,
         "unlc:id":"MK-32",
         "wd:id":"Q9050283",
         "wk:page":"Zelenikovo Municipality"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"09d12824906e090e8767dde169ca6172",
+    "wof:geomhash":"e4b4f19c304f9d7ad0022c18b81d075c",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -343,7 +345,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939454,
+    "wof:lastmodified":1695885333,
     "wof:name":"Zelenikovo",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/742/51/85674251.geojson
+++ b/data/856/742/51/85674251.geojson
@@ -318,17 +318,19 @@
         "gn:id":863919,
         "gp:id":24550821,
         "hasc:id":"MK.ZE",
+        "iso:code":"MK-30",
         "iso:id":"MK-30",
         "qs_pg:id":1016988,
         "unlc:id":"MK-30",
         "wd:id":"Q1996410",
         "wk:page":"\u017delino Municipality"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a7f047fdc65c37525f367aefc60db7b0",
+    "wof:geomhash":"1f7a5dda6728c86bd099fbcff541ce8d",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -344,7 +346,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939452,
+    "wof:lastmodified":1695885333,
     "wof:name":"\u017delino",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/742/53/85674253.geojson
+++ b/data/856/742/53/85674253.geojson
@@ -324,17 +324,19 @@
         "gn:id":863831,
         "gp:id":24550745,
         "hasc:id":"MK.AR",
+        "iso:code":"MK-02",
         "iso:id":"MK-02",
         "qs_pg:id":886834,
         "unlc:id":"MK-02",
         "wd:id":"Q597345",
         "wk:page":"Ara\u010dinovo Municipality"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"80cfc4c4bbc814ee199f12f84404d7ae",
+    "wof:geomhash":"d26faad598a990c0b72f72e386f6f347",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -350,7 +352,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939456,
+    "wof:lastmodified":1695885333,
     "wof:name":"Aracinovo",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/742/57/85674257.geojson
+++ b/data/856/742/57/85674257.geojson
@@ -318,17 +318,19 @@
         "gn:id":863875,
         "gp:id":24550842,
         "hasc:id":"MK.LI",
+        "iso:code":"MK-48",
         "iso:id":"MK-48",
         "qs_pg:id":995469,
         "unlc:id":"MK-48",
         "wd:id":"Q2041236",
         "wk:page":"Lipkovo Municipality"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"dfd431669cfa926d511dc3a7c7520fc3",
+    "wof:geomhash":"f87f5c6d6d544534096e21759e431018",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -344,7 +346,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939452,
+    "wof:lastmodified":1695885333,
     "wof:name":"Lipkovo",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/742/61/85674261.geojson
+++ b/data/856/742/61/85674261.geojson
@@ -286,16 +286,18 @@
         "gn:id":7056269,
         "gp:id":55848399,
         "hasc:id":"MK.BU",
+        "iso:code":"MK-09",
         "iso:id":"MK-09",
         "qs_pg:id":46447,
         "unlc:id":"MK-09",
         "wd:id":"Q935620"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d5a474c57f9b59ff3f0e8f296b4d2c47",
+    "wof:geomhash":"ec2dcba2256abc9132b2b89447dbf7d1",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -311,7 +313,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939452,
+    "wof:lastmodified":1695885333,
     "wof:name":"Butel",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/742/65/85674265.geojson
+++ b/data/856/742/65/85674265.geojson
@@ -325,17 +325,19 @@
         "gn:id":863838,
         "gp:id":24550754,
         "hasc:id":"MK.CA",
+        "iso:code":"MK-80",
         "iso:id":"MK-80",
         "qs_pg:id":1193160,
         "unlc:id":"MK-80",
         "wd:id":"Q1994547",
         "wk:page":"\u010ca\u0161ka Municipality"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1a7c9eaed083e4870e3c5e403bcb5d32",
+    "wof:geomhash":"d8b96b4b32c885b7cd4e966ee77c6901",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -351,7 +353,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939456,
+    "wof:lastmodified":1695885333,
     "wof:name":"Ca\u0161ka",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/742/73/85674273.geojson
+++ b/data/856/742/73/85674273.geojson
@@ -226,15 +226,17 @@
         "fips:code":"MKD1",
         "gp:id":24550756,
         "hasc:id":"MK.CE",
+        "iso:code":"MK-77",
         "iso:id":"MK-77",
         "qs_pg:id":483204,
         "wd:id":"Q1463152"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"acaf464c62b99267fe34c87ec16113f3",
+    "wof:geomhash":"54d3b9c8bca35beb23a48c5548360e0f",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -250,7 +252,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939454,
+    "wof:lastmodified":1695885333,
     "wof:name":"Centar",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/742/75/85674275.geojson
+++ b/data/856/742/75/85674275.geojson
@@ -321,17 +321,19 @@
         "gn:id":862958,
         "gp:id":24550824,
         "hasc:id":"MK.ZR",
+        "iso:code":"MK-33",
         "iso:id":"MK-33",
         "qs_pg:id":59751,
         "unlc:id":"MK-33",
         "wd:id":"Q950881",
         "wk:page":"Zrnovci Municipality"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f08887bcc385f819b7631d7fb23e18c9",
+    "wof:geomhash":"eb4acdc5939c07b6a3c01f63dd91f352",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -347,7 +349,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939455,
+    "wof:lastmodified":1695885333,
     "wof:name":"Zrnovci",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/742/79/85674279.geojson
+++ b/data/856/742/79/85674279.geojson
@@ -330,16 +330,18 @@
         "gn:id":862977,
         "gp:id":24550757,
         "hasc:id":"MK.CH",
+        "iso:code":"MK-81",
         "iso:id":"MK-81",
         "qs_pg:id":1191263,
         "unlc:id":"MK-81",
         "wd:id":"Q281898"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"15a755bd4d2d9691fdc3f9ebe9d9cf87",
+    "wof:geomhash":"53387316fad0cd26922ade0443b11edb",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -355,7 +357,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939457,
+    "wof:lastmodified":1695885333,
     "wof:name":"Ce\u0161inovo-Oble\u0161evo",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/742/87/85674287.geojson
+++ b/data/856/742/87/85674287.geojson
@@ -326,17 +326,19 @@
         "gn:id":863842,
         "gp:id":24550830,
         "hasc:id":"MK.CS",
+        "iso:code":"MK-82",
         "iso:id":"MK-82",
         "qs_pg:id":1311349,
         "unlc:id":"MK-82",
         "wd:id":"Q629720",
         "wk:page":"\u010cu\u010der-Sandevo Municipality"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6555f4d0824f6c8e57c47d74f4439f55",
+    "wof:geomhash":"14051b26efec48e468eab12b0503f31a",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -352,7 +354,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939454,
+    "wof:lastmodified":1695885333,
     "wof:name":"Cucer Sandevo",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/742/89/85674289.geojson
+++ b/data/856/742/89/85674289.geojson
@@ -275,16 +275,18 @@
         "gn:id":862961,
         "gp:id":24550760,
         "hasc:id":"MK.DK",
+        "iso:code":"MK-24",
         "iso:id":"MK-24",
         "qs_pg:id":989453,
         "unlc:id":"MK-24",
         "wd:id":"Q2370973"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4af1fda5566d9986b958f3c47d3a7ea4",
+    "wof:geomhash":"8a838a50b5dcec4e59f62ceb23c9e7bc",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -300,7 +302,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939454,
+    "wof:lastmodified":1695885333,
     "wof:name":"Demir Kapija",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/742/93/85674293.geojson
+++ b/data/856/742/93/85674293.geojson
@@ -324,17 +324,19 @@
         "gn:id":863849,
         "gp:id":24550763,
         "hasc:id":"MK.DE",
+        "iso:code":"MK-27",
         "iso:id":"MK-27",
         "qs_pg:id":503081,
         "unlc:id":"MK-27",
         "wd:id":"Q1992691",
         "wk:page":"Dolneni Municipality"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1f481179f1172300200796c86acb835d",
+    "wof:geomhash":"59db397e1d6da3ea3e4e0f78d837b1fe",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -350,7 +352,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939453,
+    "wof:lastmodified":1695885333,
     "wof:name":"Dolneni",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/742/97/85674297.geojson
+++ b/data/856/742/97/85674297.geojson
@@ -272,16 +272,18 @@
         "gn:id":863853,
         "gp:id":24550766,
         "hasc:id":"MK.GB",
+        "iso:code":"MK-17",
         "iso:id":"MK-17",
         "qs_pg:id":1191272,
         "unlc:id":"MK-17",
         "wd:id":"Q2019836"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"383d0f79a394653e041b79b25f38ecff",
+    "wof:geomhash":"5dcd95743973f26f075e5fdd09e189db",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -297,7 +299,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939457,
+    "wof:lastmodified":1695885333,
     "wof:name":"Gazi Baba",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/743/01/85674301.geojson
+++ b/data/856/743/01/85674301.geojson
@@ -327,17 +327,19 @@
         "gn:id":862974,
         "gp:id":24550768,
         "hasc:id":"MK.GR",
+        "iso:code":"MK-20",
         "iso:id":"MK-20",
         "qs_pg:id":231606,
         "unlc:id":"MK-20",
         "wd:id":"Q1992701",
         "wk:page":"Gradsko Municipality"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8fee1228a0088c53a67f3560916d086e",
+    "wof:geomhash":"95a76fe188d46ce2b9ccc884d2ba606e",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -353,7 +355,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939449,
+    "wof:lastmodified":1695885333,
     "wof:name":"Gradsko",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/743/07/85674307.geojson
+++ b/data/856/743/07/85674307.geojson
@@ -320,17 +320,19 @@
         "gn:id":862975,
         "gp:id":24550785,
         "hasc:id":"MK.LO",
+        "iso:code":"MK-49",
         "iso:id":"MK-49",
         "qs_pg:id":956349,
         "unlc:id":"MK-49",
         "wd:id":"Q1996470",
         "wk:page":"Lozovo Municipality"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1aa412bb50757f7cb50c5916fd40b2a2",
+    "wof:geomhash":"1a68d06268bf4e3dc0b524e4cc9659af",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -346,7 +348,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939448,
+    "wof:lastmodified":1695885333,
     "wof:name":"Lozovo",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/743/11/85674311.geojson
+++ b/data/856/743/11/85674311.geojson
@@ -321,17 +321,19 @@
         "gn:id":862953,
         "gp:id":24550778,
         "hasc:id":"MK.KN",
+        "iso:code":"MK-41",
         "iso:id":"MK-41",
         "qs_pg:id":1150446,
         "unlc:id":"MK-41",
         "wd:id":"Q1992728",
         "wk:page":"Kon\u010de Municipality"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5eccdb27a2738468ad7f1c4400c7905f",
+    "wof:geomhash":"ee0963944db2689a6b49b353bd6ad311",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -347,7 +349,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939446,
+    "wof:lastmodified":1695885333,
     "wof:name":"Konce",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/743/15/85674315.geojson
+++ b/data/856/743/15/85674315.geojson
@@ -318,17 +318,19 @@
         "gn:id":863856,
         "gp:id":24550769,
         "hasc:id":"MK.IL",
+        "iso:code":"MK-34",
         "iso:id":"MK-34",
         "qs_pg:id":231607,
         "unlc:id":"MK-34",
         "wd:id":"Q657754",
         "wk:page":"Ilinden Municipality"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7e35c55da8f7107254cb355771bf3f4c",
+    "wof:geomhash":"e5d8bc6b0f3a840f81aee76f3e5ef09c",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -344,7 +346,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939451,
+    "wof:lastmodified":1695885333,
     "wof:name":"Ilinden",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/743/19/85674319.geojson
+++ b/data/856/743/19/85674319.geojson
@@ -318,17 +318,19 @@
         "gn:id":862960,
         "gp:id":24550772,
         "hasc:id":"MK.KB",
+        "iso:code":"MK-37",
         "iso:id":"MK-37",
         "qs_pg:id":1004498,
         "unlc:id":"MK-37",
         "wd:id":"Q1346554",
         "wk:page":"Karbinci Municipality"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ddb24d0cc74d85cf99b8542f5da11f2e",
+    "wof:geomhash":"98a1bf8ec49c7e35d32405e19da42ebd",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -344,7 +346,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939447,
+    "wof:lastmodified":1695885333,
     "wof:name":"Karbinci",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/743/23/85674323.geojson
+++ b/data/856/743/23/85674323.geojson
@@ -258,16 +258,18 @@
         "gn:id":863860,
         "gp:id":24550773,
         "hasc:id":"MK.KX",
+        "iso:code":"MK-38",
         "iso:id":"MK-38",
         "qs_pg:id":1316871,
         "unlc:id":"MK-38",
         "wd:id":"Q1463246"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"133abe51d41008040827a74ba35d5304",
+    "wof:geomhash":"e2c335203b0da85534b70b722ba52ea4",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -283,7 +285,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939451,
+    "wof:lastmodified":1695885333,
     "wof:name":"Karpo\u0161",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/743/27/85674327.geojson
+++ b/data/856/743/27/85674327.geojson
@@ -317,17 +317,19 @@
         "gn:id":863861,
         "gp:id":24550774,
         "hasc:id":"MK.AV",
+        "iso:code":"MK-36",
         "iso:id":"MK-36",
         "qs_pg:id":989456,
         "unlc:id":"MK-36",
         "wd:id":"Q1155055",
         "wk:page":"Kavadarci Municipality"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5bc84bac52a96b580cb6e1a2c62a55d1",
+    "wof:geomhash":"bdb572ed56076ff48368a3d3cb2796f7",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -343,7 +345,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939446,
+    "wof:lastmodified":1695885333,
     "wof:name":"Kavadartsi",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/743/31/85674331.geojson
+++ b/data/856/743/31/85674331.geojson
@@ -285,16 +285,18 @@
         "gn:id":7056266,
         "gp:id":55848400,
         "hasc:id":"MK.AD",
+        "iso:code":"MK-01",
         "iso:id":"MK-01",
         "qs_pg:id":46448,
         "unlc:id":"MK-01",
         "wd:id":"Q1992708"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"cd270fd8a7903d181b64c23204276581",
+    "wof:geomhash":"88c3c6125c99c90d06b60c09d973c250",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -310,7 +312,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939448,
+    "wof:lastmodified":1695885333,
     "wof:name":"Aerodrom",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/743/37/85674337.geojson
+++ b/data/856/743/37/85674337.geojson
@@ -216,17 +216,19 @@
         "fips:code":"MK44",
         "gp:id":24550866,
         "hasc:id":"MK.VD",
+        "iso:code":"MK-39",
         "iso:id":"MK-39",
         "qs_pg:id":83487,
         "unlc:id":"MK-39",
         "wd:id":"Q1386136",
         "wk:page":"Kisela Voda Municipality"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3832d1e0b99d75f86056cbf7ae30fee6",
+    "wof:geomhash":"f241e6fd93f4a067c8692669bedee507",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -242,7 +244,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939449,
+    "wof:lastmodified":1695885333,
     "wof:name":"Kisela Voda",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/743/41/85674341.geojson
+++ b/data/856/743/41/85674341.geojson
@@ -316,17 +316,19 @@
         "gn:id":863865,
         "gp:id":24550777,
         "hasc:id":"MK.OC",
+        "iso:code":"MK-42",
         "iso:id":"MK-42",
         "qs_pg:id":989458,
         "unlc:id":"MK-42",
         "wd:id":"Q1819289",
         "wk:page":"Ko\u010dani Municipality"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f6c3dda69d04601212adfe3642ed104f",
+    "wof:geomhash":"a2e1534aa699b9a1e2a0e819b0bb283a",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -342,7 +344,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939450,
+    "wof:lastmodified":1695885333,
     "wof:name":"Kocani",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/743/45/85674345.geojson
+++ b/data/856/743/45/85674345.geojson
@@ -367,17 +367,19 @@
         "gn:id":789090,
         "gp:id":24550780,
         "hasc:id":"MK.KY",
+        "iso:code":"MK-43",
         "iso:id":"MK-43",
         "qs_pg:id":503446,
         "unlc:id":"MK-43",
         "wd:id":"Q1992716",
         "wk:page":"Kratovo, Macedonia"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6df10625caf89cb027089ee42992031a",
+    "wof:geomhash":"98f71fca6938f6ce193e3cdd2d0aaae6",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -393,7 +395,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939447,
+    "wof:lastmodified":1695885333,
     "wof:name":"Kratovo",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/743/49/85674349.geojson
+++ b/data/856/743/49/85674349.geojson
@@ -318,17 +318,19 @@
         "gn:id":863870,
         "gp:id":24550781,
         "hasc:id":"MK.KG",
+        "iso:code":"MK-45",
         "iso:id":"MK-45",
         "qs_pg:id":59736,
         "unlc:id":"MK-45",
         "wd:id":"Q2018930",
         "wk:page":"Krivoga\u0161tani Municipality"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d463a079e3a1c553a1a34d5248e2b546",
+    "wof:geomhash":"aab7885fbc8385155b49d212a85495b9",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -344,7 +346,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939452,
+    "wof:lastmodified":1695885334,
     "wof:name":"Krivoga\u0161tani",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/743/53/85674353.geojson
+++ b/data/856/743/53/85674353.geojson
@@ -327,17 +327,19 @@
         "gn:id":863871,
         "gp:id":24550782,
         "hasc:id":"MK.KS",
+        "iso:code":"MK-46",
         "iso:id":"MK-46",
         "qs_pg:id":224021,
         "unlc:id":"MK-46",
         "wd:id":"Q2476159",
         "wk:page":"Kru\u0161evo Municipality"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ec1dbf0998f05d5947ae107cba50ebf1",
+    "wof:geomhash":"d09350701f34d00c433da90466ae0e3f",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -353,7 +355,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939449,
+    "wof:lastmodified":1695885334,
     "wof:name":"Kru\u0161evo",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/743/55/85674355.geojson
+++ b/data/856/743/55/85674355.geojson
@@ -324,17 +324,19 @@
         "gn:id":863873,
         "gp:id":24550832,
         "hasc:id":"MK.UM",
+        "iso:code":"MK-47",
         "iso:id":"MK-47",
         "qs_pg:id":1103577,
         "unlc:id":"MK-47",
         "wd:id":"Q2352376",
         "wk:page":"Kumanovo Municipality"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5270c960ab95fd8189af653b4ed16b78",
+    "wof:geomhash":"537eb5e427d53141d01b921622d89173",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -350,7 +352,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939450,
+    "wof:lastmodified":1695885334,
     "wof:name":"Kumanovo",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/743/61/85674361.geojson
+++ b/data/856/743/61/85674361.geojson
@@ -299,17 +299,19 @@
         "gn:id":863877,
         "gp:id":24550786,
         "hasc:id":"MK.MD",
+        "iso:code":"MK-52",
         "iso:id":"MK-52",
         "qs_pg:id":1193167,
         "unlc:id":"MK-52",
         "wd:id":"Q2364199",
         "wk:page":"Makedonski Brod Municipality"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5eaf67c8a10ee1f0a86ac6b6bb554b37",
+    "wof:geomhash":"b238bebb5a4394dcc141245d6748d7eb",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -325,7 +327,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939445,
+    "wof:lastmodified":1695885334,
     "wof:name":"Brod",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/743/65/85674365.geojson
+++ b/data/856/743/65/85674365.geojson
@@ -253,17 +253,19 @@
         "gn:id":863488,
         "gp:id":24550789,
         "hasc:id":"MK.MG",
+        "iso:code":"MK-53",
         "iso:id":"MK-53",
         "qs_pg:id":911157,
         "unlc:id":"MK-53",
         "wd:id":"Q1839369",
         "wk:page":"Mogila Municipality"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"561a76122ec9f89280dcdeacc6eec86d",
+    "wof:geomhash":"cb05294943a6c2ed26aa40bafd29eb8d",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -279,7 +281,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939448,
+    "wof:lastmodified":1695885334,
     "wof:name":"Pelagonia",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/743/69/85674369.geojson
+++ b/data/856/743/69/85674369.geojson
@@ -323,17 +323,19 @@
         "gn:id":863881,
         "gp:id":24550790,
         "hasc:id":"MK.NG",
+        "iso:code":"MK-54",
         "iso:id":"MK-54",
         "qs_pg:id":503463,
         "unlc:id":"MK-54",
         "wd:id":"Q3246545",
         "wk:page":"Negotino Municipality"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2134294a423e4c6c553e8fb5015c7ac4",
+    "wof:geomhash":"10fb6bcf736eb6a5c1111b9e87c68601",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -349,7 +351,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939446,
+    "wof:lastmodified":1695885334,
     "wof:name":"Negotino",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/743/73/85674373.geojson
+++ b/data/856/743/73/85674373.geojson
@@ -254,16 +254,18 @@
         "gn:id":863468,
         "gp:id":24550791,
         "hasc:id":"MK.NV",
+        "iso:code":"MK-55",
         "iso:id":"MK-55",
         "qs_pg:id":1197779,
         "unlc:id":"MK-55",
         "wd:id":"Q2088022"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"94c177b7c52ae00e46e186014db5130a",
+    "wof:geomhash":"c11084ff5524cc264fcf56725cf94e9c",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -279,7 +281,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939447,
+    "wof:lastmodified":1695885334,
     "wof:name":"Novatsi",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/743/77/85674377.geojson
+++ b/data/856/743/77/85674377.geojson
@@ -265,16 +265,18 @@
         "gn:id":863850,
         "gp:id":24550839,
         "hasc:id":"MK.GP",
+        "iso:code":"MK-29",
         "iso:id":"MK-29",
         "qs_pg:id":502097,
         "unlc:id":"MK-29",
         "wd:id":"Q924278"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"863026421d081fe585bcd0c6121cdf0d",
+    "wof:geomhash":"3e4c2dfb0a902ee713eb4e814aa66b46",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -290,7 +292,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939450,
+    "wof:lastmodified":1695885334,
     "wof:name":"Gjorce Petrov",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/743/81/85674381.geojson
+++ b/data/856/743/81/85674381.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017483,
-    "geom:area_square_m":161625696.138554,
+    "geom:area_square_m":161625390.764277,
     "geom:bbox":"20.778336,41.530048,20.986754,41.675327",
     "geom:latitude":41.613055,
     "geom:longitude":20.896966,
@@ -291,17 +291,19 @@
         "gn:id":863917,
         "gp:id":24550864,
         "hasc:id":"MK.ZA",
+        "iso:code":"MK-31",
         "iso:id":"MK-31",
         "qs_pg:id":483524,
         "unlc:id":"MK-31",
         "wd:id":"Q2018939",
         "wk:page":"Zajas Municipality"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1166a5e81d400a27fb49349cd273c098",
+    "wof:geomhash":"4a67d5b8f7977356a11a06bcebb89bb6",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -317,7 +319,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939448,
+    "wof:lastmodified":1695884966,
     "wof:name":"Zajas",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/743/85/85674385.geojson
+++ b/data/856/743/85/85674385.geojson
@@ -321,17 +321,19 @@
         "gn:id":863841,
         "gp:id":24550829,
         "hasc:id":"MK.CZ",
+        "iso:code":"MK-78",
         "iso:id":"MK-78",
         "qs_pg:id":1103589,
         "unlc:id":"MK-78",
         "wd:id":"Q1779085",
         "wk:page":"Centar \u017dupa Municipality"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"475db21e216a15320e0070f5b04386f5",
+    "wof:geomhash":"2cd0330f8a9b3ae00450f994a62e1502",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -347,7 +349,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939451,
+    "wof:lastmodified":1695885334,
     "wof:name":"Centar \u017eupa",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/743/89/85674389.geojson
+++ b/data/856/743/89/85674389.geojson
@@ -319,17 +319,19 @@
         "gn:id":863843,
         "gp:id":24550837,
         "hasc:id":"MK.DB",
+        "iso:code":"MK-21",
         "iso:id":"MK-21",
         "qs_pg:id":220916,
         "unlc:id":"MK-21",
         "wd:id":"Q1344996",
         "wk:page":"Debar Municipality"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6c4645e1082552b51336bba64d7458e2",
+    "wof:geomhash":"e71c49646db767fb562b60183074982b",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -345,7 +347,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939447,
+    "wof:lastmodified":1695885334,
     "wof:name":"Debar",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/743/95/85674395.geojson
+++ b/data/856/743/95/85674395.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.04136,
-    "geom:area_square_m":383350675.148353,
+    "geom:area_square_m":383350974.725011,
     "geom:bbox":"20.688196,41.323896,21.134503,41.591819",
     "geom:latitude":41.44702,
     "geom:longitude":20.907023,
@@ -287,17 +287,19 @@
         "gn:id":863851,
         "gp:id":24550764,
         "hasc:id":"MK.DR",
+        "iso:code":"MK-28",
         "iso:id":"MK-28",
         "qs_pg:id":59716,
         "unlc:id":"MK-28",
         "wd:id":"Q1996439",
         "wk:page":"Drugovo Municipality"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"288022d6b3b172c14ae445745e899a5e",
+    "wof:geomhash":"3031bee26b4e624dfe0a57c0dec39429",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -313,7 +315,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939445,
+    "wof:lastmodified":1695884966,
     "wof:name":"Drugovo",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/743/99/85674399.geojson
+++ b/data/856/743/99/85674399.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005297,
-    "geom:area_square_m":49039392.532096,
+    "geom:area_square_m":49039382.045541,
     "geom:bbox":"20.888344,41.479246,21.002014,41.564259",
     "geom:latitude":41.524102,
     "geom:longitude":20.950121,
@@ -313,17 +313,19 @@
         "gn:id":863862,
         "gp:id":24550775,
         "hasc:id":"MK.KH",
+        "iso:code":"MK-40",
         "iso:id":"MK-40",
         "qs_pg:id":503416,
         "unlc:id":"MK-40",
         "wd:id":"Q2018957",
         "wk:page":"Ki\u010devo Municipality"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"061872c866d891d9ea1f4ffe977aee8b",
+    "wof:geomhash":"b23db787c029dca078c5508b6462760a",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -339,7 +341,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939450,
+    "wof:lastmodified":1695884521,
     "wof:name":"Kicevo",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/744/03/85674403.geojson
+++ b/data/856/744/03/85674403.geojson
@@ -333,16 +333,18 @@
         "gn:id":863892,
         "gp:id":24550858,
         "hasc:id":"MK.MR",
+        "iso:code":"MK-50",
         "iso:id":"MK-50",
         "qs_pg:id":1085986,
         "unlc:id":"MK-50",
         "wd:id":"Q1323332"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"108d5ed52ee8beee7629445eef7e74f4",
+    "wof:geomhash":"079e53cffbdc886892bd7e4f853c79fc",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -358,7 +360,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939439,
+    "wof:lastmodified":1695885334,
     "wof:name":"Mavrovo and Rostusa",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/744/07/85674407.geojson
+++ b/data/856/744/07/85674407.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.013006,
-    "geom:area_square_m":120269917.68623,
+    "geom:area_square_m":120270092.75585,
     "geom:bbox":"20.966552,41.514318,21.106119,41.665145",
     "geom:latitude":41.594796,
     "geom:longitude":21.032883,
@@ -293,16 +293,18 @@
         "gn:id":863885,
         "gp:id":24550795,
         "hasc:id":"MK.OS",
+        "iso:code":"MK-57",
         "iso:id":"MK-57",
         "qs_pg:id":59738,
         "unlc:id":"MK-57",
         "wd:id":"Q2001785"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8b8173af2bc5dd52658c0bfa3a11345a",
+    "wof:geomhash":"e9cdf8c859744ed36ddbcd7010bedb0f",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -318,7 +320,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939442,
+    "wof:lastmodified":1695884966,
     "wof:name":"Oslomej",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/744/13/85674413.geojson
+++ b/data/856/744/13/85674413.geojson
@@ -320,17 +320,19 @@
         "gn:id":863906,
         "gp:id":24550861,
         "hasc:id":"MK.TR",
+        "iso:code":"MK-75",
         "iso:id":"MK-75",
         "qs_pg:id":1193249,
         "unlc:id":"MK-75",
         "wd:id":"Q2282274",
         "wk:page":"Tearce Municipality"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"64943154a23ae9fc19d1e9016f5a694d",
+    "wof:geomhash":"e089116ce4ab48577b66288f7088115f",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -346,7 +348,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939445,
+    "wof:lastmodified":1695885334,
     "wof:name":"Tearce",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/744/17/85674417.geojson
+++ b/data/856/744/17/85674417.geojson
@@ -325,17 +325,19 @@
         "gn:id":863907,
         "gp:id":24550862,
         "hasc:id":"MK.ET",
+        "iso:code":"MK-76",
         "iso:id":"MK-76",
         "qs_pg:id":241657,
         "unlc:id":"MK-76",
         "wd:id":"Q3245456",
         "wk:page":"Tetovo Municipality"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e9f400ea7a6d135fd671e22cb8f07164",
+    "wof:geomhash":"4f913b8166a3b815fec6990b6c940e47",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -351,7 +353,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939441,
+    "wof:lastmodified":1695885334,
     "wof:name":"Tetovo",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/744/21/85674421.geojson
+++ b/data/856/744/21/85674421.geojson
@@ -262,16 +262,18 @@
         "gn:id":863914,
         "gp:id":24550819,
         "hasc:id":"MK.VH",
+        "iso:code":"MK-16",
         "iso:id":"MK-16",
         "qs_pg:id":1193219,
         "wd:id":"Q1996740",
         "wk:page":"Vrap\u010di\u0161te Municipality"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0a226e09f1f378e435e823ba5a28bd21",
+    "wof:geomhash":"ec71eacaee18188ec6f9dc683d6ae7b4",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -287,7 +289,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939441,
+    "wof:lastmodified":1695885334,
     "wof:name":"Polog",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/744/25/85674425.geojson
+++ b/data/856/744/25/85674425.geojson
@@ -332,16 +332,18 @@
         "gn:id":863834,
         "gp:id":24550828,
         "hasc:id":"MK.VJ",
+        "iso:code":"MK-06",
         "iso:id":"MK-06",
         "qs_pg:id":1103588,
         "unlc:id":"MK-06",
         "wd:id":"Q9035785"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b1f08f893090382d27629ed792f94f8a",
+    "wof:geomhash":"97dcc17493da2ea80b79575897c91668",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -357,7 +359,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939445,
+    "wof:lastmodified":1695885334,
     "wof:name":"Bogovinje",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/744/27/85674427.geojson
+++ b/data/856/744/27/85674427.geojson
@@ -326,17 +326,19 @@
         "gn:id":863835,
         "gp:id":24550751,
         "hasc:id":"MK.BN",
+        "iso:code":"MK-08",
         "iso:id":"MK-08",
         "qs_pg:id":1025876,
         "unlc:id":"MK-08",
         "wd:id":"Q1057563",
         "wk:page":"Brvenica Municipality"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"76f57f95de629ab0df7e6bf639dabc49",
+    "wof:geomhash":"76ef7909bf0e1a89a9511ff5e1b73664",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -352,7 +354,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939440,
+    "wof:lastmodified":1695885334,
     "wof:name":"Brvenica",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/744/33/85674433.geojson
+++ b/data/856/744/33/85674433.geojson
@@ -355,17 +355,19 @@
         "gn:id":863855,
         "gp:id":24550767,
         "hasc:id":"MK.GT",
+        "iso:code":"MK-19",
         "iso:id":"MK-19",
         "qs_pg:id":989454,
         "unlc:id":"MK-19",
         "wd:id":"Q521112",
         "wk:page":"Gostivar Municipality"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e43ee2e421108aed06ac89a2f825d46b",
+    "wof:geomhash":"09818c612c30278ee39268ffa908a9b7",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -381,7 +383,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939440,
+    "wof:lastmodified":1695885334,
     "wof:name":"Gostivar",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/744/37/85674437.geojson
+++ b/data/856/744/37/85674437.geojson
@@ -325,17 +325,19 @@
         "gn:id":863858,
         "gp:id":24550771,
         "hasc:id":"MK.JG",
+        "iso:code":"MK-35",
         "iso:id":"MK-35",
         "qs_pg:id":1322885,
         "unlc:id":"MK-35",
         "wd:id":"Q431908",
         "wk:page":"Jegunovce Municipality"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1f8a0b8b785f71b14de7108e94a933ed",
+    "wof:geomhash":"581053b3a4961821a72c30ef3c531329",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -351,7 +353,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939443,
+    "wof:lastmodified":1695885334,
     "wof:name":"Jegunovce",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/744/39/85674439.geojson
+++ b/data/856/744/39/85674439.geojson
@@ -320,17 +320,19 @@
         "gn:id":863902,
         "gp:id":24550808,
         "hasc:id":"MK.RU",
+        "iso:code":"MK-73",
         "iso:id":"MK-73",
         "qs_pg:id":1103585,
         "unlc:id":"MK-73",
         "wd:id":"Q2308287",
         "wk:page":"Strumica Municipality"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"35842d73fbfbbb82480dd265557cf21a",
+    "wof:geomhash":"822013034525725e3235f7aae5a4309e",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -346,7 +348,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939443,
+    "wof:lastmodified":1695885334,
     "wof:name":"Southeastern",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/744/43/85674443.geojson
+++ b/data/856/744/43/85674443.geojson
@@ -281,17 +281,19 @@
         "gn:id":784732,
         "gp:id":24550813,
         "hasc:id":"MK.VA",
+        "iso:code":"MK-10",
         "iso:id":"MK-10",
         "qs_pg:id":1103587,
         "unlc:id":"MK-10",
         "wd:id":"Q2018965",
         "wk:page":"Valandovo Municipality"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"96b0c1ab88b573adea5479e6028d7f60",
+    "wof:geomhash":"d47c2cd724d02b2992aa4edcdc34adcd",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -307,7 +309,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939442,
+    "wof:lastmodified":1695885334,
     "wof:name":"Valandovo",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/744/49/85674449.geojson
+++ b/data/856/744/49/85674449.geojson
@@ -317,17 +317,19 @@
         "gn:id":862947,
         "gp:id":24550814,
         "hasc:id":"MK.VL",
+        "iso:code":"MK-11",
         "iso:id":"MK-11",
         "qs_pg:id":956350,
         "unlc:id":"MK-11",
         "wd:id":"Q2018980",
         "wk:page":"Vasilevo Municipality"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5ef276834399c2d3f1ebbbae024bf366",
+    "wof:geomhash":"46b88eb84348b07fdcadb79563cd81df",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -343,7 +345,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939444,
+    "wof:lastmodified":1695885334,
     "wof:name":"Vasilevo",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/744/53/85674453.geojson
+++ b/data/856/744/53/85674453.geojson
@@ -328,17 +328,19 @@
         "gn:id":862950,
         "gp:id":24550827,
         "hasc:id":"MK.BG",
+        "iso:code":"MK-05",
         "iso:id":"MK-05",
         "qs_pg:id":1311341,
         "unlc:id":"MK-05",
         "wd:id":"Q1992752",
         "wk:page":"Bogdanci Municipality"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c75d172022078a703c998294f53127ab",
+    "wof:geomhash":"d53a3a625f18b3ac5020242c800e9126",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -354,7 +356,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939442,
+    "wof:lastmodified":1695885334,
     "wof:name":"Bogdanci",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/744/57/85674457.geojson
+++ b/data/856/744/57/85674457.geojson
@@ -319,17 +319,19 @@
         "gn:id":862946,
         "gp:id":24550750,
         "hasc:id":"MK.BS",
+        "iso:code":"MK-07",
         "iso:id":"MK-07",
         "qs_pg:id":934358,
         "unlc:id":"MK-07",
         "wd:id":"Q1779775",
         "wk:page":"Bosilovo Municipality"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1335246f32e4122795dc31c794d7592c",
+    "wof:geomhash":"f01cb7228e33d1a7b9d889eec0730dc9",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -345,7 +347,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939439,
+    "wof:lastmodified":1695885334,
     "wof:name":"Bosilovo",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/744/61/85674461.geojson
+++ b/data/856/744/61/85674461.geojson
@@ -256,17 +256,19 @@
         "gn:id":863854,
         "gp:id":24550840,
         "hasc:id":"MK.GV",
+        "iso:code":"MK-18",
         "iso:id":"MK-18",
         "qs_pg:id":1020085,
         "unlc:id":"MK-18",
         "wd:id":"Q2018974",
         "wk:page":"Gevgelija Municipality"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"33cd2faddc4e880234a72a8cd6866860",
+    "wof:geomhash":"792dcb6de3436bdb06db1a3589673d78",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -282,7 +284,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939439,
+    "wof:lastmodified":1695885334,
     "wof:name":"Southeastern",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/744/67/85674467.geojson
+++ b/data/856/744/67/85674467.geojson
@@ -311,17 +311,19 @@
         "gn:id":862945,
         "gp:id":24550853,
         "hasc:id":"MK.NS",
+        "iso:code":"MK-56",
         "iso:id":"MK-56",
         "qs_pg:id":1016990,
         "unlc:id":"MK-56",
         "wd:id":"Q1946579",
         "wk:page":"Novo Selo Municipality"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4a61541a54389bfa57b78cb98f07751e",
+    "wof:geomhash":"0da493faa5da4c35bfdefe12d23cb1ad",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -337,7 +339,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939440,
+    "wof:lastmodified":1695885334,
     "wof:name":"Novo Selo",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/744/73/85674473.geojson
+++ b/data/856/744/73/85674473.geojson
@@ -279,17 +279,19 @@
         "gn:id":862949,
         "gp:id":24550860,
         "hasc:id":"MK.SD",
+        "iso:code":"MK-26",
         "iso:id":"MK-26",
         "qs_pg:id":1197783,
         "unlc:id":"MK-26",
         "wd:id":"Q1996413",
         "wk:page":"Dojran Municipality"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c6507403539083ecd9339defb6f6234c",
+    "wof:geomhash":"801486f737d1ecd00c7e04915fdb1885",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -305,7 +307,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939441,
+    "wof:lastmodified":1695885334,
     "wof:name":"Dojran",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/744/75/85674475.geojson
+++ b/data/856/744/75/85674475.geojson
@@ -315,17 +315,19 @@
         "gn:id":863912,
         "gp:id":24550817,
         "hasc:id":"MK.NI",
+        "iso:code":"MK-14",
         "iso:id":"MK-14",
         "qs_pg:id":999053,
         "unlc:id":"MK-14",
         "wd:id":"Q2479526",
         "wk:page":"Vinica Municipality, Macedonia"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f55da56cbb6abd150dcc10c76bc66bfa",
+    "wof:geomhash":"f03e4839fb2e4aab4afa4c9b246066e2",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -341,7 +343,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939442,
+    "wof:lastmodified":1695885334,
     "wof:name":"Vinitsa",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/744/79/85674479.geojson
+++ b/data/856/744/79/85674479.geojson
@@ -323,16 +323,18 @@
         "gn:id":863485,
         "gp:id":24550826,
         "hasc:id":"MK.BR",
+        "iso:code":"MK-03",
         "iso:id":"MK-03",
         "qs_pg:id":1118949,
         "unlc:id":"MK-03",
         "wd:id":"Q793727"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a1f52483f17cc2984e2c1b62c86defad",
+    "wof:geomhash":"1ce1dadb69f3cf9a66bfbca266e65aac",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -348,7 +350,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939444,
+    "wof:lastmodified":1695885334,
     "wof:name":"Berovo",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/744/85/85674485.geojson
+++ b/data/856/744/85/85674485.geojson
@@ -322,17 +322,19 @@
         "gn:id":863844,
         "gp:id":24550838,
         "hasc:id":"MK.DL",
+        "iso:code":"MK-23",
         "iso:id":"MK-23",
         "qs_pg:id":1311348,
         "unlc:id":"MK-23",
         "wd:id":"Q1323322",
         "wk:page":"Del\u010devo Municipality"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"49a10838adbe2332edb7bcbd0f08066a",
+    "wof:geomhash":"342e153b8c886928ae67f7f82954d3fc",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -348,7 +350,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939444,
+    "wof:lastmodified":1695885334,
     "wof:name":"Delcevo",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/744/89/85674489.geojson
+++ b/data/856/744/89/85674489.geojson
@@ -320,17 +320,19 @@
         "gn:id":862956,
         "gp:id":24550851,
         "hasc:id":"MK.MK",
+        "iso:code":"MK-51",
         "iso:id":"MK-51",
         "qs_pg:id":1016989,
         "unlc:id":"MK-51",
         "wd:id":"Q2041219",
         "wk:page":"Makedonska Kamenica Municipality"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0ed4013f5caa19e2e77838ca39ab3a10",
+    "wof:geomhash":"5359bccfceee16c28e46b6fa05215cc8",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -346,7 +348,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939441,
+    "wof:lastmodified":1695885334,
     "wof:name":"Makedonska Kamenica",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/744/95/85674495.geojson
+++ b/data/856/744/95/85674495.geojson
@@ -321,17 +321,19 @@
         "gn:id":862938,
         "gp:id":24550854,
         "hasc:id":"MK.PH",
+        "iso:code":"MK-60",
         "iso:id":"MK-60",
         "qs_pg:id":999055,
         "unlc:id":"MK-60",
         "wd:id":"Q426114",
         "wk:page":"Peh\u010devo Municipality"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ed53ce6c5f5087af046b0d8ff083a0e2",
+    "wof:geomhash":"d6fac54ce2a7dcaeccec717e3f944e92",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -347,7 +349,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939439,
+    "wof:lastmodified":1695885334,
     "wof:name":"Phecevo",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/744/97/85674497.geojson
+++ b/data/856/744/97/85674497.geojson
@@ -315,17 +315,19 @@
         "gn:id":863901,
         "gp:id":24550846,
         "hasc:id":"MK.UG",
+        "iso:code":"MK-72",
         "iso:id":"MK-72",
         "qs_pg:id":1103578,
         "unlc:id":"MK-72",
         "wd:id":"Q749618",
         "wk:page":"Struga Municipality"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"33032ef270a52b9c63e5d51fa352dc21",
+    "wof:geomhash":"2676dbce13bff914060484b7ae9823d5",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -341,7 +343,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939443,
+    "wof:lastmodified":1695885334,
     "wof:name":"Struga",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/745/03/85674503.geojson
+++ b/data/856/745/03/85674503.geojson
@@ -316,17 +316,19 @@
         "gn:id":863891,
         "gp:id":24550844,
         "hasc:id":"MK.RN",
+        "iso:code":"MK-65",
         "iso:id":"MK-65",
         "qs_pg:id":1193222,
         "unlc:id":"MK-65",
         "wd:id":"Q1475001",
         "wk:page":"Rankovce Municipality"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"08725ebbfc36463997034519c0df955b",
+    "wof:geomhash":"005d9eb6345476d589fb325d02f654a8",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -342,7 +344,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1690939458,
+    "wof:lastmodified":1695885334,
     "wof:name":"Rankovce",
     "wof:parent_id":85632373,
     "wof:placetype":"region",

--- a/data/856/745/07/85674507.geojson
+++ b/data/856/745/07/85674507.geojson
@@ -131,10 +131,12 @@
         "fips:code":"MKA3",
         "gp:id":24550756,
         "hasc:id":"MK.SO",
+        "iso:code":"MK-84",
         "iso:id":"MK-84",
         "qs_pg:id":483204,
         "unlc:id":"MK-84"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"MK",
     "wof:geom_alt":[
         "quattroshapes"
@@ -155,7 +157,7 @@
         "mkd",
         "sqi"
     ],
-    "wof:lastmodified":1684354004,
+    "wof:lastmodified":1695885334,
     "wof:name":"\u0160uto Orizari",
     "wof:parent_id":85632373,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.