### PR TITLE
Validate edtf string

### DIFF
--- a/data/856/323/73/85632373.geojson
+++ b/data/856/323/73/85632373.geojson
@@ -2,1591 +2,1592 @@
   "id": 85632373,
   "type": "Feature",
   "properties": {
-    "abrv:eng_x_preferred":[
-        "ARYM"
-    ],
-    "date:inception_lower":"1991-09-01",
-    "date:inception_upper":"1992-03-31",
-    "edtf:cessation":"uuuu",
-    "edtf:inception":"1991-09~/1992-03~",
-    "eurostat:country_code":"MK",
-    "eurostat:level_code":"2",
-    "eurostat:name_latin":"Severna Makedonija",
-    "eurostat:name_local":"\u0421\u0435\u0432\u0435\u0440\u043d\u0430 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u0458\u0430",
-    "eurostat:nuts_2021_id":"MK00",
-    "eurostat:nuts_2021_level_0":"MK",
-    "eurostat:nuts_2021_level_1":"MK0",
-    "eurostat:nuts_2021_level_2":"MK00",
-    "eurostat:population":1837114,
-    "eurostat:population_year":2022,
-    "geom:area":2.747592,
-    "geom:area_square_m":25405474830.881435,
-    "geom:bbox":"20.452423,40.853344,23.034093,42.37363",
-    "geom:latitude":41.600288,
-    "geom:longitude":21.700726,
-    "gn:population":2062294,
-    "iso:country":"MK",
-    "itu:country_code":[
-        "389"
-    ],
-    "label:eng_x_preferred_placetype":[
-        "country"
-    ],
-    "label:eng_x_preferred_shortcode":[
-        "MKD"
-    ],
-    "lbl:latitude":41.569245,
-    "lbl:longitude":21.547313,
-    "lbl:max_zoom":8.0,
-    "lbl:min_zoom":4.0,
-    "mps:latitude":41.569245,
-    "mps:longitude":21.547313,
-    "mz:hierarchy_label":1,
-    "mz:is_current":1,
-    "mz:max_zoom":10.0,
-    "mz:min_zoom":5.0,
-    "name:abk_x_preferred":[
-        "\u0410\u04a9\u0430\u0434\u0430\u0442\u04d9\u0438 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u0430"
-    ],
-    "name:ace_x_preferred":[
-        "Mak\u00e8donia Utara"
+    "abrv:eng_x_preferred": [
+      "ARYM"
+    ],
+    "date:inception_lower": "1991-09-01",
+    "date:inception_upper": "1992-03-31",
+    "edtf:cessation": "",
+    "edtf:inception": "1991-09-~01/1992-03-~31",
+    "eurostat:country_code": "MK",
+    "eurostat:level_code": "2",
+    "eurostat:name_latin": "Severna Makedonija",
+    "eurostat:name_local": "Северна Македонија",
+    "eurostat:nuts_2021_id": "MK00",
+    "eurostat:nuts_2021_level_0": "MK",
+    "eurostat:nuts_2021_level_1": "MK0",
+    "eurostat:nuts_2021_level_2": "MK00",
+    "eurostat:population": 1837114,
+    "eurostat:population_year": 2022,
+    "geom:area": 2.7475915813014997,
+    "geom:area_square_m": 25405474830.881435,
+    "geom:bbox": "20.452423,40.853344,23.034093,42.373630",
+    "geom:latitude": 41.6002880803743,
+    "geom:longitude": 21.700725816315344,
+    "gn:population": 2062294,
+    "iso:country": "MK",
+    "itu:country_code": [
+      "389"
+    ],
+    "label:eng_x_preferred_placetype": [
+      "country"
+    ],
+    "label:eng_x_preferred_shortcode": [
+      "MKD"
+    ],
+    "lbl:latitude": 41.569245,
+    "lbl:longitude": 21.547313,
+    "lbl:max_zoom": 8,
+    "lbl:min_zoom": 4,
+    "mps:latitude": 41.569245,
+    "mps:longitude": 21.547313,
+    "mz:hierarchy_label": 1,
+    "mz:is_current": 1,
+    "mz:max_zoom": 10,
+    "mz:min_zoom": 5,
+    "name:abk_x_preferred": [
+      "Аҩадатәи Македониа"
+    ],
+    "name:ace_x_preferred": [
+      "Makèdonia Utara"
     ],
-    "name:ady_x_preferred":[
-        "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u044d\u0443 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u0435"
+    "name:ady_x_preferred": [
+      "Республикэу Македоние"
     ],
-    "name:afr_x_historical":[
-        "Masedoni\u00eb (dubbelsinnig)",
-        "Macedoni\u00eb"
+    "name:afr_x_historical": [
+      "Masedonië (dubbelsinnig)",
+      "Macedonië"
     ],
-    "name:afr_x_preferred":[
-        "Republiek Noord-Masedoni\u00eb"
-    ],
-    "name:aka_x_historical":[
-        "Masedonia"
-    ],
-    "name:aka_x_preferred":[
-        "Republic of Macedonia"
+    "name:afr_x_preferred": [
+      "Republiek Noord-Masedonië"
+    ],
+    "name:aka_x_historical": [
+      "Masedonia"
+    ],
+    "name:aka_x_preferred": [
+      "Republic of Macedonia"
     ],
-    "name:amh_x_historical":[
-        "\u121b\u12a8\u12f6\u1292\u12eb"
+    "name:amh_x_historical": [
+      "ማከዶኒያ"
     ],
-    "name:amh_x_preferred":[
-        "\u12e8\u1218\u1244\u12f6\u1295\u12eb \u122c\u1351\u1265\u120a\u12ad"
+    "name:amh_x_preferred": [
+      "የመቄዶንያ ሬፑብሊክ"
     ],
-    "name:ami_x_preferred":[
-        "Macedonia"
+    "name:ami_x_preferred": [
+      "Macedonia"
     ],
-    "name:ang_x_preferred":[
-        "Cynew\u012bse Macedonia"
+    "name:ang_x_preferred": [
+      "Cynewīse Macedonia"
     ],
-    "name:anp_x_preferred":[
-        "\u0909\u0924\u094d\u0924\u0930 \u092e\u0948\u0938\u0947\u0921\u094b\u0928\u093f\u092f\u093e"
+    "name:anp_x_preferred": [
+      "उत्तर मैसेडोनिया"
     ],
-    "name:ara_x_historical":[
-        "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0645\u0642\u062f\u0648\u0646\u064a\u0627",
-        "\u0645\u0642\u062f\u0648\u0646\u064a\u0627"
+    "name:ara_x_historical": [
+      "جمهورية مقدونيا",
+      "مقدونيا"
     ],
-    "name:ara_x_preferred":[
-        "\u0645\u0642\u062f\u0648\u0646\u064a\u0627 \u0627\u0644\u0634\u0645\u0627\u0644\u064a\u0629"
+    "name:ara_x_preferred": [
+      "مقدونيا الشمالية"
     ],
-    "name:arc_x_historical":[
-        "\u0721\u0729\u0715\u0718\u0722\u071d\u0710"
+    "name:arc_x_historical": [
+      "ܡܩܕܘܢܝܐ"
     ],
-    "name:arc_x_preferred":[
-        "\u0729\u0718\u071b\u0722\u071d\u0718\u072c\u0710 \u0715\u0721\u0729\u0715\u0718\u0722\u071d\u0710"
+    "name:arc_x_preferred": [
+      "ܩܘܛܢܝܘܬܐ ܕܡܩܕܘܢܝܐ"
     ],
-    "name:arg_x_historical":[
-        "Macedonia"
+    "name:arg_x_historical": [
+      "Macedonia"
     ],
-    "name:arg_x_preferred":[
-        "Macedonia d'o Norte"
+    "name:arg_x_preferred": [
+      "Macedonia d'o Norte"
     ],
-    "name:ary_x_preferred":[
-        "\u0634\u0645\u0627\u0644 \u0645\u0642\u062f\u0648\u0646\u064a\u0627"
+    "name:ary_x_preferred": [
+      "شمال مقدونيا"
     ],
-    "name:arz_x_historical":[
-        "\u0645\u0642\u062f\u0648\u0646\u064a\u0627"
+    "name:arz_x_historical": [
+      "مقدونيا"
     ],
-    "name:arz_x_preferred":[
-        "\u062c\u0645\u0647\u0648\u0631\u064a\u0629 \u0645\u0642\u062f\u0648\u0646\u064a\u0627"
+    "name:arz_x_preferred": [
+      "جمهورية مقدونيا"
     ],
-    "name:ast_x_historical":[
-        "Macedonia (dixebra)",
-        "Rep\u00fablica de Macedonia"
+    "name:ast_x_historical": [
+      "Macedonia (dixebra)",
+      "República de Macedonia"
     ],
-    "name:ast_x_preferred":[
-        "Macedonia del Norte"
+    "name:ast_x_preferred": [
+      "Macedonia del Norte"
     ],
-    "name:ava_x_preferred":[
-        "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f"
+    "name:ava_x_preferred": [
+      "Республика Македония"
     ],
-    "name:avk_x_preferred":[
-        "Makedonia"
+    "name:avk_x_preferred": [
+      "Makedonia"
     ],
-    "name:awa_x_preferred":[
-        "\u0909\u0924\u094d\u0924\u0930 \u092e\u0948\u0938\u093f\u0921\u094b\u0928\u093f\u092f\u093e"
+    "name:awa_x_preferred": [
+      "उत्तर मैसिडोनिया"
     ],
-    "name:azb_x_historical":[
-        "\u0645\u0642\u062f\u0648\u0646\u06cc\u0647",
-        "\u0645\u0648\u0644\u062f\u0627\u0648\u06cc"
+    "name:azb_x_historical": [
+      "مقدونیه",
+      "مولداوی"
     ],
-    "name:azb_x_preferred":[
-        "\u0634\u0648\u0645\u0627\u0644\u06cc \u0645\u0642\u062f\u0648\u0646\u06cc\u0647"
+    "name:azb_x_preferred": [
+      "شومالی مقدونیه"
     ],
-    "name:aze_x_historical":[
-        "Makedoniya",
-        "Masedoniya"
+    "name:aze_x_historical": [
+      "Makedoniya",
+      "Masedoniya"
     ],
-    "name:aze_x_preferred":[
-        "\u015eimali Makedoniya"
+    "name:aze_x_preferred": [
+      "Şimali Makedoniya"
     ],
-    "name:bak_x_preferred":[
-        "\u0422\u04e9\u043d\u044c\u044f\u04a1 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f"
+    "name:bak_x_preferred": [
+      "Төньяҡ Македония"
     ],
-    "name:ban_x_preferred":[
-        "Macedonia Utara"
+    "name:ban_x_preferred": [
+      "Macedonia Utara"
     ],
-    "name:bar_x_historical":[
-        "Mazedonien (Begriffskl\u00e4rung)"
+    "name:bar_x_historical": [
+      "Mazedonien (Begriffsklärung)"
     ],
-    "name:bar_x_preferred":[
-        "Noadmazedonien"
+    "name:bar_x_preferred": [
+      "Noadmazedonien"
     ],
-    "name:bcl_x_preferred":[
-        "Republika kan Masedonya"
+    "name:bcl_x_preferred": [
+      "Republika kan Masedonya"
     ],
-    "name:bel_x_historical":[
-        "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0456\u044f, \u0437\u043d\u0430\u0447\u044d\u043d\u043d\u0456",
-        "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0456\u044f",
-        "\u0420\u044d\u0441\u043f\u0443\u0431\u043b\u0456\u043a\u0430 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0456\u044f",
-        "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0456\u044f, \u0411\u042e\u0420"
+    "name:bel_x_historical": [
+      "Македонія, значэнні",
+      "Македонія",
+      "Рэспубліка Македонія",
+      "Македонія, БЮР"
     ],
-    "name:bel_x_preferred":[
-        "\u041f\u0430\u045e\u043d\u043e\u0447\u043d\u0430\u044f \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0456\u044f"
+    "name:bel_x_preferred": [
+      "Паўночная Македонія"
     ],
-    "name:ben_x_historical":[
-        "\u09ae\u09cd\u09af\u09be\u09b8\u09be\u09a1\u09cb\u09a8\u09bf\u09af\u09bc\u09be",
-        "\u0989\u09a4\u09cd\u09a4\u09b0 \u09ae\u09cd\u09af\u09be\u09b8\u09c7\u09a1\u09cb\u09a8\u09bf\u09af\u09bc\u09be"
+    "name:ben_x_historical": [
+      "ম্যাসাডোনিয়া",
+      "উত্তর ম্যাসেডোনিয়া"
     ],
-    "name:ben_x_preferred":[
-        "\u0989\u09a4\u09cd\u09a4\u09b0 \u09ae\u09c7\u09b8\u09bf\u09a1\u09cb\u09a8\u09bf\u09af\u09bc\u09be"
+    "name:ben_x_preferred": [
+      "উত্তর মেসিডোনিয়া"
     ],
-    "name:bho_x_preferred":[
-        "\u092e\u0947\u0938\u0940\u0921\u094b\u0928\u093f\u092f\u093e"
+    "name:bho_x_preferred": [
+      "मेसीडोनिया"
     ],
-    "name:bho_x_variant":[
-        "\u0909\u0924\u094d\u0924\u0930 \u092e\u0948\u0938\u0940\u0921\u094b\u0928\u093f\u092f\u093e"
+    "name:bho_x_variant": [
+      "उत्तर मैसीडोनिया"
     ],
-    "name:bis_x_preferred":[
-        "Not Macedonia"
+    "name:bis_x_preferred": [
+      "Not Macedonia"
     ],
-    "name:bis_x_variant":[
-        "Not Masedonia"
+    "name:bis_x_variant": [
+      "Not Masedonia"
     ],
-    "name:bod_x_preferred":[
-        "\u0f58\u0f0b\u0f66\u0f7a\u0f0b\u0f4c\u0f7c\u0f0b\u0f53\u0f72\u0f61\u0f0d"
+    "name:bod_x_preferred": [
+      "མ་སེ་ཌོ་ནིཡ།"
     ],
-    "name:bos_x_historical":[
-        "Makedonija (\u010dvor)",
-        "Republika Makedonija",
-        "Makedonija"
+    "name:bos_x_historical": [
+      "Makedonija (čvor)",
+      "Republika Makedonija",
+      "Makedonija"
     ],
-    "name:bos_x_preferred":[
-        "Sjeverna Makedonija"
+    "name:bos_x_preferred": [
+      "Sjeverna Makedonija"
     ],
-    "name:bpy_x_preferred":[
-        "\u09ae\u09c7\u09b8\u09bf\u09a1\u09cb\u09a8\u09bf\u09af\u09bc\u09be"
+    "name:bpy_x_preferred": [
+      "মেসিডোনিয়া"
     ],
-    "name:bre_x_historical":[
-        "Republik Makedonia",
-        "Makedonia"
+    "name:bre_x_historical": [
+      "Republik Makedonia",
+      "Makedonia"
     ],
-    "name:bre_x_preferred":[
-        "Makedonia an Norzh"
+    "name:bre_x_preferred": [
+      "Makedonia an Norzh"
     ],
-    "name:bul_x_historical":[
-        "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f",
-        "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f, \u0420\u0435\u043f\u0443\u0431\u043b\u0438\u043a\u0430",
-        "\u0420\u0435\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f"
+    "name:bul_x_historical": [
+      "Македония",
+      "Македония, Република",
+      "Република Македония"
     ],
-    "name:bul_x_preferred":[
-        "\u0421\u0435\u0432\u0435\u0440\u043d\u0430 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f"
+    "name:bul_x_preferred": [
+      "Северна Македония"
     ],
-    "name:bxr_x_preferred":[
-        "\u0425\u043e\u0439\u0442\u043e \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438"
+    "name:bxr_x_preferred": [
+      "Хойто Македони"
     ],
-    "name:cat_x_historical":[
-        "Maced\u00f2nia",
-        "Rep\u00fablica de Maced\u00f2nia"
+    "name:cat_x_historical": [
+      "Macedònia",
+      "República de Macedònia"
     ],
-    "name:cat_x_preferred":[
-        "Maced\u00f2nia del Nord"
+    "name:cat_x_preferred": [
+      "Macedònia del Nord"
     ],
-    "name:cdo_x_preferred":[
-        "B\u00e1e\u0324k M\u0101-g\u00ec-d\u00f3ng"
+    "name:cdo_x_preferred": [
+      "Báe̤k Mā-gì-dóng"
     ],
-    "name:ceb_x_historical":[
-        "Macedonia (pagklaro)"
+    "name:ceb_x_historical": [
+      "Macedonia (pagklaro)"
     ],
-    "name:ceb_x_preferred":[
-        "Republika sa Amihanan Makedoniya"
+    "name:ceb_x_preferred": [
+      "Republika sa Amihanan Makedoniya"
     ],
-    "name:ces_x_historical":[
-        "Makedonie (rozcestn\u00edk)",
-        "Macedonia",
-        "Republika Makedonie",
-        "Makedonie"
+    "name:ces_x_historical": [
+      "Makedonie (rozcestník)",
+      "Macedonia",
+      "Republika Makedonie",
+      "Makedonie"
     ],
-    "name:ces_x_preferred":[
-        "Severn\u00ed Makedonie"
+    "name:ces_x_preferred": [
+      "Severní Makedonie"
     ],
-    "name:che_x_historical":[
-        "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438"
+    "name:che_x_historical": [
+      "Македони"
     ],
-    "name:che_x_preferred":[
-        "\u041a\u044a\u0438\u043b\u0431\u0430\u0441\u0435\u0434\u0430 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438"
+    "name:che_x_preferred": [
+      "Къилбаседа Македони"
     ],
-    "name:chr_x_preferred":[
-        "\u13b9\u13ce\u13d9\u13c2\u13ef"
+    "name:chr_x_preferred": [
+      "ᎹᏎᏙᏂᏯ"
     ],
-    "name:chu_x_historical":[
-        "\u041c\u0430\u043a\u0454\u0434\u043e\u043d\u0457\ua657 \u00b7 \u0441\u044a\u043c\ua651\u0441\u043b\u0438"
+    "name:chu_x_historical": [
+      "Макєдонїꙗ · съмꙑсли"
     ],
-    "name:chu_x_preferred":[
-        "\u0421\u0463\u0432\u0454\u0440\u044c\u043d\u0430 \u041c\u0430\u043a\u0454\u0434\u043e\u043d\u0457\ua657"
+    "name:chu_x_preferred": [
+      "Сѣвєрьна Макєдонїꙗ"
     ],
-    "name:chv_x_historical":[
-        "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438 \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0438"
+    "name:chv_x_historical": [
+      "Македони Республики"
     ],
-    "name:chv_x_preferred":[
-        "\u00c7\u0443\u0440\u00e7\u0115\u0440 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438"
+    "name:chv_x_preferred": [
+      "Çурçĕр Македони"
     ],
-    "name:ckb_x_preferred":[
-        "\u06a9\u06c6\u0645\u0627\u0631\u06cc \u0645\u06d5\u0642\u062f\u0648\u0648\u0646\u06cc\u0627"
+    "name:ckb_x_preferred": [
+      "کۆماری مەقدوونیا"
     ],
-    "name:cor_x_preferred":[
-        "Repoblek Makedoni"
+    "name:cor_x_preferred": [
+      "Repoblek Makedoni"
     ],
-    "name:crh_x_historical":[
-        "Makedoniya"
+    "name:crh_x_historical": [
+      "Makedoniya"
     ],
-    "name:crh_x_preferred":[
-        "\u015eimaliy Makedoniya"
+    "name:crh_x_preferred": [
+      "Şimaliy Makedoniya"
     ],
-    "name:csb_x_preferred":[
-        "Nordow\u00f4 Macedo\u0144sk\u00f4"
+    "name:csb_x_preferred": [
+      "Nordowô Macedońskô"
     ],
-    "name:cym_x_historical":[
-        "Macedonia",
-        "Gweriniaeth Macedonia"
+    "name:cym_x_historical": [
+      "Macedonia",
+      "Gweriniaeth Macedonia"
     ],
-    "name:cym_x_preferred":[
-        "Gogledd Macedonia"
+    "name:cym_x_preferred": [
+      "Gogledd Macedonia"
     ],
-    "name:dag_x_preferred":[
-        "Macedonia"
+    "name:dag_x_preferred": [
+      "Macedonia"
     ],
-    "name:dan_x_historical":[
-        "Makedonien",
-        "Republikken Makedonien",
-        "Tidligere jugoslaviske republik Makedonien",
-        "Tidligere Jugoslaviske Republik Makedonien"
+    "name:dan_x_historical": [
+      "Makedonien",
+      "Republikken Makedonien",
+      "Tidligere jugoslaviske republik Makedonien",
+      "Tidligere Jugoslaviske Republik Makedonien"
     ],
-    "name:dan_x_preferred":[
-        "Nordmakedonien"
+    "name:dan_x_preferred": [
+      "Nordmakedonien"
     ],
-    "name:deu_x_historical":[
-        "Mazedonien (Begriffskl\u00e4rung)",
-        "Mazedonien",
-        "Ehemalige Jugoslawische Republik Mazedonien",
-        "Ehemalige jugoslawische Republik Mazedonien"
+    "name:deu_x_historical": [
+      "Mazedonien (Begriffsklärung)",
+      "Mazedonien",
+      "Ehemalige Jugoslawische Republik Mazedonien",
+      "Ehemalige jugoslawische Republik Mazedonien"
     ],
-    "name:deu_x_preferred":[
-        "Nordmazedonien"
+    "name:deu_x_preferred": [
+      "Nordmazedonien"
     ],
-    "name:diq_x_historical":[
-        "Cumur\u00eat\u00ea Makedonya"
+    "name:diq_x_historical": [
+      "Cumurêtê Makedonya"
     ],
-    "name:diq_x_preferred":[
-        "Makedonya Z\u0131mey"
+    "name:diq_x_preferred": [
+      "Makedonya Zımey"
     ],
-    "name:div_x_preferred":[
-        "\u0789\u07ac\u0790\u07ac\u0791\u07af\u0782\u07a8\u0787\u07a7"
+    "name:div_x_preferred": [
+      "މެސެޑޯނިއާ"
     ],
-    "name:dsb_x_historical":[
-        "Makedo\u0144ska"
+    "name:dsb_x_historical": [
+      "Makedońska"
     ],
-    "name:dsb_x_preferred":[
-        "P\u00f3dpo\u0142nocna Makedo\u0144ska"
+    "name:dsb_x_preferred": [
+      "Pódpołnocna Makedońska"
     ],
-    "name:dty_x_preferred":[
-        "\u092e\u094d\u092f\u093e\u0938\u0947\u0921\u094b\u0928\u093f\u092f\u093e"
+    "name:dty_x_preferred": [
+      "म्यासेडोनिया"
     ],
-    "name:ell_x_historical":[
-        "\u039c\u03b1\u03ba\u03b5\u03b4\u03bf\u03bd\u03af\u03b1 (\u03b1\u03c0\u03bf\u03c3\u03b1\u03c6\u03ae\u03bd\u03b9\u03c3\u03b7)",
-        "\u03a0\u0393\u0394 \u039c\u03b1\u03ba\u03b5\u03b4\u03bf\u03bd\u03af\u03b1\u03c2",
-        "\u03a0\u03c1\u03ce\u03b7\u03bd \u0393\u03b9\u03bf\u03c5\u03b3\u03ba\u03bf\u03c3\u03bb\u03b1\u03b2\u03b9\u03ba\u03ae \u0394\u03b7\u03bc\u03bf\u03ba\u03c1\u03b1\u03c4\u03af\u03b1 \u03c4\u03b7\u03c2 \u039c\u03b1\u03ba\u03b5\u03b4\u03bf\u03bd\u03af\u03b1\u03c2",
-        "\u03a0.\u0393.\u0394. \u039c\u03b1\u03ba\u03b5\u03b4\u03bf\u03bd\u03af\u03b1\u03c2"
+    "name:ell_x_historical": [
+      "Μακεδονία (αποσαφήνιση)",
+      "ΠΓΔ Μακεδονίας",
+      "Πρώην Γιουγκοσλαβική Δημοκρατία της Μακεδονίας",
+      "Π.Γ.Δ. Μακεδονίας"
     ],
-    "name:ell_x_preferred":[
-        "\u0392\u03cc\u03c1\u03b5\u03b9\u03b1 \u039c\u03b1\u03ba\u03b5\u03b4\u03bf\u03bd\u03af\u03b1"
+    "name:ell_x_preferred": [
+      "Βόρεια Μακεδονία"
     ],
-    "name:eng_x_colloquial":[
-        "Macedonia (FYR)",
-        "Macedonia, The Former Yugoslav Republic Of"
+    "name:eng_x_colloquial": [
+      "Macedonia (FYR)",
+      "Macedonia, The Former Yugoslav Republic Of"
     ],
-    "name:eng_x_historical":[
-        "Macedonia",
-        "F.Y.R.O. Macedonia",
-        "FYR of Macedonia",
-        "Former Yugoslav Republic of Macedonia",
-        "Macedonian",
-        "Rep. Macedonia",
-        "Republic of Macedonia",
-        "The FYR of Macedonia",
-        "The Former Yugoslav Republic of Macedonia",
-        "Macedonia (FYR)",
-        "Macedonia, The Former Yugoslav Republic Of"
+    "name:eng_x_historical": [
+      "Macedonia",
+      "F.Y.R.O. Macedonia",
+      "FYR of Macedonia",
+      "Former Yugoslav Republic of Macedonia",
+      "Macedonian",
+      "Rep. Macedonia",
+      "Republic of Macedonia",
+      "The FYR of Macedonia",
+      "The Former Yugoslav Republic of Macedonia",
+      "Macedonia (FYR)",
+      "Macedonia, The Former Yugoslav Republic Of"
     ],
-    "name:eng_x_preferred":[
-        "North Macedonia"
+    "name:eng_x_preferred": [
+      "North Macedonia"
     ],
-    "name:eng_x_unknown":[
-        "MK",
-        "MKD"
+    "name:eng_x_unknown": [
+      "MK",
+      "MKD"
     ],
-    "name:epo_x_historical":[
-        "Makedonio",
-        "Makedonujo",
-        "Respubliko Makedonio"
+    "name:epo_x_historical": [
+      "Makedonio",
+      "Makedonujo",
+      "Respubliko Makedonio"
     ],
-    "name:epo_x_preferred":[
-        "Nord-Makedonio"
+    "name:epo_x_preferred": [
+      "Nord-Makedonio"
     ],
-    "name:est_x_historical":[
-        "Makedoonia Vabariik",
-        "Makedoonia"
+    "name:est_x_historical": [
+      "Makedoonia Vabariik",
+      "Makedoonia"
     ],
-    "name:est_x_preferred":[
-        "P\u00f5hja-Makedoonia"
+    "name:est_x_preferred": [
+      "Põhja-Makedoonia"
     ],
-    "name:eus_x_historical":[
-        "Mazedonia (argipena)",
-        "Mazedonia",
-        "Mazedoniako Errepublika"
+    "name:eus_x_historical": [
+      "Mazedonia (argipena)",
+      "Mazedonia",
+      "Mazedoniako Errepublika"
     ],
-    "name:eus_x_preferred":[
-        "Ipar Mazedonia"
+    "name:eus_x_preferred": [
+      "Ipar Mazedonia"
     ],
-    "name:ewe_x_historical":[
-        "Makedonia nutome"
+    "name:ewe_x_historical": [
+      "Makedonia nutome"
     ],
-    "name:ewe_x_preferred":[
-        "North Macedonia"
+    "name:ewe_x_preferred": [
+      "North Macedonia"
     ],
-    "name:ext_x_preferred":[
-        "Maced\u00f3nia del Norti"
+    "name:ext_x_preferred": [
+      "Macedónia del Norti"
     ],
-    "name:fao_x_historical":[
-        "Maked\u00f3nia"
+    "name:fao_x_historical": [
+      "Makedónia"
     ],
-    "name:fao_x_preferred":[
-        "L\u00fd\u00f0veldi\u00f0 Maked\u00f3nia"
+    "name:fao_x_preferred": [
+      "Lýðveldið Makedónia"
     ],
-    "name:fas_x_historical":[
-        "\u0645\u0642\u062f\u0648\u0646\u06cc\u0647",
-        "\u0645\u06a9\u062f\u0648\u0646\u06cc\u0627"
+    "name:fas_x_historical": [
+      "مقدونیه",
+      "مکدونیا"
     ],
-    "name:fas_x_preferred":[
-        "\u0645\u0642\u062f\u0648\u0646\u06cc\u0647 \u0634\u0645\u0627\u0644\u06cc"
+    "name:fas_x_preferred": [
+      "مقدونیه شمالی"
     ],
-    "name:fin_x_historical":[
-        "Makedonia",
-        "Macedonia (t\u00e4smennyssivu)",
-        "Entinen Jugoslavian tasavalta Makedonia",
-        "Makedonian tasavalta",
-        "Makedonian valtakunta"
+    "name:fin_x_historical": [
+      "Makedonia",
+      "Macedonia (täsmennyssivu)",
+      "Entinen Jugoslavian tasavalta Makedonia",
+      "Makedonian tasavalta",
+      "Makedonian valtakunta"
     ],
-    "name:fin_x_preferred":[
-        "Pohjois-Makedonia"
+    "name:fin_x_preferred": [
+      "Pohjois-Makedonia"
     ],
-    "name:fra_x_colloquial":[
-        "Macedoine"
+    "name:fra_x_colloquial": [
+      "Macedoine"
     ],
-    "name:fra_x_historical":[
-        "Macedonia",
-        "Ancienne r\u00e9publique yougoslave de Mac\u00e9doine",
-        "Mac\u00e9doine"
+    "name:fra_x_historical": [
+      "Macedonia",
+      "Ancienne république yougoslave de Macédoine",
+      "Macédoine"
     ],
-    "name:fra_x_preferred":[
-        "Mac\u00e9doine du Nord"
+    "name:fra_x_preferred": [
+      "Macédoine du Nord"
     ],
-    "name:frp_x_historical":[
-        "R\u00e8publica de Mac\u00e8donie"
+    "name:frp_x_historical": [
+      "Rèpublica de Macèdonie"
     ],
-    "name:frp_x_preferred":[
-        "Mac\u00e8donie du Nord"
+    "name:frp_x_preferred": [
+      "Macèdonie du Nord"
     ],
-    "name:frr_x_preferred":[
-        "Nuurd-Matsedoonien"
+    "name:frr_x_preferred": [
+      "Nuurd-Matsedoonien"
     ],
-    "name:fry_x_historical":[
-        "Masedoanje"
+    "name:fry_x_historical": [
+      "Masedoanje"
     ],
-    "name:fry_x_preferred":[
-        "Noard-Masedoanje"
+    "name:fry_x_preferred": [
+      "Noard-Masedoanje"
     ],
-    "name:ful_x_historical":[
-        "Meceduwaan"
+    "name:ful_x_historical": [
+      "Meceduwaan"
     ],
-    "name:ful_x_preferred":[
-        "Masedoniya"
+    "name:ful_x_preferred": [
+      "Masedoniya"
     ],
-    "name:fur_x_historical":[
-        "Macedonie"
+    "name:fur_x_historical": [
+      "Macedonie"
     ],
-    "name:fur_x_preferred":[
-        "Macedonie dal Nort"
+    "name:fur_x_preferred": [
+      "Macedonie dal Nort"
     ],
-    "name:gag_x_preferred":[
-        "Poyraz Makedoniya"
+    "name:gag_x_preferred": [
+      "Poyraz Makedoniya"
     ],
-    "name:gcr_x_preferred":[
-        "Mas\u00e9dwann"
+    "name:gcr_x_preferred": [
+      "Masédwann"
     ],
-    "name:gla_x_preferred":[
-        "Poblachd na Masadoine"
+    "name:gla_x_preferred": [
+      "Poblachd na Masadoine"
     ],
-    "name:gle_x_historical":[
-        "An Mhacad\u00f3in"
+    "name:gle_x_historical": [
+      "An Mhacadóin"
     ],
-    "name:gle_x_preferred":[
-        "An Mhacad\u00f3in Thuaidh"
+    "name:gle_x_preferred": [
+      "An Mhacadóin Thuaidh"
     ],
-    "name:glv_x_preferred":[
-        "Pobblaght y Vassadoan Hwoaie"
+    "name:glv_x_preferred": [
+      "Pobblaght y Vassadoan Hwoaie"
     ],
-    "name:gom_x_preferred":[
-        "\u092e\u0945\u0938\u093f\u0921\u094b\u0928\u093f\u092f\u093e"
+    "name:gom_x_preferred": [
+      "मॅसिडोनिया"
     ],
-    "name:got_x_preferred":[
-        "\ud800\udf3c\ud800\udf30\ud800\udf3a\ud800\udf30\ud800\udf39\ud800\udf33\ud800\udf49\ud800\udf3d\ud800\udf3e\ud800\udf30"
+    "name:got_x_preferred": [
+      "𐌼𐌰𐌺𐌰𐌹𐌳𐍉𐌽𐌾𐌰"
     ],
-    "name:gpe_x_preferred":[
-        "Macedonia"
+    "name:gpe_x_preferred": [
+      "Macedonia"
     ],
-    "name:grn_x_preferred":[
-        "Yvate Masendo\u00f1a"
+    "name:grn_x_preferred": [
+      "Yvate Masendoña"
     ],
-    "name:gsw_x_preferred":[
-        "Republik Mazedonie"
+    "name:gsw_x_preferred": [
+      "Republik Mazedonie"
     ],
-    "name:guj_x_preferred":[
-        "\u0aae\u0ac7\u0ab8\u0ac7\u0aa1\u0acb\u0aa8\u0abf\u0aaf\u0abe"
+    "name:guj_x_preferred": [
+      "મેસેડોનિયા"
     ],
-    "name:hak_x_preferred":[
-        "Pet Macedonia"
+    "name:hak_x_preferred": [
+      "Pet Macedonia"
     ],
-    "name:hat_x_preferred":[
-        "Repiblik d Masedoni"
+    "name:hat_x_preferred": [
+      "Repiblik d Masedoni"
     ],
-    "name:hau_x_historical":[
-        "Masedoniya"
+    "name:hau_x_historical": [
+      "Masedoniya"
     ],
-    "name:hau_x_preferred":[
-        "Masadoiniya ta Arewa"
+    "name:hau_x_preferred": [
+      "Masadoiniya ta Arewa"
     ],
-    "name:haw_x_preferred":[
-        "Repupalika o \u2018\u0100kau Masedonia"
+    "name:haw_x_preferred": [
+      "Repupalika o ‘Ākau Masedonia"
     ],
-    "name:heb_x_historical":[
-        "\u05de\u05e7\u05d3\u05d5\u05e0\u05d9\u05d4 (\u05e4\u05d9\u05e8\u05d5\u05e9\u05d5\u05e0\u05d9\u05dd)",
-        "\u05de\u05e7\u05d3\u05d5\u05e0\u05d9\u05d4"
+    "name:heb_x_historical": [
+      "מקדוניה (פירושונים)",
+      "מקדוניה"
     ],
-    "name:heb_x_preferred":[
-        "\u05de\u05e7\u05d3\u05d5\u05e0\u05d9\u05d4 \u05d4\u05e6\u05e4\u05d5\u05e0\u05d9\u05ea"
+    "name:heb_x_preferred": [
+      "מקדוניה הצפונית"
     ],
-    "name:hif_x_preferred":[
-        "Republic of Macedonia"
+    "name:hif_x_preferred": [
+      "Republic of Macedonia"
     ],
-    "name:hin_x_historical":[
-        "\u092e\u0948\u0938\u0947\u0921\u094b\u0928\u093f\u092f\u093e",
-        "\u092e\u0948\u0938\u093f\u0921\u094b\u0928\u093f\u092f\u093e"
+    "name:hin_x_historical": [
+      "मैसेडोनिया",
+      "मैसिडोनिया"
     ],
-    "name:hin_x_preferred":[
-        "\u0909\u0924\u094d\u0924\u0930 \u092e\u0948\u0938\u093f\u0921\u094b\u0928\u093f\u092f\u093e"
+    "name:hin_x_preferred": [
+      "उत्तर मैसिडोनिया"
     ],
-    "name:hrv_x_historical":[
-        "Makedonija (razdvojba)",
-        "Makedonija, Republika",
-        "Republika Makedonija",
-        "Makedonija"
+    "name:hrv_x_historical": [
+      "Makedonija (razdvojba)",
+      "Makedonija, Republika",
+      "Republika Makedonija",
+      "Makedonija"
     ],
-    "name:hrv_x_preferred":[
-        "Sjeverna Makedonija"
+    "name:hrv_x_preferred": [
+      "Sjeverna Makedonija"
     ],
-    "name:hsb_x_historical":[
-        "Makedonska"
+    "name:hsb_x_historical": [
+      "Makedonska"
     ],
-    "name:hsb_x_preferred":[
-        "Sewjerna Makedonska"
+    "name:hsb_x_preferred": [
+      "Sewjerna Makedonska"
     ],
-    "name:hun_x_historical":[
-        "Maced\u00f3nia",
-        "Macedonia (egy\u00e9rtelm\u0171s\u00edt\u0151 lap)",
-        "Maced\u00f3n K\u00f6zt\u00e1rsas\u00e1g",
-        "Maced\u00f3nia, K\u00f6zt\u00e1rsas\u00e1g",
-        "Maked\u00f3nia"
+    "name:hun_x_historical": [
+      "Macedónia",
+      "Macedonia (egyértelműsítő lap)",
+      "Macedón Köztársaság",
+      "Macedónia, Köztársaság",
+      "Makedónia"
     ],
-    "name:hun_x_preferred":[
-        "\u00c9szak-Maced\u00f3nia"
+    "name:hun_x_preferred": [
+      "Észak-Macedónia"
     ],
-    "name:hye_x_historical":[
-        "\u0544\u0561\u056f\u0565\u0564\u0578\u0576\u056b\u0561 (\u0561\u0575\u056c \u056f\u056b\u0580\u0561\u057c\u0578\u0582\u0574\u0576\u0565\u0580)",
-        "\u0544\u0561\u056f\u0565\u0564\u0578\u0576\u056b\u0561"
+    "name:hye_x_historical": [
+      "Մակեդոնիա (այլ կիրառումներ)",
+      "Մակեդոնիա"
     ],
-    "name:hye_x_preferred":[
-        "\u0540\u0575\u0578\u0582\u057d\u056b\u057d\u0561\u0575\u056b\u0576 \u0544\u0561\u056f\u0565\u0564\u0578\u0576\u056b\u0561"
+    "name:hye_x_preferred": [
+      "Հյուսիսային Մակեդոնիա"
     ],
-    "name:ibo_x_preferred":[
-        "Macedonia"
+    "name:ibo_x_preferred": [
+      "Macedonia"
     ],
-    "name:ido_x_historical":[
-        "Republiko Macedonia"
+    "name:ido_x_historical": [
+      "Republiko Macedonia"
     ],
-    "name:ido_x_preferred":[
-        "Republiko Norda-Macedonia"
+    "name:ido_x_preferred": [
+      "Republiko Norda-Macedonia"
     ],
-    "name:ile_x_historical":[
-        "Macedonia"
+    "name:ile_x_historical": [
+      "Macedonia"
     ],
-    "name:ile_x_preferred":[
-        "Nord-Macedonia"
+    "name:ile_x_preferred": [
+      "Nord-Macedonia"
     ],
-    "name:ilo_x_preferred":[
-        "Amianan a Macedonia"
+    "name:ilo_x_preferred": [
+      "Amianan a Macedonia"
     ],
-    "name:ind_x_historical":[
-        "Macedonia",
-        "Republik Makedonia",
-        "Makedonia"
+    "name:ind_x_historical": [
+      "Macedonia",
+      "Republik Makedonia",
+      "Makedonia"
     ],
-    "name:ind_x_preferred":[
-        "Republik Makedonia Utara"
+    "name:ind_x_preferred": [
+      "Republik Makedonia Utara"
     ],
-    "name:ind_x_variant":[
-        "Makedonia Utara"
+    "name:ind_x_variant": [
+      "Makedonia Utara"
     ],
-    "name:isl_x_historical":[
-        "Maked\u00f3n\u00eda",
-        "L\u00fd\u00f0veldi\u00f0 Maked\u00f3n\u00eda"
+    "name:isl_x_historical": [
+      "Makedónía",
+      "Lýðveldið Makedónía"
     ],
-    "name:isl_x_preferred":[
-        "Nor\u00f0ur-Maked\u00f3n\u00eda"
+    "name:isl_x_preferred": [
+      "Norður-Makedónía"
     ],
-    "name:ita_x_historical":[
-        "Repubblica di Macedonia",
-        "Macedonia",
-        "Macedonia, Ex Repubblica Jugoslava",
-        "Macedonia, Repubblica",
-        "Ex Repubblica Jugoslava di Macedonia"
+    "name:ita_x_historical": [
+      "Repubblica di Macedonia",
+      "Macedonia",
+      "Macedonia, Ex Repubblica Jugoslava",
+      "Macedonia, Repubblica",
+      "Ex Repubblica Jugoslava di Macedonia"
     ],
-    "name:ita_x_preferred":[
-        "Macedonia del Nord"
+    "name:ita_x_preferred": [
+      "Macedonia del Nord"
     ],
-    "name:jam_x_historical":[
-        "Masiduonia"
+    "name:jam_x_historical": [
+      "Masiduonia"
     ],
-    "name:jam_x_preferred":[
-        "Ripoblik a Masiduonia"
+    "name:jam_x_preferred": [
+      "Ripoblik a Masiduonia"
     ],
-    "name:jav_x_preferred":[
-        "R\u00e9publik Makedonia"
+    "name:jav_x_preferred": [
+      "Républik Makedonia"
     ],
-    "name:jpn_x_historical":[
-        "\u30de\u30b1\u30c9\u30cb\u30a2",
-        "\u30de\u30b1\u30c9\u30cb\u30a2 (\u66d6\u6627\u3055\u56de\u907f)",
-        "\u30de\u30b1\u30c9\u30cb\u30a2\u5171\u548c\u56fd",
-        "\u30de\u30b1\u30c9\u30cb\u30a2\u65e7\u30e6\u30fc\u30b4\u30b9\u30e9\u30d3\u30a2\u5171\u548c\u56fd"
+    "name:jpn_x_historical": [
+      "マケドニア",
+      "マケドニア (曖昧さ回避)",
+      "マケドニア共和国",
+      "マケドニア旧ユーゴスラビア共和国"
     ],
-    "name:jpn_x_preferred":[
-        "\u5317\u30de\u30b1\u30c9\u30cb\u30a2"
+    "name:jpn_x_preferred": [
+      "北マケドニア"
     ],
-    "name:kaa_x_preferred":[
-        "Makedoniya"
+    "name:kaa_x_preferred": [
+      "Makedoniya"
     ],
-    "name:kal_x_preferred":[
-        "Makedonia"
+    "name:kal_x_preferred": [
+      "Makedonia"
     ],
-    "name:kan_x_historical":[
-        "\u0cae\u0ccd\u0caf\u0cbe\u0cb8\u0cbf\u0ca1\u0ccb\u0ca8\u0cbf\u0caf\u0cbe",
-        "\u0cae\u0ccd\u0caf\u0cbe\u0cb8\u0cc6\u0ca1\u0cca\u0ca8\u0cbf\u0caf \u0c97\u0ca3\u0cb0\u0cbe\u0c9c\u0ccd\u0caf"
+    "name:kan_x_historical": [
+      "ಮ್ಯಾಸಿಡೋನಿಯಾ",
+      "ಮ್ಯಾಸೆಡೊನಿಯ ಗಣರಾಜ್ಯ"
     ],
-    "name:kan_x_preferred":[
-        "\u0c89\u0ca4\u0ccd\u0ca4\u0cb0 \u0cae\u0ccd\u0caf\u0cbe\u0cb8\u0cc6\u0ca1\u0cca\u0ca8\u0cbf\u0caf"
+    "name:kan_x_preferred": [
+      "ಉತ್ತರ ಮ್ಯಾಸೆಡೊನಿಯ"
     ],
-    "name:kat_x_historical":[
-        "\u10db\u10d0\u10d9\u10d4\u10d3\u10dd\u10dc\u10d8\u10d0 (\u10db\u10e0\u10d0\u10d5\u10d0\u10da\u10db\u10dc\u10d8\u10e8\u10d5\u10dc\u10d4\u10da\u10dd\u10d5\u10d0\u10dc\u10d8)",
-        "\u10db\u10d0\u10d9\u10d4\u10d3\u10dd\u10dc\u10d8\u10d0"
+    "name:kat_x_historical": [
+      "მაკედონია (მრავალმნიშვნელოვანი)",
+      "მაკედონია"
     ],
-    "name:kat_x_preferred":[
-        "\u10e9\u10e0\u10d3\u10d8\u10da\u10dd\u10d4\u10d7\u10d8 \u10db\u10d0\u10d9\u10d4\u10d3\u10dd\u10dc\u10d8\u10d0"
+    "name:kat_x_preferred": [
+      "ჩრდილოეთი მაკედონია"
     ],
-    "name:kaz_x_historical":[
-        "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430\u0441\u044b"
+    "name:kaz_x_historical": [
+      "Македония Республикасы"
     ],
-    "name:kaz_x_preferred":[
-        "\u0421\u043e\u043b\u0442\u04af\u0441\u0442\u0456\u043a \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f"
+    "name:kaz_x_preferred": [
+      "Солтүстік Македония"
     ],
-    "name:kbd_x_preferred":[
-        "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u044d \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044d"
+    "name:kbd_x_preferred": [
+      "Республикэ Македониэ"
     ],
-    "name:kbd_x_variant":[
-        "\u0418\u0448\u044a\u0445\u044a\u044d\u0440\u044d \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044d"
+    "name:kbd_x_variant": [
+      "Ишъхъэрэ Македониэ"
     ],
-    "name:khm_x_historical":[
-        "\u1798\u17c9\u17b6\u179f\u17c1\u178a\u1793"
+    "name:khm_x_historical": [
+      "ម៉ាសេដន"
     ],
-    "name:khm_x_preferred":[
-        "\u1798\u17c9\u17b6\u179f\u17c1\u178a\u17bc\u1793\u17b6\u1781\u17b6\u1784\u178f\u17d2\u1794\u17bc\u1784"
+    "name:khm_x_preferred": [
+      "ម៉ាសេដូនាខាងត្បូង"
     ],
-    "name:kin_x_historical":[
-        "Masedoniya"
+    "name:kin_x_historical": [
+      "Masedoniya"
     ],
-    "name:kin_x_preferred":[
-        "Masedoniya ya Ruguru"
+    "name:kin_x_preferred": [
+      "Masedoniya ya Ruguru"
     ],
-    "name:kir_x_preferred":[
-        "\u0422\u04af\u043d\u0434\u04af\u043a \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f"
+    "name:kir_x_preferred": [
+      "Түндүк Македония"
     ],
-    "name:koi_x_historical":[
-        "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f"
+    "name:koi_x_historical": [
+      "Республика Македония"
     ],
-    "name:koi_x_preferred":[
-        "\u041e\u0439\u0432\u044b\u0432 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f"
+    "name:koi_x_preferred": [
+      "Ойвыв Македония"
     ],
-    "name:kom_x_preferred":[
-        "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430"
+    "name:kom_x_preferred": [
+      "Македония Республика"
     ],
-    "name:kon_x_preferred":[
-        "Makedonia"
+    "name:kon_x_preferred": [
+      "Makedonia"
     ],
-    "name:kor_x_historical":[
-        "\ub9c8\ucf00\ub3c4\ub2c8\uc544 \uacf5\ud654\uad6d",
-        "\ub9c8\ucf00\ub3c4\ub2c8\uc544",
-        "\ub9c8\ucf00\ub3c4\ub2c8\uc544\uc5b4",
-        "\uc804 \uc720\uace0\uc2ac\ub77c\ube44\uc544 \ub9c8\ucf00\ub3c4\ub2c8\uc544"
+    "name:kor_x_historical": [
+      "마케도니아 공화국",
+      "마케도니아",
+      "마케도니아어",
+      "전 유고슬라비아 마케도니아"
     ],
-    "name:kor_x_preferred":[
-        "\ubd81\ub9c8\ucf00\ub3c4\ub2c8\uc544"
+    "name:kor_x_preferred": [
+      "북마케도니아"
     ],
-    "name:krc_x_preferred":[
-        "\u0428\u0438\u043c\u0430\u043b \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f"
+    "name:krc_x_preferred": [
+      "Шимал Македония"
     ],
-    "name:kur_x_historical":[
-        "Komara Makedonyay\u00ea"
+    "name:kur_x_historical": [
+      "Komara Makedonyayê"
     ],
-    "name:kur_x_preferred":[
-        "Makedonyaya Bakur"
+    "name:kur_x_preferred": [
+      "Makedonyaya Bakur"
     ],
-    "name:lad_x_preferred":[
-        "Makedonia"
+    "name:lad_x_preferred": [
+      "Makedonia"
     ],
-    "name:lao_x_historical":[
-        "\u0ec1\u0ea1\u0e8a\u0eb4\u0ec2\u0e84\u0ec0\u0e99\u0e8d"
+    "name:lao_x_historical": [
+      "ແມຊິໂຄເນຍ"
     ],
-    "name:lao_x_preferred":[
-        "\u0ea1\u0eb2\u0e8a\u0eb4\u0ec2\u0e94\u0ec0\u0e99\u0e8d\u0ec0\u0edc\u0eb7\u0ead"
+    "name:lao_x_preferred": [
+      "ມາຊິໂດເນຍເໜືອ"
     ],
-    "name:lat_x_historical":[
-        "Macedonia",
-        "Res publica Macedonica"
+    "name:lat_x_historical": [
+      "Macedonia",
+      "Res publica Macedonica"
     ],
-    "name:lat_x_preferred":[
-        "Macedonia Septentrionalis"
+    "name:lat_x_preferred": [
+      "Macedonia Septentrionalis"
     ],
-    "name:lav_x_historical":[
-        "Ma\u0137edonija",
-        "Ma\u0137edonijas Republika"
+    "name:lav_x_historical": [
+      "Maķedonija",
+      "Maķedonijas Republika"
     ],
-    "name:lav_x_preferred":[
-        "Zieme\u013cma\u0137edonija"
+    "name:lav_x_preferred": [
+      "Ziemeļmaķedonija"
     ],
-    "name:lez_x_preferred":[
-        "\u041a\u0435\u0444\u0435\u0440\u043f\u0430\u0442\u0430\u043d \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f"
+    "name:lez_x_preferred": [
+      "Кеферпатан Македония"
     ],
-    "name:lfn_x_historical":[
-        "Macedonia"
+    "name:lfn_x_historical": [
+      "Macedonia"
     ],
-    "name:lfn_x_preferred":[
-        "Macedonia Norde"
+    "name:lfn_x_preferred": [
+      "Macedonia Norde"
     ],
-    "name:lim_x_historical":[
-        "Macedoni\u00eb"
+    "name:lim_x_historical": [
+      "Macedonië"
     ],
-    "name:lim_x_preferred":[
-        "Noord-Macedoni\u00eb"
+    "name:lim_x_preferred": [
+      "Noord-Macedonië"
     ],
-    "name:lin_x_historical":[
-        "Masedwan\u025b"
+    "name:lin_x_historical": [
+      "Masedwanɛ"
     ],
-    "name:lin_x_preferred":[
-        "Masedoni ya Nola"
+    "name:lin_x_preferred": [
+      "Masedoni ya Nola"
     ],
-    "name:lit_x_historical":[
-        "Makedonija"
+    "name:lit_x_historical": [
+      "Makedonija"
     ],
-    "name:lit_x_preferred":[
-        "\u0160iaur\u0117s Makedonija"
+    "name:lit_x_preferred": [
+      "Šiaurės Makedonija"
     ],
-    "name:lld_x_preferred":[
-        "Macedonia dl Nort"
+    "name:lld_x_preferred": [
+      "Macedonia dl Nort"
     ],
-    "name:lld_x_variant":[
-        "Macedonia dl Nord"
+    "name:lld_x_variant": [
+      "Macedonia dl Nord"
     ],
-    "name:lmo_x_historical":[
-        "Macedonia"
+    "name:lmo_x_historical": [
+      "Macedonia"
     ],
-    "name:lmo_x_preferred":[
-        "Macedonia del Nord"
+    "name:lmo_x_preferred": [
+      "Macedonia del Nord"
     ],
-    "name:lrc_x_preferred":[
-        "\u0645\u0671\u0642\u062f\u06ca\u0646\u06cc\u0671"
+    "name:lrc_x_preferred": [
+      "مٱقدۊنیٱ"
     ],
-    "name:ltg_x_historical":[
-        "Makedonejis Republika"
+    "name:ltg_x_historical": [
+      "Makedonejis Republika"
     ],
-    "name:ltg_x_preferred":[
-        "Z\u012bme\u013cmakedoneja"
+    "name:ltg_x_preferred": [
+      "Zīmeļmakedoneja"
     ],
-    "name:ltz_x_preferred":[
-        "Nordmazedonien"
+    "name:ltz_x_preferred": [
+      "Nordmazedonien"
     ],
-    "name:lzh_x_preferred":[
-        "\u5317\u99ac\u5176\u9813"
+    "name:lzh_x_preferred": [
+      "北馬其頓"
     ],
-    "name:mad_x_preferred":[
-        "Makedonia"
+    "name:mad_x_preferred": [
+      "Makedonia"
     ],
-    "name:mai_x_preferred":[
-        "\u092e\u094d\u092f\u093e\u0938\u0947\u0921\u094b\u0928\u093f\u092f\u093e"
+    "name:mai_x_preferred": [
+      "म्यासेडोनिया"
     ],
-    "name:mal_x_historical":[
-        "\u0d2e\u0d3e\u0d38\u0d3f\u0d21\u0d4b\u0d23\u0d3f\u0d2f"
+    "name:mal_x_historical": [
+      "മാസിഡോണിയ"
     ],
-    "name:mal_x_preferred":[
-        "\u0d28\u0d4b\u0d7c\u0d24\u0d4d\u0d24\u0d4d \u0d2e\u0d3e\u0d38\u0d3f\u0d21\u0d4b\u0d23\u0d3f\u0d2f"
+    "name:mal_x_preferred": [
+      "നോർത്ത് മാസിഡോണിയ"
     ],
-    "name:mar_x_historical":[
-        "\u092e\u0945\u0938\u0947\u0921\u094b\u0928\u093f\u092f\u093e"
+    "name:mar_x_historical": [
+      "मॅसेडोनिया"
     ],
-    "name:mar_x_preferred":[
-        "\u0909\u0924\u094d\u0924\u0930 \u092e\u0945\u0938\u093f\u0921\u094b\u0928\u093f\u092f\u093e"
+    "name:mar_x_preferred": [
+      "उत्तर मॅसिडोनिया"
     ],
-    "name:mdf_x_preferred":[
-        "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u0435"
+    "name:mdf_x_preferred": [
+      "Македоние"
     ],
-    "name:mdf_x_variant":[
-        "\u041a\u0435\u043b\u044c\u043c\u0435\u0448\u0438\u0440\u0435\u043d\u044c \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f"
+    "name:mdf_x_variant": [
+      "Кельмеширень Македония"
     ],
-    "name:mhr_x_historical":[
-        "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u0439"
+    "name:mhr_x_historical": [
+      "Македоний"
     ],
-    "name:mhr_x_preferred":[
-        "\u0419\u04f1\u0434\u0432\u0435\u043b \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u0439"
+    "name:mhr_x_preferred": [
+      "Йӱдвел Македоний"
     ],
-    "name:min_x_preferred":[
-        "Republik Makedonia"
+    "name:min_x_preferred": [
+      "Republik Makedonia"
     ],
-    "name:mkd_x_historical":[
-        "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u0458\u0430 (\u043f\u043e\u0458\u0430\u0441\u043d\u0443\u0432\u0430\u045a\u0435)",
-        "\u0420\u0435\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u0458\u0430"
+    "name:mkd_x_historical": [
+      "Македонија (појаснување)",
+      "Република Македонија"
     ],
-    "name:mkd_x_preferred":[
-        "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u0458\u0430"
+    "name:mkd_x_preferred": [
+      "Македонија"
     ],
-    "name:mlg_x_historical":[
-        "Makedonia",
-        "Masedonia"
+    "name:mlg_x_historical": [
+      "Makedonia",
+      "Masedonia"
     ],
-    "name:mlg_x_preferred":[
-        "Mased\u00f4nia Avaratra"
+    "name:mlg_x_preferred": [
+      "Masedônia Avaratra"
     ],
-    "name:mlt_x_historical":[
-        "Ma\u010bedonja"
+    "name:mlt_x_historical": [
+      "Maċedonja"
     ],
-    "name:mlt_x_preferred":[
-        "Ma\u010bedonja ta' Fuq"
+    "name:mlt_x_preferred": [
+      "Maċedonja ta' Fuq"
     ],
-    "name:mon_x_preferred":[
-        "\u0423\u043c\u0430\u0440\u0434 \u041c\u0430\u043a\u0435\u0434\u043e\u043d"
+    "name:mon_x_preferred": [
+      "Умард Македон"
     ],
-    "name:mri_x_preferred":[
-        "Maker\u014dnia"
+    "name:mri_x_preferred": [
+      "Makerōnia"
     ],
-    "name:msa_x_historical":[
-        "Macedonia",
-        "Republik Macedonia"
+    "name:msa_x_historical": [
+      "Macedonia",
+      "Republik Macedonia"
     ],
-    "name:msa_x_preferred":[
-        "Makedonia Utara"
+    "name:msa_x_preferred": [
+      "Makedonia Utara"
     ],
-    "name:msa_x_variant":[
-        "Macedonia Utara"
+    "name:msa_x_variant": [
+      "Macedonia Utara"
     ],
-    "name:mya_x_historical":[
-        "\u1019\u102c\u1005\u102e\u1012\u102d\u102f\u1038\u1014\u102e\u1038\u101a\u102c\u1038"
+    "name:mya_x_historical": [
+      "မာစီဒိုးနီးယား"
     ],
-    "name:mya_x_preferred":[
-        "\u1019\u1000\u103a\u1005\u102e\u1012\u102d\u102f\u1038\u1014\u102e\u1038\u101a\u102c\u1038\u1014\u102d\u102f\u1004\u103a\u1004\u1036"
+    "name:mya_x_preferred": [
+      "မက်စီဒိုးနီးယားနိုင်ငံ"
     ],
-    "name:myv_x_preferred":[
-        "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f \u041c\u0430\u0441\u0442\u043e\u0440"
+    "name:myv_x_preferred": [
+      "Македония Мастор"
     ],
-    "name:mzn_x_preferred":[
-        "\u0645\u0642\u062f\u0648\u0646\u06cc\u0647"
+    "name:mzn_x_preferred": [
+      "مقدونیه"
     ],
-    "name:nah_x_preferred":[
-        "Tl\u0101catlahtohc\u0101y\u014dtl Macedonia"
+    "name:nah_x_preferred": [
+      "Tlācatlahtohcāyōtl Macedonia"
     ],
-    "name:nan_x_preferred":[
-        "Pak Macedonia"
+    "name:nan_x_preferred": [
+      "Pak Macedonia"
     ],
-    "name:nau_x_historical":[
-        "Macedonia"
+    "name:nau_x_historical": [
+      "Macedonia"
     ],
-    "name:nau_x_preferred":[
-        "Matedoniya"
+    "name:nau_x_preferred": [
+      "Matedoniya"
     ],
-    "name:nav_x_preferred":[
-        "Dzi\u0142n\u00e9z\u00edtah Dine\u02bc\u00e9 Bik\u00e9yah"
+    "name:nav_x_preferred": [
+      "Dziłnézítah Dineʼé Bikéyah"
     ],
-    "name:nds_x_historical":[
-        "Makedonien",
-        "Republiek Makedonien"
+    "name:nds_x_historical": [
+      "Makedonien",
+      "Republiek Makedonien"
     ],
-    "name:nds_x_preferred":[
-        "Noordmakedonien"
+    "name:nds_x_preferred": [
+      "Noordmakedonien"
     ],
-    "name:nep_x_historical":[
-        "\u092e\u094d\u092f\u093e\u0915\u0947\u0921\u094b\u0928\u093f\u092f\u093e"
+    "name:nep_x_historical": [
+      "म्याकेडोनिया"
     ],
-    "name:nep_x_preferred":[
-        "\u092e\u094d\u092f\u093e\u0938\u0947\u0921\u094b\u0928\u093f\u092f\u093e"
+    "name:nep_x_preferred": [
+      "म्यासेडोनिया"
     ],
-    "name:new_x_preferred":[
-        "\u092e\u094d\u092f\u093e\u0938\u0947\u0921\u094b\u0928\u093f\u092f\u093e"
+    "name:new_x_preferred": [
+      "म्यासेडोनिया"
     ],
-    "name:nld_x_colloquial":[
-        "Macedonie"
+    "name:nld_x_colloquial": [
+      "Macedonie"
     ],
-    "name:nld_x_historical":[
-        "Macedonia",
-        "Voormalige Joegoslavische Republiek Macedoni\u00eb",
-        "Macedoni\u00eb, Republiek",
-        "Macedoni\u00eb"
+    "name:nld_x_historical": [
+      "Macedonia",
+      "Voormalige Joegoslavische Republiek Macedonië",
+      "Macedonië, Republiek",
+      "Macedonië"
     ],
-    "name:nld_x_preferred":[
-        "Noord-Macedoni\u00eb"
+    "name:nld_x_preferred": [
+      "Noord-Macedonië"
     ],
-    "name:nno_x_historical":[
-        "Makedonia",
-        "Republikken Makedonia"
+    "name:nno_x_historical": [
+      "Makedonia",
+      "Republikken Makedonia"
     ],
-    "name:nno_x_preferred":[
-        "Nord-Makedonia"
+    "name:nno_x_preferred": [
+      "Nord-Makedonia"
     ],
-    "name:nob_x_historical":[
-        "Makedonia"
+    "name:nob_x_historical": [
+      "Makedonia"
     ],
-    "name:nob_x_preferred":[
-        "Nord-Makedonia"
+    "name:nob_x_preferred": [
+      "Nord-Makedonia"
     ],
-    "name:oci_x_historical":[
-        "Maced\u00f2nia",
-        "Republica de Maced\u00f2nia"
+    "name:oci_x_historical": [
+      "Macedònia",
+      "Republica de Macedònia"
     ],
-    "name:oci_x_preferred":[
-        "Maced\u00f2nia del N\u00f2rd"
+    "name:oci_x_preferred": [
+      "Macedònia del Nòrd"
     ],
-    "name:olo_x_historical":[
-        "Makedounii"
+    "name:olo_x_historical": [
+      "Makedounii"
     ],
-    "name:olo_x_preferred":[
-        "Pohjas-Makedounii"
+    "name:olo_x_preferred": [
+      "Pohjas-Makedounii"
     ],
-    "name:ori_x_historical":[
-        "\u0b2e\u0b3e\u0b38\u0b47\u0b21\u0b4b\u0b28\u0b3f\u0b06"
+    "name:ori_x_historical": [
+      "ମାସେଡୋନିଆ"
     ],
-    "name:ori_x_preferred":[
-        "\u0b2e\u0b3e\u0b38\u0b3f\u0b21\u0b4b\u0b28\u0b3f\u0b06"
+    "name:ori_x_preferred": [
+      "ମାସିଡୋନିଆ"
     ],
-    "name:orm_x_preferred":[
-        "Maqedooniyaa"
+    "name:orm_x_preferred": [
+      "Maqedooniyaa"
     ],
-    "name:oss_x_preferred":[
-        "\u0426\u00e6\u0433\u0430\u0442 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438"
+    "name:oss_x_preferred": [
+      "Цæгат Македони"
     ],
-    "name:pag_x_preferred":[
-        "Masedoniya"
+    "name:pag_x_preferred": [
+      "Masedoniya"
     ],
-    "name:pam_x_historical":[
-        "Republika ning Makedonia"
+    "name:pam_x_historical": [
+      "Republika ning Makedonia"
     ],
-    "name:pam_x_preferred":[
-        "Pangulung Makedonia"
+    "name:pam_x_preferred": [
+      "Pangulung Makedonia"
     ],
-    "name:pan_x_preferred":[
-        "\u0a30\u0a40\u0a2a\u0a2c\u0a32\u0a3f\u0a15 \u0a06\u0a2b \u0a28\u0a3e\u0a30\u0a25 \u0a2e\u0a15\u0a26\u0a42\u0a28\u0a40\u0a06"
+    "name:pan_x_preferred": [
+      "ਰੀਪਬਲਿਕ ਆਫ ਨਾਰਥ ਮਕਦੂਨੀਆ"
     ],
-    "name:pap_x_preferred":[
-        "Nort Macedonia"
+    "name:pap_x_preferred": [
+      "Nort Macedonia"
     ],
-    "name:pcd_x_preferred":[
-        "Mach\u00e9do\u00e8ne"
+    "name:pcd_x_preferred": [
+      "Machédoène"
     ],
-    "name:pih_x_preferred":[
-        "Repablik o' Masedoenya"
+    "name:pih_x_preferred": [
+      "Repablik o' Masedoenya"
     ],
-    "name:pli_x_preferred":[
-        "\u092e\u0947\u0938\u0947\u0921\u094b\u0928\u093f\u092f\u093e"
+    "name:pli_x_preferred": [
+      "मेसेडोनिया"
     ],
-    "name:pms_x_historical":[
-        "Maced\u00f2nia"
+    "name:pms_x_historical": [
+      "Macedònia"
     ],
-    "name:pms_x_preferred":[
-        "Maced\u00f2nia d\u00ebl N\u00f2rd"
+    "name:pms_x_preferred": [
+      "Macedònia dël Nòrd"
     ],
-    "name:pnb_x_preferred":[
-        "\u0645\u0642\u062f\u0648\u0646\u06cc\u06c1"
+    "name:pnb_x_preferred": [
+      "مقدونیہ"
     ],
-    "name:pnb_x_variant":[
-        "\u0634\u0645\u0627\u0644\u06cc \u0645\u0642\u062f\u0648\u0646\u06cc\u0627"
+    "name:pnb_x_variant": [
+      "شمالی مقدونیا"
     ],
-    "name:pnt_x_preferred":[
-        "\u0392\u03cc\u03c1\u03b5\u03b9\u03b1 \u039c\u03b1\u03ba\u03b5\u03b4\u03bf\u03bd\u03af\u03b1"
+    "name:pnt_x_preferred": [
+      "Βόρεια Μακεδονία"
     ],
-    "name:pol_x_historical":[
-        "Macedonia (ujednoznacznienie)",
-        "Macedonia, Republika",
-        "Macedonia",
-        "By\u0142a Jugos\u0142owia\u0144ska Republika Macedonii"
+    "name:pol_x_historical": [
+      "Macedonia (ujednoznacznienie)",
+      "Macedonia, Republika",
+      "Macedonia",
+      "Była Jugosłowiańska Republika Macedonii"
     ],
-    "name:pol_x_preferred":[
-        "Macedonia P\u00f3\u0142nocna"
+    "name:pol_x_preferred": [
+      "Macedonia Północna"
     ],
-    "name:por_x_colloquial":[
-        "Antiga Republica jugoslava da Macedonia"
+    "name:por_x_colloquial": [
+      "Antiga Republica jugoslava da Macedonia"
     ],
-    "name:por_x_preferred":[
-        "Maced\u00f3nia do Norte"
+    "name:por_x_preferred": [
+      "Macedónia do Norte"
     ],
-    "name:pus_x_preferred":[
-        "\u062f \u0645\u0642\u062f\u0648\u0646\u064a\u06d0 \u0648\u0644\u0633\u0645\u0634\u0631\u064a\u0632\u0647"
+    "name:pus_x_preferred": [
+      "د مقدونيې ولسمشريزه"
     ],
-    "name:que_x_historical":[
-        "Makiduniya"
+    "name:que_x_historical": [
+      "Makiduniya"
     ],
-    "name:que_x_preferred":[
-        "Chinchay Masitunya"
+    "name:que_x_preferred": [
+      "Chinchay Masitunya"
     ],
-    "name:rmy_x_preferred":[
-        "Republika Makedoniya"
+    "name:rmy_x_preferred": [
+      "Republika Makedoniya"
     ],
-    "name:roh_x_historical":[
-        "Macedonia"
+    "name:roh_x_historical": [
+      "Macedonia"
     ],
-    "name:roh_x_preferred":[
-        "Macedonia dal Nord"
+    "name:roh_x_preferred": [
+      "Macedonia dal Nord"
     ],
-    "name:ron_x_preferred":[
-        "Macedonia de Nord"
+    "name:ron_x_preferred": [
+      "Macedonia de Nord"
     ],
-    "name:rue_x_historical":[
-        "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0456\u044f"
+    "name:rue_x_historical": [
+      "Македонія"
     ],
-    "name:rue_x_preferred":[
-        "\u0421\u0463\u0432\u0435\u0440\u043d\u0430 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0456\u044f"
+    "name:rue_x_preferred": [
+      "Сѣверна Македонія"
     ],
-    "name:rus_x_historical":[
-        "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f",
-        "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f"
+    "name:rus_x_historical": [
+      "Македония",
+      "Республика Македония"
     ],
-    "name:rus_x_preferred":[
-        "\u0421\u0435\u0432\u0435\u0440\u043d\u0430\u044f \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f"
+    "name:rus_x_preferred": [
+      "Северная Македония"
     ],
-    "name:sah_x_preferred":[
-        "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0438\u043a\u0430\u0442\u0430"
+    "name:sah_x_preferred": [
+      "Македония Республиката"
     ],
-    "name:san_x_preferred":[
-        "\u092e\u0947\u0938\u0947\u0921\u094b\u0928\u093f\u092f\u093e"
+    "name:san_x_preferred": [
+      "मेसेडोनिया"
     ],
-    "name:sat_x_preferred":[
-        "\u1c62\u1c5f\u1c65\u1c64\u1c70\u1c5a\u1c71\u1c64\u1c6d\u1c5f"
+    "name:sat_x_preferred": [
+      "ᱢᱟᱥᱤᱰᱚᱱᱤᱭᱟ"
     ],
-    "name:sco_x_historical":[
-        "Macedonie"
+    "name:sco_x_historical": [
+      "Macedonie"
     ],
-    "name:sco_x_preferred":[
-        "North Macedonie"
+    "name:sco_x_preferred": [
+      "North Macedonie"
     ],
-    "name:sgs_x_preferred":[
-        "Makeduon\u0117j\u0117"
+    "name:sgs_x_preferred": [
+      "Makeduonėjė"
     ],
-    "name:shn_x_preferred":[
-        "\u1019\u102d\u1030\u1004\u103a\u1038\u1019\u1085\u1010\u103a\u1087\u101e\u102e\u1087\u1010\u1030\u101d\u103a\u1038\u107c\u102e\u1038\u101a\u1083\u1038"
+    "name:shn_x_preferred": [
+      "မိူင်းမႅတ်ႇသီႇတူဝ်းၼီးယႃး"
     ],
-    "name:sin_x_preferred":[
-        "\u0d8b\u0dad\u0dd4\u0dbb\u0dd4 \u0db8\u0dd0\u0dc3\u0dd2\u0da9\u0ddd\u0db1\u0dd2\u0dba\u0dcf\u0dc0"
+    "name:sin_x_preferred": [
+      "උතුරු මැසිඩෝනියාව"
     ],
-    "name:slk_x_historical":[
-        "Maced\u00f3nsko, republika",
-        "Maced\u00f3nsko"
+    "name:slk_x_historical": [
+      "Macedónsko, republika",
+      "Macedónsko"
     ],
-    "name:slk_x_preferred":[
-        "Severn\u00e9 Maced\u00f3nsko"
+    "name:slk_x_preferred": [
+      "Severné Macedónsko"
     ],
-    "name:slv_x_historical":[
-        "Republika Makedonija",
-        "Makedonija"
+    "name:slv_x_historical": [
+      "Republika Makedonija",
+      "Makedonija"
     ],
-    "name:slv_x_preferred":[
-        "Severna Makedonija"
+    "name:slv_x_preferred": [
+      "Severna Makedonija"
     ],
-    "name:sme_x_historical":[
-        "D\u00e1ssev\u00e1ldi Makedonia",
-        "Makedonia"
+    "name:sme_x_historical": [
+      "Dásseváldi Makedonia",
+      "Makedonia"
     ],
-    "name:sme_x_preferred":[
-        "Davvi-Makedonia"
+    "name:sme_x_preferred": [
+      "Davvi-Makedonia"
     ],
-    "name:smn_x_preferred":[
-        "Tave-Makedonia"
+    "name:smn_x_preferred": [
+      "Tave-Makedonia"
     ],
-    "name:smo_x_preferred":[
-        "Ripapelika o Maketonia"
+    "name:smo_x_preferred": [
+      "Ripapelika o Maketonia"
     ],
-    "name:sms_x_preferred":[
-        "T\u00e2\u02b9vv-Makedonia"
+    "name:sms_x_preferred": [
+      "Tâʹvv-Makedonia"
     ],
-    "name:sna_x_preferred":[
-        "Macedonia"
+    "name:sna_x_preferred": [
+      "Macedonia"
     ],
-    "name:som_x_historical":[
-        "Makadooniya"
+    "name:som_x_historical": [
+      "Makadooniya"
     ],
-    "name:som_x_preferred":[
-        "Jamhuuriyada Waqooyiga Macedonia"
+    "name:som_x_preferred": [
+      "Jamhuuriyada Waqooyiga Macedonia"
     ],
-    "name:spa_x_colloquial":[
-        "Antigua Republica Yugoslava de Macedonia",
-        "Ex Republica Yugoslava de Macedonia"
+    "name:spa_x_colloquial": [
+      "Antigua Republica Yugoslava de Macedonia",
+      "Ex Republica Yugoslava de Macedonia"
     ],
-    "name:spa_x_historical":[
-        "Rep\u00fablica de Macedonia",
-        "Macedonia",
-        "Antigua Rep\u00fablica Yugoslava de Macedonia",
-        "Ex Rep\u00fablica Yugoslava de Macedonia",
-        "Macedonia, Antigua Rep\u00fablica Yugoslava"
+    "name:spa_x_historical": [
+      "República de Macedonia",
+      "Macedonia",
+      "Antigua República Yugoslava de Macedonia",
+      "Ex República Yugoslava de Macedonia",
+      "Macedonia, Antigua República Yugoslava"
     ],
-    "name:spa_x_preferred":[
-        "Macedonia del Norte"
+    "name:spa_x_preferred": [
+      "Macedonia del Norte"
     ],
-    "name:sqi_x_historical":[
-        "Maqedonia (kthjellim)",
-        "Maqedoni",
-        "Republika e Maqedonis\u00eb"
+    "name:sqi_x_historical": [
+      "Maqedonia (kthjellim)",
+      "Maqedoni",
+      "Republika e Maqedonisë"
     ],
-    "name:sqi_x_preferred":[
-        "Maqedonia e Veriut"
+    "name:sqi_x_preferred": [
+      "Maqedonia e Veriut"
     ],
-    "name:srn_x_preferred":[
-        "Masedoniyakondre"
+    "name:srn_x_preferred": [
+      "Masedoniyakondre"
     ],
-    "name:srp_x_historical":[
-        "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u0458\u0430 (\u0432\u0438\u0448\u0435\u0437\u043d\u0430\u0447\u043d\u0430 \u043e\u0434\u0440\u0435\u0434\u043d\u0438\u0446\u0430)",
-        "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u0458\u0430",
-        "\u0420\u0435\u043f\u0443\u0431\u043b\u0438\u043a\u0430 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u0458\u0430"
+    "name:srp_x_historical": [
+      "Македонија (вишезначна одредница)",
+      "Македонија",
+      "Република Македонија"
     ],
-    "name:srp_x_preferred":[
-        "\u0421\u0435\u0432\u0435\u0440\u043d\u0430 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u0458\u0430"
+    "name:srp_x_preferred": [
+      "Северна Македонија"
     ],
-    "name:ssw_x_historical":[
-        "IMakhedoniya"
+    "name:ssw_x_historical": [
+      "IMakhedoniya"
     ],
-    "name:ssw_x_preferred":[
-        "iMakhedoniya leseNyakatfo"
+    "name:ssw_x_preferred": [
+      "iMakhedoniya leseNyakatfo"
     ],
-    "name:stq_x_historical":[
-        "Makedonien"
+    "name:stq_x_historical": [
+      "Makedonien"
     ],
-    "name:stq_x_preferred":[
-        "Noudmakedonien"
+    "name:stq_x_preferred": [
+      "Noudmakedonien"
     ],
-    "name:sun_x_preferred":[
-        "Mak\u00e9donia Kal\u00e9r"
+    "name:sun_x_preferred": [
+      "Makédonia Kalér"
     ],
-    "name:swa_x_historical":[
-        "Jamhuri ya Masedonia",
-        "Masedonia"
+    "name:swa_x_historical": [
+      "Jamhuri ya Masedonia",
+      "Masedonia"
     ],
-    "name:swa_x_preferred":[
-        "Masedonia ya Kaskazini"
+    "name:swa_x_preferred": [
+      "Masedonia ya Kaskazini"
     ],
-    "name:swe_x_historical":[
-        "Makedonien",
-        "Macedonia (olika betydelser)",
-        "F.d. jugoslaviska republiken Makedonien",
-        "FYROM"
+    "name:swe_x_historical": [
+      "Makedonien",
+      "Macedonia (olika betydelser)",
+      "F.d. jugoslaviska republiken Makedonien",
+      "FYROM"
     ],
-    "name:swe_x_preferred":[
-        "Nordmakedonien"
+    "name:swe_x_preferred": [
+      "Nordmakedonien"
     ],
-    "name:szl_x_preferred":[
-        "P\u016f\u0142nocno Maced\u016f\u0144ijo"
+    "name:szl_x_preferred": [
+      "Půłnocno Macedůńijo"
     ],
-    "name:szy_x_preferred":[
-        "Macedonia"
+    "name:szy_x_preferred": [
+      "Macedonia"
     ],
-    "name:tam_x_historical":[
-        "\u0bae\u0bbe\u0b9a\u0bbf\u0b9f\u0bcb\u0ba9\u0bbf\u0baf\u0bbe"
+    "name:tam_x_historical": [
+      "மாசிடோனியா"
     ],
-    "name:tam_x_preferred":[
-        "\u0bb5\u0b9f\u0b95\u0bcd\u0b95\u0bc1 \u0bae\u0bbe\u0b95\u0bcd\u0b95\u0b9f\u0bcb\u0ba9\u0bbf\u0baf\u0bbe"
+    "name:tam_x_preferred": [
+      "வடக்கு மாக்கடோனியா"
     ],
-    "name:tat_x_historical":[
-        "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f \u0496\u04e9\u043c\u04bb\u04af\u0440\u0438\u044f\u0442\u0435"
+    "name:tat_x_historical": [
+      "Македония Җөмһүрияте"
     ],
-    "name:tat_x_preferred":[
-        "\u0422\u04e9\u043d\u044c\u044f\u043a \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f"
+    "name:tat_x_preferred": [
+      "Төньяк Македония"
     ],
-    "name:tay_x_preferred":[
-        "Macedonia"
+    "name:tay_x_preferred": [
+      "Macedonia"
     ],
-    "name:tel_x_historical":[
-        "\u0c2e\u0c47\u0c38\u0c46\u0c21\u0c4b\u0c28\u0c3f\u0c2f\u0c3e"
+    "name:tel_x_historical": [
+      "మేసెడోనియా"
     ],
-    "name:tel_x_preferred":[
-        "\u0c09\u0c24\u0c4d\u0c24\u0c30 \u0c2e\u0c46\u0c38\u0c3f\u0c21\u0c4b\u0c28\u0c3f\u0c2f\u0c3e"
+    "name:tel_x_preferred": [
+      "ఉత్తర మెసిడోనియా"
     ],
-    "name:tet_x_historical":[
-        "Mased\u00f3nia"
+    "name:tet_x_historical": [
+      "Masedónia"
     ],
-    "name:tet_x_preferred":[
-        "Mased\u00f3nia Norte"
+    "name:tet_x_preferred": [
+      "Masedónia Norte"
     ],
-    "name:tgk_x_historical":[
-        "\u04b6\u0443\u043c\u04b3\u0443\u0440\u0438\u0438 \u041c\u0430\u049b\u0434\u0443\u043d\u0438\u044f"
+    "name:tgk_x_historical": [
+      "Ҷумҳурии Мақдуния"
     ],
-    "name:tgk_x_preferred":[
-        "\u041c\u0430\u049b\u0434\u0443\u043d\u0438\u044f\u0438 \u0428\u0438\u043c\u043e\u043b\u04e3"
+    "name:tgk_x_preferred": [
+      "Мақдунияи Шимолӣ"
     ],
-    "name:tgl_x_historical":[
-        "Republika ng Macedonia"
+    "name:tgl_x_historical": [
+      "Republika ng Macedonia"
     ],
-    "name:tgl_x_preferred":[
-        "Hilagang Macedonia"
+    "name:tgl_x_preferred": [
+      "Hilagang Macedonia"
     ],
-    "name:tha_x_historical":[
-        "\u0e21\u0e32\u0e0b\u0e34\u0e42\u0e14\u0e40\u0e19\u0e35\u0e22",
-        "\u0e1b\u0e23\u0e30\u0e40\u0e17\u0e28\u0e21\u0e32\u0e0b\u0e34\u0e42\u0e14\u0e40\u0e19\u0e35\u0e22"
+    "name:tha_x_historical": [
+      "มาซิโดเนีย",
+      "ประเทศมาซิโดเนีย"
     ],
-    "name:tha_x_preferred":[
-        "\u0e1b\u0e23\u0e30\u0e40\u0e17\u0e28\u0e19\u0e2d\u0e23\u0e4c\u0e17\u0e21\u0e32\u0e0b\u0e34\u0e42\u0e14\u0e40\u0e19\u0e35\u0e22"
+    "name:tha_x_preferred": [
+      "ประเทศนอร์ทมาซิโดเนีย"
     ],
-    "name:tha_x_variant":[
-        "\u0e1b\u0e23\u0e30\u0e40\u0e17\u0e28\u0e21\u0e32\u0e0b\u0e34\u0e42\u0e14\u0e40\u0e19\u0e35\u0e22\u0e40\u0e2b\u0e19\u0e37\u0e2d"
+    "name:tha_x_variant": [
+      "ประเทศมาซิโดเนียเหนือ"
     ],
-    "name:tok_x_preferred":[
-        "ma Maketonija"
+    "name:tok_x_preferred": [
+      "ma Maketonija"
     ],
-    "name:ton_x_preferred":[
-        "Maset\u014dnia fakatokelau"
+    "name:ton_x_preferred": [
+      "Masetōnia fakatokelau"
     ],
-    "name:tpi_x_preferred":[
-        "Republic of Macedonia"
+    "name:tpi_x_preferred": [
+      "Republic of Macedonia"
     ],
-    "name:trv_x_preferred":[
-        "Macedonia"
+    "name:trv_x_preferred": [
+      "Macedonia"
     ],
-    "name:tso_x_preferred":[
-        "Republic of Macedonia"
+    "name:tso_x_preferred": [
+      "Republic of Macedonia"
     ],
-    "name:tuk_x_preferred":[
-        "Demirgazyk Makedoni\u00fda"
+    "name:tuk_x_preferred": [
+      "Demirgazyk Makedoniýa"
     ],
-    "name:tur_x_historical":[
-        "Makedonya"
+    "name:tur_x_historical": [
+      "Makedonya"
     ],
-    "name:tur_x_preferred":[
-        "Kuzey Makedonya"
+    "name:tur_x_preferred": [
+      "Kuzey Makedonya"
     ],
-    "name:twi_x_preferred":[
-        "Masidonia"
+    "name:twi_x_preferred": [
+      "Masidonia"
     ],
-    "name:udm_x_preferred":[
-        "\u0423\u0439\u043f\u0430\u043b \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f"
+    "name:udm_x_preferred": [
+      "Уйпал Македония"
     ],
-    "name:uig_x_preferred":[
-        "\u0645\u0627\u0643\u06d0\u062f\u0648\u0646\u0649\u064a\u06d5"
+    "name:uig_x_preferred": [
+      "ماكېدونىيە"
     ],
-    "name:ukr_x_historical":[
-        "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0456\u044f",
-        "\u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0456\u043a\u0430 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0456\u044f",
-        "\u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0456\u044f, \u043a\u043e\u043b\u0438\u0448\u043d\u044f \u042e\u0433\u043e\u0441\u043b\u0430\u0432\u0441\u044c\u043a\u0430 \u0420\u0435\u0441\u043f\u0443\u0431\u043b\u0456\u043a\u0430"
+    "name:ukr_x_historical": [
+      "Македонія",
+      "Республіка Македонія",
+      "Македонія, колишня Югославська Республіка"
     ],
-    "name:ukr_x_preferred":[
-        "\u041f\u0456\u0432\u043d\u0456\u0447\u043d\u0430 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0456\u044f"
+    "name:ukr_x_preferred": [
+      "Північна Македонія"
     ],
-    "name:und_x_colloquial":[
-        "Macedonsko",
-        "Makedonias",
-        "Proin Giougkoslaviki Dimokratia tis Makedonias"
+    "name:und_x_colloquial": [
+      "Macedonsko",
+      "Makedonias",
+      "Proin Giougkoslaviki Dimokratia tis Makedonias"
     ],
-    "name:und_x_variant":[
-        "Makedon\u00eda",
-        "Makedon\u00edas",
-        "Nekdanja jugoslovanska republika Makedonija",
-        "Pr\u00f3in Giougkoslavik\u00ed Dimokrat\u00eda tis Makedon\u00edas",
-        "Peoples Republic of Macedonia"
+    "name:und_x_variant": [
+      "Makedonía",
+      "Makedonías",
+      "Nekdanja jugoslovanska republika Makedonija",
+      "Próin Giougkoslavikí Dimokratía tis Makedonías",
+      "Peoples Republic of Macedonia"
     ],
-    "name:urd_x_historical":[
-        "\u0645\u0642\u062f\u0648\u0646\u06cc\u06c1"
+    "name:urd_x_historical": [
+      "مقدونیہ"
     ],
-    "name:urd_x_preferred":[
-        "\u0634\u0645\u0627\u0644\u06cc \u0645\u0642\u062f\u0648\u0646\u06cc\u06c1"
+    "name:urd_x_preferred": [
+      "شمالی مقدونیہ"
     ],
-    "name:uzb_x_historical":[
-        "Makedoniya"
+    "name:uzb_x_historical": [
+      "Makedoniya"
     ],
-    "name:uzb_x_preferred":[
-        "Shimoliy Makedoniya"
+    "name:uzb_x_preferred": [
+      "Shimoliy Makedoniya"
     ],
-    "name:vec_x_historical":[
-        "Macedonia"
+    "name:vec_x_historical": [
+      "Macedonia"
     ],
-    "name:vec_x_preferred":[
-        "Maced\u00f2nia del Nord"
+    "name:vec_x_preferred": [
+      "Macedònia del Nord"
     ],
-    "name:vep_x_preferred":[
-        "Pohjoi\u017emakedonii"
+    "name:vep_x_preferred": [
+      "Pohjoižmakedonii"
     ],
-    "name:vie_x_historical":[
-        "Macedonia (\u0111\u1ecbnh h\u01b0\u1edbng)",
-        "Ma-x\u00ea-\u0111\u00f4-ni-a",
-        "Ma-x\u00ea-\u0111\u00f4-ni-a (Macedonia)"
+    "name:vie_x_historical": [
+      "Macedonia (định hướng)",
+      "Ma-xê-đô-ni-a",
+      "Ma-xê-đô-ni-a (Macedonia)"
     ],
-    "name:vie_x_preferred":[
-        "B\u1eafc Macedonia"
+    "name:vie_x_preferred": [
+      "Bắc Macedonia"
     ],
-    "name:vls_x_historical":[
-        "Macedoni\u00eb"
+    "name:vls_x_historical": [
+      "Macedonië"
     ],
-    "name:vls_x_preferred":[
-        "Noord-Macedoni\u00eb"
+    "name:vls_x_preferred": [
+      "Noord-Macedonië"
     ],
-    "name:vol_x_historical":[
-        "Macedonia",
-        "Makedon\u00e4n",
-        "Makedoniy\u00e4n"
+    "name:vol_x_historical": [
+      "Macedonia",
+      "Makedonän",
+      "Makedoniyän"
     ],
-    "name:vol_x_preferred":[
-        "Nol\u00fcda-Makedoniy\u00e4n"
+    "name:vol_x_preferred": [
+      "Nolüda-Makedoniyän"
     ],
-    "name:vro_x_preferred":[
-        "Mak\u00f5doonia Vabariik"
+    "name:vro_x_preferred": [
+      "Makõdoonia Vabariik"
     ],
-    "name:war_x_historical":[
-        "Republika han Macedonia"
+    "name:war_x_historical": [
+      "Republika han Macedonia"
     ],
-    "name:war_x_preferred":[
-        "Norte nga Macedonia"
+    "name:war_x_preferred": [
+      "Norte nga Macedonia"
     ],
-    "name:wln_x_preferred":[
-        "Bijhe-Macedwene"
+    "name:wln_x_preferred": [
+      "Bijhe-Macedwene"
     ],
-    "name:wol_x_preferred":[
-        "R\u00e9ewum Maseduwaan"
+    "name:wol_x_preferred": [
+      "Réewum Maseduwaan"
     ],
-    "name:wuu_x_preferred":[
-        "\u9a6c\u5176\u987f"
+    "name:wuu_x_preferred": [
+      "马其顿"
     ],
-    "name:xal_x_preferred":[
-        "\u041c\u0430\u0441\u0438\u0434\u0438\u043d \u041e\u0440\u043d"
+    "name:xal_x_preferred": [
+      "Масидин Орн"
     ],
-    "name:xmf_x_preferred":[
-        "\u10dd\u10dd\u10e0\u10e3\u10d4 \u10db\u10d0\u10d9\u10d4\u10d3\u10dd\u10dc\u10d8\u10d0"
+    "name:xmf_x_preferred": [
+      "ოორუე მაკედონია"
     ],
-    "name:yid_x_preferred":[
-        "\u05e6\u05e4\u05d5\u05df-\u05de\u05d0\u05e7\u05e2\u05d3\u05d0\u05e0\u05d9\u05e2"
+    "name:yid_x_preferred": [
+      "צפון-מאקעדאניע"
     ],
-    "name:yor_x_historical":[
-        "Or\u00edl\u1eb9\u0301\u00e8de Masidonia"
+    "name:yor_x_historical": [
+      "Orílẹ́ède Masidonia"
     ],
-    "name:yor_x_preferred":[
-        "Or\u00edl\u1eb9\u0300-\u00e8d\u00e8 Ol\u00f3m\u00ecnira il\u1eb9\u0300 Mak\u1eb9d\u00f3n\u00ed\u00e0"
+    "name:yor_x_preferred": [
+      "Orílẹ̀-èdè Olómìnira ilẹ̀ Makẹdóníà"
     ],
-    "name:yue_x_preferred":[
-        "\u5317\u99ac\u5176\u9813\u5171\u548c\u570b"
+    "name:yue_x_preferred": [
+      "北馬其頓共和國"
     ],
-    "name:zea_x_preferred":[
-        "Noord-Macedoni\u00eb"
+    "name:zea_x_preferred": [
+      "Noord-Macedonië"
     ],
-    "name:zha_x_preferred":[
-        "Baek Macedonia"
+    "name:zha_x_preferred": [
+      "Baek Macedonia"
     ],
-    "name:zho_x_historical":[
-        "\u99ac\u5176\u9813 (\u6d88\u6b67\u7fa9)",
-        "\u99ac\u5176\u9813",
-        "\u9a6c\u5176\u987f\u738b\u56fd",
-        "\u99ac\u5176\u9813\u5171\u548c\u570b",
-        "\u524d\u5357\u65af\u62c9\u592b\u9a6c\u5176\u987f\u5171\u548c\u56fd"
+    "name:zho_x_historical": [
+      "馬其頓 (消歧義)",
+      "馬其頓",
+      "马其顿王国",
+      "馬其頓共和國",
+      "前南斯拉夫马其顿共和国"
     ],
-    "name:zho_x_preferred":[
-        "\u5317\u9a6c\u5176\u987f"
+    "name:zho_x_preferred": [
+      "北马其顿"
     ],
-    "name:zul_x_historical":[
-        "I-Macedonia",
-        "IMakedoniya"
+    "name:zul_x_historical": [
+      "I-Macedonia",
+      "IMakedoniya"
     ],
-    "name:zul_x_preferred":[
-        "INyakatho Masedoniya"
+    "name:zul_x_preferred": [
+      "INyakatho Masedoniya"
     ],
-    "ne:abbrev":"N. Mac.",
-    "ne:abbrev_len":7,
-    "ne:adm0_a3":"MKD",
-    "ne:adm0_a3_ar":"MKD",
-    "ne:adm0_a3_bd":"MKD",
-    "ne:adm0_a3_br":"MKD",
-    "ne:adm0_a3_cn":"MKD",
-    "ne:adm0_a3_de":"MKD",
-    "ne:adm0_a3_eg":"MKD",
-    "ne:adm0_a3_es":"MKD",
-    "ne:adm0_a3_fr":"MKD",
-    "ne:adm0_a3_gb":"MKD",
-    "ne:adm0_a3_gr":"MKD",
-    "ne:adm0_a3_id":"MKD",
-    "ne:adm0_a3_il":"MKD",
-    "ne:adm0_a3_in":"MKD",
-    "ne:adm0_a3_is":"MKD",
-    "ne:adm0_a3_it":"MKD",
-    "ne:adm0_a3_jp":"MKD",
-    "ne:adm0_a3_ko":"MKD",
-    "ne:adm0_a3_ma":"MKD",
-    "ne:adm0_a3_nl":"MKD",
-    "ne:adm0_a3_np":"MKD",
-    "ne:adm0_a3_pk":"MKD",
-    "ne:adm0_a3_pl":"MKD",
-    "ne:adm0_a3_ps":"MKD",
-    "ne:adm0_a3_pt":"MKD",
-    "ne:adm0_a3_ru":"MKD",
-    "ne:adm0_a3_sa":"MKD",
-    "ne:adm0_a3_se":"MKD",
-    "ne:adm0_a3_tr":"MKD",
-    "ne:adm0_a3_tw":"MKD",
-    "ne:adm0_a3_ua":"MKD",
-    "ne:adm0_a3_un":-99,
-    "ne:adm0_a3_us":"MKD",
-    "ne:adm0_a3_vn":"MKD",
-    "ne:adm0_a3_wb":-99,
-    "ne:adm0_dif":0,
-    "ne:admin":"North Macedonia",
-    "ne:brk_a3":"MKD",
-    "ne:brk_diff":0,
-    "ne:brk_group":null,
-    "ne:brk_name":"North Macedonia",
-    "ne:continent":"Europe",
-    "ne:economy":"6. Developing region",
-    "ne:featurecla":"Admin-0 country",
-    "ne:fips_10":"MK",
-    "ne:fips_10_":"MK",
-    "ne:formal_en":"Republic of North Macedonia",
-    "ne:formal_fr":null,
-    "ne:gdp_md":12547,
-    "ne:gdp_md_est":18780,
-    "ne:gdp_year":2019,
-    "ne:geou_dif":0,
-    "ne:geounit":"North Macedonia",
-    "ne:gu_a3":"MKD",
-    "ne:homepart":1,
-    "ne:income_grp":"3. Upper middle income",
-    "ne:iso_a2":"MK",
-    "ne:iso_a2_eh":"MK",
-    "ne:iso_a3":"MKD",
-    "ne:iso_a3_eh":"MKD",
-    "ne:iso_n3":"807",
-    "ne:iso_n3_eh":"807",
-    "ne:labelrank":6,
-    "ne:lastcensus":2010,
-    "ne:level":2,
-    "ne:long_len":15,
-    "ne:mapcolor13":3,
-    "ne:mapcolor7":5,
-    "ne:mapcolor8":3,
-    "ne:mapcolor9":7,
-    "ne:max_label":10,
-    "ne:min_label":5,
-    "ne:min_zoom":0,
-    "ne:name_alt":null,
-    "ne:name_ar":"\u0645\u0642\u062f\u0648\u0646\u064a\u0627 \u0627\u0644\u0634\u0645\u0627\u0644\u064a\u0629",
-    "ne:name_bn":"\u0989\u09a4\u09cd\u09a4\u09b0 \u09ae\u09cd\u09af\u09be\u09b8\u09c7\u09a1\u09cb\u09a8\u09bf\u09af\u09bc\u09be",
-    "ne:name_ciawf":"North Macedonia",
-    "ne:name_de":"Nordmazedonien",
-    "ne:name_el":"\u0392\u03cc\u03c1\u03b5\u03b9\u03b1 \u039c\u03b1\u03ba\u03b5\u03b4\u03bf\u03bd\u03af\u03b1",
-    "ne:name_en":"North Macedonia",
-    "ne:name_es":"Macedonia del Norte",
-    "ne:name_fr":"Mac\u00e9doine du Nord",
-    "ne:name_he":"\u05de\u05e7\u05d3\u05d5\u05e0\u05d9\u05d4 \u05d4\u05e6\u05e4\u05d5\u05e0\u05d9\u05ea",
-    "ne:name_hi":"\u0909\u0924\u094d\u0924\u0930 \u092e\u0948\u0938\u093f\u0921\u094b\u0928\u093f\u092f\u093e",
-    "ne:name_hu":"\u00c9szak-Maced\u00f3nia",
-    "ne:name_id":"Republik Makedonia Utara",
-    "ne:name_it":"Macedonia del Nord",
-    "ne:name_ja":"\u5317\u30de\u30b1\u30c9\u30cb\u30a2",
-    "ne:name_ko":"\ubd81\ub9c8\ucf00\ub3c4\ub2c8\uc544",
-    "ne:name_len":15,
-    "ne:name_long":"North Macedonia",
-    "ne:name_nl":"Noord-Macedoni\u00eb",
-    "ne:name_pl":"Macedonia P\u00f3\u0142nocna",
-    "ne:name_pt":"Rep\u00fablica da Maced\u00f3nia do Norte",
-    "ne:name_ru":"\u0421\u0435\u0432\u0435\u0440\u043d\u0430\u044f \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0438\u044f",
-    "ne:name_sort":"North Macedonia",
-    "ne:name_sv":"Nordmakedonien",
-    "ne:name_tr":"Kuzey Makedonya",
-    "ne:name_uk":"\u041f\u0456\u0432\u043d\u0456\u0447\u043d\u0430 \u041c\u0430\u043a\u0435\u0434\u043e\u043d\u0456\u044f",
-    "ne:name_ur":"\u0634\u0645\u0627\u0644\u06cc \u0645\u0642\u062f\u0648\u0646\u06cc\u06c1",
-    "ne:name_vi":"B\u1eafc Macedonia",
-    "ne:name_zh":"\u5317\u9a6c\u5176\u987f",
-    "ne:note_adm0":null,
-    "ne:note_brk":null,
-    "ne:pop_est":2083459,
-    "ne:pop_rank":12,
-    "ne:pop_year":2019,
-    "ne:postal":"NM",
-    "ne:region_un":"Europe",
-    "ne:region_wb":"Europe & Central Asia",
-    "ne:scalerank":0,
-    "ne:sov_a3":"MKD",
-    "ne:sovereignt":"North Macedonia",
-    "ne:su_a3":"MKD",
-    "ne:su_dif":0,
-    "ne:subregion":"Southern Europe",
-    "ne:subunit":"North Macedonia",
-    "ne:tiny":-99,
-    "ne:type":"Sovereign country",
-    "ne:un_a3":"807",
-    "ne:wb_a2":"MK",
-    "ne:wb_a3":"MKD",
-    "ne:wikidataid":"Q221",
-    "ne:wikipedia":"-99",
-    "ne:woe_id":23424890,
-    "ne:woe_id_eh":23424890,
-    "ne:woe_note":"Exact WOE match as country",
-    "qs:a0":"Macedonia",
-    "qs:a0_alt":"Macedonia",
-    "qs:adm0":"Macedonia",
-    "qs:adm0_a3":"MKD",
-    "qs:level":"adm0",
-    "qs:scale":200000,
-    "qs:source":"US State Department, with Natural Earth mods",
-    "src:geom":"quattroshapes",
-    "src:geom_alt":[
-        "naturalearth",
-        "meso"
+    "ne:abbrev": "N. Mac.",
+    "ne:abbrev_len": 7,
+    "ne:adm0_a3": "MKD",
+    "ne:adm0_a3_ar": "MKD",
+    "ne:adm0_a3_bd": "MKD",
+    "ne:adm0_a3_br": "MKD",
+    "ne:adm0_a3_cn": "MKD",
+    "ne:adm0_a3_de": "MKD",
+    "ne:adm0_a3_eg": "MKD",
+    "ne:adm0_a3_es": "MKD",
+    "ne:adm0_a3_fr": "MKD",
+    "ne:adm0_a3_gb": "MKD",
+    "ne:adm0_a3_gr": "MKD",
+    "ne:adm0_a3_id": "MKD",
+    "ne:adm0_a3_il": "MKD",
+    "ne:adm0_a3_in": "MKD",
+    "ne:adm0_a3_is": "MKD",
+    "ne:adm0_a3_it": "MKD",
+    "ne:adm0_a3_jp": "MKD",
+    "ne:adm0_a3_ko": "MKD",
+    "ne:adm0_a3_ma": "MKD",
+    "ne:adm0_a3_nl": "MKD",
+    "ne:adm0_a3_np": "MKD",
+    "ne:adm0_a3_pk": "MKD",
+    "ne:adm0_a3_pl": "MKD",
+    "ne:adm0_a3_ps": "MKD",
+    "ne:adm0_a3_pt": "MKD",
+    "ne:adm0_a3_ru": "MKD",
+    "ne:adm0_a3_sa": "MKD",
+    "ne:adm0_a3_se": "MKD",
+    "ne:adm0_a3_tr": "MKD",
+    "ne:adm0_a3_tw": "MKD",
+    "ne:adm0_a3_ua": "MKD",
+    "ne:adm0_a3_un": -99,
+    "ne:adm0_a3_us": "MKD",
+    "ne:adm0_a3_vn": "MKD",
+    "ne:adm0_a3_wb": -99,
+    "ne:adm0_dif": 0,
+    "ne:admin": "North Macedonia",
+    "ne:brk_a3": "MKD",
+    "ne:brk_diff": 0,
+    "ne:brk_group": null,
+    "ne:brk_name": "North Macedonia",
+    "ne:continent": "Europe",
+    "ne:economy": "6. Developing region",
+    "ne:featurecla": "Admin-0 country",
+    "ne:fips_10": "MK",
+    "ne:fips_10_": "MK",
+    "ne:formal_en": "Republic of North Macedonia",
+    "ne:formal_fr": null,
+    "ne:gdp_md": 12547,
+    "ne:gdp_md_est": 18780,
+    "ne:gdp_year": 2019,
+    "ne:geou_dif": 0,
+    "ne:geounit": "North Macedonia",
+    "ne:gu_a3": "MKD",
+    "ne:homepart": 1,
+    "ne:income_grp": "3. Upper middle income",
+    "ne:iso_a2": "MK",
+    "ne:iso_a2_eh": "MK",
+    "ne:iso_a3": "MKD",
+    "ne:iso_a3_eh": "MKD",
+    "ne:iso_n3": "807",
+    "ne:iso_n3_eh": "807",
+    "ne:labelrank": 6,
+    "ne:lastcensus": 2010,
+    "ne:level": 2,
+    "ne:long_len": 15,
+    "ne:mapcolor13": 3,
+    "ne:mapcolor7": 5,
+    "ne:mapcolor8": 3,
+    "ne:mapcolor9": 7,
+    "ne:max_label": 10,
+    "ne:min_label": 5,
+    "ne:min_zoom": 0,
+    "ne:name_alt": null,
+    "ne:name_ar": "مقدونيا الشمالية",
+    "ne:name_bn": "উত্তর ম্যাসেডোনিয়া",
+    "ne:name_ciawf": "North Macedonia",
+    "ne:name_de": "Nordmazedonien",
+    "ne:name_el": "Βόρεια Μακεδονία",
+    "ne:name_en": "North Macedonia",
+    "ne:name_es": "Macedonia del Norte",
+    "ne:name_fr": "Macédoine du Nord",
+    "ne:name_he": "מקדוניה הצפונית",
+    "ne:name_hi": "उत्तर मैसिडोनिया",
+    "ne:name_hu": "Észak-Macedónia",
+    "ne:name_id": "Republik Makedonia Utara",
+    "ne:name_it": "Macedonia del Nord",
+    "ne:name_ja": "北マケドニア",
+    "ne:name_ko": "북마케도니아",
+    "ne:name_len": 15,
+    "ne:name_long": "North Macedonia",
+    "ne:name_nl": "Noord-Macedonië",
+    "ne:name_pl": "Macedonia Północna",
+    "ne:name_pt": "República da Macedónia do Norte",
+    "ne:name_ru": "Северная Македония",
+    "ne:name_sort": "North Macedonia",
+    "ne:name_sv": "Nordmakedonien",
+    "ne:name_tr": "Kuzey Makedonya",
+    "ne:name_uk": "Північна Македонія",
+    "ne:name_ur": "شمالی مقدونیہ",
+    "ne:name_vi": "Bắc Macedonia",
+    "ne:name_zh": "北马其顿",
+    "ne:note_adm0": null,
+    "ne:note_brk": null,
+    "ne:pop_est": 2083459,
+    "ne:pop_rank": 12,
+    "ne:pop_year": 2019,
+    "ne:postal": "NM",
+    "ne:region_un": "Europe",
+    "ne:region_wb": "Europe \u0026 Central Asia",
+    "ne:scalerank": 0,
+    "ne:sov_a3": "MKD",
+    "ne:sovereignt": "North Macedonia",
+    "ne:su_a3": "MKD",
+    "ne:su_dif": 0,
+    "ne:subregion": "Southern Europe",
+    "ne:subunit": "North Macedonia",
+    "ne:tiny": -99,
+    "ne:type": "Sovereign country",
+    "ne:un_a3": "807",
+    "ne:wb_a2": "MK",
+    "ne:wb_a3": "MKD",
+    "ne:wikidataid": "Q221",
+    "ne:wikipedia": "-99",
+    "ne:woe_id": 23424890,
+    "ne:woe_id_eh": 23424890,
+    "ne:woe_note": "Exact WOE match as country",
+    "qs:a0": "Macedonia",
+    "qs:a0_alt": "Macedonia",
+    "qs:adm0": "Macedonia",
+    "qs:adm0_a3": "MKD",
+    "qs:level": "adm0",
+    "qs:scale": 200000,
+    "qs:source": "US State Department, with Natural Earth mods",
+    "src:geom": "quattroshapes",
+    "src:geom_alt": [
+      "naturalearth",
+      "meso"
     ],
-    "src:lbl_centroid":"mapshaper",
-    "src:population":"eurostat",
-    "src:population_date":"2022",
-    "statoids:dial":"389",
-    "statoids:ds":"MK",
-    "statoids:fifa":"MKD",
-    "statoids:gaul":"241",
-    "statoids:gec":"MK",
-    "statoids:independent":"Yes",
-    "statoids:ioc":"MKD",
-    "statoids:iso_a2":"MK",
-    "statoids:iso_a3":"MKD",
-    "statoids:iso_num":"807",
-    "statoids:itu":"MKD",
-    "statoids:marc":"xn",
-    "statoids:name":"Macedonia",
-    "statoids:wmo":"MJ",
-    "wof:belongsto":[
-        102191581
+    "src:lbl_centroid": "mapshaper",
+    "src:population": "eurostat",
+    "src:population_date": "2022",
+    "statoids:dial": "389",
+    "statoids:ds": "MK",
+    "statoids:fifa": "MKD",
+    "statoids:gaul": "241",
+    "statoids:gec": "MK",
+    "statoids:independent": "Yes",
+    "statoids:ioc": "MKD",
+    "statoids:iso_a2": "MK",
+    "statoids:iso_a3": "MKD",
+    "statoids:iso_num": "807",
+    "statoids:itu": "MKD",
+    "statoids:marc": "xn",
+    "statoids:name": "Macedonia",
+    "statoids:wmo": "MJ",
+    "wof:belongsto": [
+      102191581
     ],
-    "wof:breaches":[],
-    "wof:capital":[
-        890491957
+    "wof:breaches": [],
+    "wof:capital": [
+      890491957
     ],
-    "wof:concordances":{
-        "dbp:id":"Republic_of_Macedonia",
-        "digitalenvoy:country_code":807,
-        "eurostat:nuts_2021_id":"MK00",
-        "fb:id":"en.republic_of_macedonia",
-        "fifa:id":"MKD",
-        "fips:code":"MK",
-        "gaul:id":"241",
-        "gn:id":718075,
-        "gp:id":23424890,
-        "hasc:id":"MK",
-        "icao:code":"Z3",
-        "ioc:id":"MKD",
-        "iso:code":"MK",
-        "itu:id":"MKD",
-        "m49:code":"807",
-        "marc:id":"xn",
-        "mzb:id":"macedonia",
-        "ne:adm0_a3":"MKD",
-        "ne:id":1159321061,
-        "nyt:id":"N10179867412688300691",
-        "qs_pg:id":220227,
-        "uncrt:id":"MK",
-        "wd:id":"Q221",
-        "wk:page":"Republic of Macedonia",
-        "wmo:id":"MJ"
+    "wof:concordances": {
+      "dbp:id": "Republic_of_Macedonia",
+      "digitalenvoy:country_code": 807,
+      "eurostat:nuts_2021_id": "MK00",
+      "fb:id": "en.republic_of_macedonia",
+      "fifa:id": "MKD",
+      "fips:code": "MK",
+      "gaul:id": "241",
+      "gn:id": 718075,
+      "gp:id": 23424890,
+      "hasc:id": "MK",
+      "icao:code": "Z3",
+      "ioc:id": "MKD",
+      "iso:code": "MK",
+      "itu:id": "MKD",
+      "m49:code": "807",
+      "marc:id": "xn",
+      "mzb:id": "macedonia",
+      "ne:adm0_a3": "MKD",
+      "ne:id": 1159321061,
+      "nyt:id": "N10179867412688300691",
+      "qs_pg:id": 220227,
+      "uncrt:id": "MK",
+      "wd:id": "Q221",
+      "wk:page": "Republic of Macedonia",
+      "wmo:id": "MJ"
     },
-    "wof:concordances_official":"iso:code",
-    "wof:country":"MK",
-    "wof:country_alpha3":"MKD",
-    "wof:geom_alt":[
-        "meso",
-        "naturalearth",
-        "naturalearth-display-terrestrial-zoom6"
+    "wof:concordances_official": "iso:code",
+    "wof:country": "MK",
+    "wof:country_alpha3": "MKD",
+    "wof:created": 1712250763,
+    "wof:geom_alt": [
+      "meso",
+      "naturalearth",
+      "naturalearth-display-terrestrial-zoom6"
     ],
-    "wof:geomhash":"15e83cba4df3d6456d97f2592b744aec",
-    "wof:hierarchy":[
-        {
-            "continent_id":102191581,
-            "country_id":85632373
-        }
+    "wof:geomhash": "ec1648894a6594a5d3b9e4d216dbf645",
+    "wof:hierarchy": [
+      {
+        "continent_id": 102191581,
+        "country_id": 85632373
+      }
     ],
-    "wof:id":85632373,
-    "wof:lang_x_official":[
-        "mkd"
+    "wof:id": 85632373,
+    "wof:lang_x_official": [
+      "mkd"
     ],
-    "wof:lang_x_spoken":[
-        "mkd",
-        "sqi"
+    "wof:lang_x_spoken": [
+      "mkd",
+      "sqi"
     ],
-    "wof:lastmodified":1695881376,
-    "wof:name":"North Macedonia",
-    "wof:parent_id":102191581,
-    "wof:placetype":"country",
-    "wof:population":1837114,
-    "wof:population_rank":12,
-    "wof:repo":"whosonfirst-data-admin-mk",
-    "wof:shortcode":"MKD",
-    "wof:superseded_by":[],
-    "wof:supersedes":[
-        1108955787
+    "wof:lastmodified": 1712250763,
+    "wof:name": "North Macedonia",
+    "wof:parent_id": 102191581,
+    "wof:placetype": "country",
+    "wof:population": 1837114,
+    "wof:population_rank": 12,
+    "wof:repo": "whosonfirst-data-admin-mk",
+    "wof:shortcode": "MKD",
+    "wof:superseded_by": [],
+    "wof:supersedes": [
+      1108955787
     ],
-    "wof:tags":[]
-},
+    "wof:tags": []
+  },
   "bbox": [
     20.452423,
     40.853344,
     23.034093,
     42.37363
-],
-  "geometry": {"coordinates":[[[21.421777,42.241387],[21.420279,42.241454],[21.420315,42.241034],[21.421748,42.241072],[21.422452,42.240767],[21.422973,42.240392],[21.424367,42.239796],[21.424825,42.239233],[21.425492,42.238289],[21.426079,42.238067],[21.426208,42.237357],[21.426978,42.236201],[21.42801,42.236508],[21.428533,42.23674],[21.429071,42.236803],[21.429773,42.236668],[21.430096,42.236122],[21.429996,42.235511],[21.430538,42.234719],[21.430923,42.234073],[21.432564,42.232339],[21.433041,42.232325],[21.433941,42.231691],[21.434312,42.23201],[21.435478,42.232455],[21.435537,42.233107],[21.436563,42.232587],[21.437597,42.233738],[21.438884,42.233484],[21.439248,42.233992],[21.439956,42.233821],[21.440313,42.234176],[21.442518,42.235052],[21.443122,42.234866],[21.444318,42.234931],[21.443442,42.236672],[21.443563,42.237336],[21.443177,42.238366],[21.442754,42.238718],[21.442176,42.239494],[21.442509,42.239828],[21.442802,42.240586],[21.44353,42.241165],[21.443037,42.241622],[21.442008,42.241929],[21.441572,42.242627],[21.440942,42.24348],[21.440506,42.244128],[21.439656,42.244967],[21.439431,42.245339],[21.437555,42.246409],[21.437057,42.246787],[21.43659,42.247033],[21.436267,42.247706],[21.434839,42.249758],[21.434829,42.250476],[21.434873,42.251322],[21.434653,42.252009],[21.434568,42.252542],[21.433876,42.253708],[21.433441,42.254904],[21.433431,42.255495],[21.432902,42.258423],[21.432506,42.259304],[21.437013,42.260553],[21.440422,42.26234],[21.440595,42.26329],[21.441024,42.267574],[21.439968,42.269362],[21.441241,42.271979],[21.44006,42.272962],[21.439988,42.274265],[21.440463,42.274477],[21.441213,42.274252],[21.444213,42.275397],[21.444105,42.27608],[21.443795,42.276378],[21.444858,42.277898],[21.448275,42.279051],[21.448767,42.279004],[21.449564,42.277868],[21.450245,42.276731],[21.451923,42.276736],[21.452661,42.276491],[21.455761,42.276671],[21.456656,42.276503],[21.45911,42.276737],[21.46408,42.277776],[21.466094,42.278644],[21.466443,42.279622],[21.468457,42.280055],[21.470801,42.280035],[21.472661,42.279613],[21.474196,42.2795],[21.475596,42.279228],[21.479548,42.277083],[21.48368,42.275391],[21.485971,42.274331],[21.486659,42.273906],[21.488942,42.273913],[21.489733,42.27353],[21.492008,42.273284],[21.492502,42.273563],[21.493003,42.273725],[21.493516,42.274118],[21.494301,42.27429],[21.49512,42.274131],[21.49564,42.274609],[21.49623,42.2746],[21.496563,42.27431],[21.497036,42.274051],[21.49725,42.273496],[21.498214,42.27282],[21.499119,42.272831],[21.500008,42.272599],[21.500463,42.271399],[21.500895,42.271308],[21.503898,42.269804],[21.504996,42.270908],[21.50591,42.271136],[21.507216,42.271881],[21.50751,42.271455],[21.507985,42.271113],[21.50847,42.270918],[21.509392,42.270668],[21.51044,42.270533],[21.511138,42.270538],[21.511517,42.270255],[21.512094,42.269497],[21.512166,42.269152],[21.511572,42.268634],[21.511047,42.268352],[21.510801,42.267372],[21.511121,42.26602],[21.511437,42.265731],[21.513834,42.264907],[21.514335,42.263795],[21.515401,42.263355],[21.51589,42.263263],[21.516595,42.262986],[21.516978,42.263129],[21.517399,42.263163],[21.519273,42.262147],[21.519505,42.261722],[21.519592,42.261029],[21.520159,42.260607],[21.518599,42.260623],[21.518391,42.260214],[21.517759,42.259605],[21.517862,42.258956],[21.517993,42.257953],[21.518509,42.257314],[21.519018,42.255173],[21.519907,42.253512],[21.5203,42.25246],[21.520385,42.25137],[21.519302,42.24958],[21.519635,42.24834],[21.520234,42.247775],[21.520552,42.247286],[21.520719,42.246694],[21.52043,42.245553],[21.520575,42.244851],[21.521309,42.244759],[21.521226,42.243467],[21.521002,42.24283],[21.520933,42.242197],[21.521277,42.241469],[21.523505,42.241181],[21.524156,42.241236],[21.526557,42.241068],[21.527506,42.241009],[21.528727,42.241142],[21.529548,42.240846],[21.532035,42.240617],[21.533552,42.241593],[21.533023,42.242032],[21.532403,42.242512],[21.532909,42.243279],[21.534507,42.244435],[21.534834,42.244765],[21.53437,42.245492],[21.535059,42.245902],[21.535368,42.246188],[21.535956,42.246337],[21.536663,42.246895],[21.53727,42.248479],[21.537873,42.249302],[21.538533,42.250014],[21.538723,42.250397],[21.539075,42.250629],[21.540433,42.250912],[21.541216,42.251465],[21.542547,42.252232],[21.542823,42.252402],[21.542847,42.252041],[21.542406,42.251686],[21.542906,42.251459],[21.543777,42.251249],[21.544244,42.251102],[21.544405,42.25177],[21.54429,42.252215],[21.543776,42.25325],[21.544259,42.25345],[21.544907,42.253629],[21.545181,42.253294],[21.54618,42.253535],[21.54757,42.253154],[21.548685,42.253405],[21.549505,42.253599],[21.550129,42.252945],[21.550434,42.252324],[21.551463,42.252476],[21.55189,42.25216],[21.552389,42.252298],[21.553713,42.250424],[21.55571,42.25045],[21.557714,42.25086],[21.558704,42.251439],[21.558947,42.251747],[21.558485,42.252879],[21.563046,42.250737],[21.567964,42.250919],[21.569046,42.250744],[21.570775,42.251829],[21.575373,42.254198],[21.575794,42.254995],[21.575878,42.25541],[21.57622,42.255854],[21.57665,42.256004],[21.578238,42.25679],[21.580327,42.259443],[21.580861,42.259734],[21.581712,42.260097],[21.581721,42.259719],[21.582323,42.259474],[21.583226,42.25923],[21.58359,42.259343],[21.583501,42.259842],[21.584372,42.260227],[21.584574,42.260521],[21.585153,42.260814],[21.585623,42.261401],[21.586239,42.261994],[21.586443,42.262519],[21.587002,42.262783],[21.587413,42.262404],[21.587747,42.262022],[21.588104,42.261631],[21.588623,42.261456],[21.589302,42.261481],[21.589842,42.261257],[21.590223,42.26104],[21.590815,42.260754],[21.591341,42.260464],[21.591821,42.260251],[21.591946,42.259914],[21.591782,42.25946],[21.591756,42.259041],[21.592209,42.258841],[21.592306,42.258474],[21.592669,42.258362],[21.592989,42.25823],[21.593355,42.257954],[21.593912,42.257513],[21.594472,42.257325],[21.595152,42.257227],[21.5958,42.257175],[21.596281,42.256985],[21.596665,42.256771],[21.597366,42.256428],[21.598036,42.256069],[21.598675,42.255734],[21.599567,42.255207],[21.600204,42.254795],[21.600588,42.254554],[21.601012,42.254446],[21.600863,42.254875],[21.600733,42.255429],[21.600539,42.256126],[21.600465,42.256724],[21.601185,42.256672],[21.601858,42.256527],[21.602657,42.256401],[21.603491,42.256207],[21.604,42.255894],[21.604479,42.255608],[21.605148,42.255054],[21.605482,42.254803],[21.605948,42.254765],[21.606525,42.254879],[21.607231,42.254997],[21.607939,42.255184],[21.608583,42.255371],[21.609726,42.255842],[21.610677,42.256263],[21.611868,42.256733],[21.61248,42.256969],[21.613073,42.257027],[21.613472,42.256798],[21.613789,42.256413],[21.614525,42.256103],[21.615036,42.255921],[21.615515,42.255692],[21.616059,42.255522],[21.616635,42.255398],[21.617128,42.25504],[21.617365,42.254726],[21.617681,42.254322],[21.618031,42.253937],[21.618542,42.253555],[21.619081,42.25322],[21.619491,42.252995],[21.620201,42.252583],[21.62073,42.252358],[21.621225,42.252285],[21.621801,42.252445],[21.622404,42.252657],[21.622898,42.252605],[21.623381,42.252396],[21.624,42.252132],[21.624598,42.251942],[21.625334,42.251766],[21.626024,42.251678],[21.626877,42.251518],[21.628418,42.251152],[21.62895,42.251008],[21.629303,42.2509],[21.62968,42.250982],[21.630101,42.251229],[21.630692,42.251475],[21.631247,42.251503],[21.631685,42.25157],[21.63217,42.251671],[21.632607,42.251667],[21.633207,42.251663],[21.633852,42.251606],[21.634382,42.251591],[21.634933,42.251553],[21.635418,42.251549],[21.635879,42.251452],[21.636643,42.251101],[21.637266,42.250778],[21.637725,42.250495],[21.638092,42.250275],[21.638608,42.25004],[21.639346,42.249979],[21.640014,42.249958],[21.640647,42.249815],[21.641336,42.24976],[21.641972,42.2498],[21.642789,42.249733],[21.643412,42.249729],[21.643999,42.249752],[21.644518,42.249725],[21.644979,42.249722],[21.645395,42.249775],[21.645971,42.249752],[21.646605,42.249775],[21.647274,42.249737],[21.647688,42.249771],[21.648218,42.249729],[21.648622,42.249676],[21.649095,42.249699],[21.649693,42.249594],[21.650127,42.249325],[21.650494,42.249065],[21.651068,42.248772],[21.651664,42.248495],[21.652191,42.24815],[21.652614,42.247857],[21.653131,42.247715],[21.653523,42.247562],[21.654073,42.247334],[21.654532,42.247082],[21.654922,42.247089],[21.655443,42.247212],[21.656094,42.247692],[21.656534,42.247994],[21.656988,42.24843],[21.657441,42.248797],[21.657905,42.248932],[21.658432,42.248703],[21.659004,42.248375],[21.659372,42.248184],[21.659784,42.248032],[21.660244,42.247822],[21.660635,42.247665],[21.661116,42.247436],[21.661598,42.247166],[21.66208,42.246996],[21.662495,42.246952],[21.662932,42.246845],[21.663368,42.246679],[21.663572,42.246365],[21.663805,42.245887],[21.663885,42.245522],[21.664102,42.245223],[21.663974,42.244774],[21.663529,42.244501],[21.663534,42.243918],[21.663866,42.243561],[21.664427,42.243258],[21.664981,42.243031],[21.665314,42.242661],[21.665469,42.24306],[21.665864,42.243124],[21.666183,42.242596],[21.666623,42.242792],[21.666839,42.243212],[21.667492,42.243164],[21.667963,42.243058],[21.668473,42.24276],[21.668714,42.243137],[21.669232,42.243128],[21.669871,42.242985],[21.669797,42.242492],[21.670016,42.242059],[21.670384,42.241928],[21.670754,42.242072],[21.671236,42.242046],[21.671681,42.241909],[21.672115,42.242218],[21.672568,42.242611],[21.672928,42.242855],[21.673221,42.243233],[21.673483,42.242889],[21.673662,42.242544],[21.674015,42.242184],[21.674538,42.241934],[21.675026,42.241696],[21.675459,42.241226],[21.675903,42.240792],[21.676605,42.240822],[21.677277,42.240902],[21.677714,42.240902],[21.678223,42.241035],[21.678823,42.241119],[21.67947,42.24128],[21.67947,42.241829],[21.679273,42.242351],[21.679297,42.242698],[21.679783,42.2425],[21.680333,42.242308],[21.681035,42.242192],[21.681738,42.242165],[21.682268,42.242107],[21.682821,42.242123],[21.683408,42.242053],[21.683891,42.242027],[21.684548,42.241827],[21.685096,42.241398],[21.685528,42.240876],[21.685915,42.240466],[21.686293,42.240276],[21.686858,42.240265],[21.687399,42.240166],[21.687881,42.240078],[21.688364,42.239956],[21.688801,42.239853],[21.689215,42.239746],[21.689629,42.239613],[21.690027,42.239304],[21.690453,42.23914],[21.690935,42.23893],[21.6913,42.238571],[21.691525,42.238037],[21.691669,42.237616],[21.691989,42.23728],[21.692434,42.236807],[21.692612,42.236347],[21.692872,42.235904],[21.693212,42.235344],[21.693609,42.234837],[21.693871,42.234432],[21.694096,42.234001],[21.694275,42.233505],[21.694471,42.233178],[21.695216,42.233074],[21.695837,42.232929],[21.696295,42.232792],[21.696743,42.232602],[21.697319,42.232615],[21.697792,42.232613],[21.698181,42.232475],[21.698526,42.232315],[21.698788,42.232142],[21.699005,42.231796],[21.699264,42.231602],[21.69957,42.232429],[21.699688,42.233181],[21.699632,42.233701],[21.700064,42.233864],[21.700548,42.233894],[21.701126,42.233959],[21.701656,42.234043],[21.702095,42.234116],[21.702283,42.234503],[21.701942,42.235348],[21.701884,42.235892],[21.702201,42.23659],[21.702622,42.236855],[21.703094,42.236826],[21.703671,42.236899],[21.704235,42.236912],[21.704697,42.236946],[21.705411,42.236925],[21.705921,42.237059],[21.706223,42.237297],[21.706535,42.237612],[21.706794,42.237961],[21.707085,42.238266],[21.70725,42.238549],[21.707553,42.238863],[21.707992,42.238979],[21.708592,42.239071],[21.709228,42.239195],[21.709714,42.239439],[21.710285,42.239848],[21.71068,42.240215],[21.711052,42.240519],[21.71154,42.240818],[21.711842,42.241013],[21.712076,42.241362],[21.712219,42.241755],[21.712431,42.242147],[21.712814,42.242489],[21.713064,42.242807],[21.713538,42.243124],[21.713947,42.243775],[21.714381,42.244368],[21.714825,42.244907],[21.715128,42.245194],[21.715477,42.245486],[21.715732,42.245792],[21.715992,42.246169],[21.716551,42.246718],[21.716661,42.24725],[21.716423,42.24757],[21.716115,42.247956],[21.715773,42.248322],[21.715661,42.248637],[21.715768,42.249208],[21.715681,42.249752],[21.715286,42.250069],[21.715023,42.250294],[21.714808,42.250664],[21.714699,42.251064],[21.714726,42.251536],[21.714731,42.251973],[21.715058,42.252279],[21.715269,42.252602],[21.71548,42.252938],[21.715782,42.253128],[21.716196,42.253162],[21.716612,42.253197],[21.717096,42.253174],[21.717615,42.253094],[21.71829,42.253299],[21.718846,42.253918],[21.719278,42.254403],[21.71979,42.254826],[21.720205,42.255301],[21.720181,42.255684],[21.720335,42.256161],[21.72078,42.25642],[21.72114,42.256951],[21.721489,42.257172],[21.722098,42.257129],[21.722595,42.257244],[21.723044,42.257214],[21.723462,42.257376],[21.723756,42.257902],[21.724016,42.258499],[21.724218,42.25897],[21.724304,42.259457],[21.724424,42.259903],[21.724499,42.260311],[21.724514,42.261784],[21.724474,42.262199],[21.724493,42.262924],[21.724419,42.263464],[21.724207,42.264004],[21.723995,42.264633],[21.723795,42.265328],[21.724176,42.265476],[21.72459,42.265408],[21.725052,42.265423],[21.725513,42.265419],[21.726055,42.265315],[21.726662,42.265083],[21.727098,42.264877],[21.727696,42.264584],[21.728222,42.264275],[21.728679,42.263996],[21.729275,42.263668],[21.729848,42.263371],[21.730604,42.263004],[21.731705,42.262363],[21.732231,42.262074],[21.73262,42.261864],[21.733032,42.261536],[21.733513,42.261191],[21.734039,42.260857],[21.734533,42.260712],[21.735224,42.260658],[21.735731,42.260685],[21.736284,42.260651],[21.736931,42.260658],[21.737484,42.260605],[21.738012,42.260605],[21.73859,42.260616],[21.739075,42.260612],[21.73951,42.26049],[21.740064,42.260479],[21.740778,42.260433],[21.741238,42.260326],[21.741862,42.260424],[21.742624,42.26059],[21.743065,42.260761],[21.743551,42.260851],[21.744163,42.260982],[21.744556,42.261122],[21.745088,42.261164],[21.745529,42.261234],[21.746075,42.26119],[21.746674,42.261074],[21.747122,42.260969],[21.747795,42.260926],[21.74847,42.260933],[21.748942,42.260969],[21.749418,42.261069],[21.749821,42.261215],[21.75015,42.261257],[21.750479,42.261246],[21.750877,42.261181],[21.751181,42.261027],[21.751457,42.260681],[21.751838,42.260279],[21.752306,42.25984],[21.752678,42.259466],[21.75318,42.259155],[21.753546,42.258961],[21.753967,42.258681],[21.754564,42.258308],[21.755026,42.258041],[21.755618,42.257712],[21.756174,42.257435],[21.756649,42.257181],[21.757053,42.257183],[21.757456,42.257267],[21.757811,42.257427],[21.758342,42.257578],[21.75885,42.25783],[21.759182,42.258182],[21.75947,42.258411],[21.759856,42.258227],[21.760347,42.258288],[21.760884,42.258347],[21.761412,42.258169],[21.761885,42.258108],[21.762424,42.258331],[21.76299,42.258658],[21.763441,42.258833],[21.763716,42.258976],[21.764136,42.259201],[21.764988,42.259654],[21.765169,42.26025],[21.765001,42.260548],[21.765072,42.260816],[21.765463,42.26097],[21.765514,42.261807],[21.765531,42.262493],[21.7657,42.262982],[21.766317,42.263245],[21.766623,42.263357],[21.766994,42.263417],[21.767294,42.263587],[21.767607,42.263744],[21.767962,42.263956],[21.768256,42.264326],[21.768356,42.264717],[21.768462,42.265185],[21.768984,42.265385],[21.769462,42.265303],[21.770105,42.265294],[21.770609,42.265392],[21.770948,42.265428],[21.771492,42.265324],[21.771845,42.26532],[21.772262,42.265301],[21.772581,42.265186],[21.773094,42.265173],[21.773671,42.265189],[21.774002,42.265534],[21.773874,42.266073],[21.7736,42.266495],[21.773323,42.266856],[21.773199,42.267185],[21.772962,42.26746],[21.772598,42.26783],[21.772496,42.268255],[21.773151,42.268216],[21.773803,42.268064],[21.774088,42.267868],[21.774337,42.267588],[21.774584,42.267207],[21.774999,42.266951],[21.775428,42.266783],[21.775864,42.266535],[21.776234,42.26689],[21.776731,42.267369],[21.777201,42.267757],[21.777533,42.268065],[21.777931,42.268517],[21.778302,42.268984],[21.777797,42.269369],[21.777153,42.269797],[21.776669,42.270168],[21.776232,42.270613],[21.775755,42.270985],[21.775383,42.271343],[21.7752,42.271558],[21.775491,42.271607],[21.775957,42.2717],[21.776622,42.271626],[21.77721,42.271565],[21.777709,42.271977],[21.778057,42.272327],[21.778407,42.272665],[21.778927,42.273253],[21.779458,42.273897],[21.779773,42.274378],[21.780086,42.274817],[21.780328,42.275113],[21.780605,42.275537],[21.780909,42.275853],[21.781275,42.276219],[21.781576,42.276611],[21.781837,42.277039],[21.782131,42.277405],[21.782371,42.277782],[21.782654,42.278097],[21.783003,42.278525],[21.783301,42.278914],[21.783771,42.279076],[21.784135,42.279219],[21.784633,42.279476],[21.785064,42.279677],[21.785555,42.279862],[21.785953,42.280203],[21.786196,42.280514],[21.78641,42.280848],[21.786686,42.281193],[21.786876,42.281553],[21.786994,42.282029],[21.787113,42.282518],[21.787033,42.282941],[21.786491,42.282818],[21.785977,42.282719],[21.785988,42.283133],[21.786138,42.283539],[21.786272,42.283993],[21.786478,42.284474],[21.786787,42.284793],[21.787117,42.284828],[21.787446,42.284842],[21.787661,42.28509],[21.787955,42.285154],[21.788395,42.285012],[21.788881,42.284747],[21.789312,42.28455],[21.789655,42.2846],[21.789762,42.28498],[21.789906,42.285512],[21.790212,42.286106],[21.79044,42.28657],[21.790707,42.287018],[21.790976,42.287438],[21.791215,42.287955],[21.79143,42.288399],[21.791668,42.288832],[21.791889,42.289211],[21.792087,42.289639],[21.792286,42.290139],[21.792421,42.290681],[21.792589,42.291296],[21.792744,42.291779],[21.792986,42.292229],[21.793393,42.29266],[21.793676,42.293063],[21.793813,42.293526],[21.793792,42.294113],[21.793689,42.294804],[21.793646,42.295546],[21.793655,42.296246],[21.793811,42.296589],[21.794113,42.296992],[21.794175,42.297443],[21.794444,42.297771],[21.79477,42.298048],[21.795085,42.29835],[21.795422,42.298309],[21.795725,42.298229],[21.7961,42.297974],[21.796528,42.29777],[21.797023,42.297706],[21.797392,42.297327],[21.797789,42.297105],[21.798342,42.297014],[21.798664,42.29667],[21.799193,42.296505],[21.799521,42.296341],[21.799937,42.296132],[21.80035,42.295889],[21.800619,42.29565],[21.801034,42.295447],[21.801575,42.295097],[21.802092,42.294649],[21.80248,42.294298],[21.802767,42.294086],[21.803078,42.293953],[21.803493,42.293896],[21.803854,42.293827],[21.804263,42.293818],[21.80472,42.29369],[21.80526,42.293615],[21.805889,42.293469],[21.806358,42.293511],[21.80677,42.293518],[21.807245,42.293499],[21.807749,42.293461],[21.80822,42.293475],[21.80868,42.293415],[21.808916,42.293133],[21.809155,42.292971],[21.80974,42.292943],[21.810256,42.293037],[21.810768,42.29295],[21.811163,42.29311],[21.811551,42.293303],[21.812011,42.293507],[21.812599,42.293718],[21.813,42.293739],[21.813426,42.293753],[21.814048,42.293796],[21.814713,42.293923],[21.815204,42.294068],[21.815632,42.294334],[21.816078,42.294661],[21.816467,42.295014],[21.816929,42.295351],[21.817366,42.295626],[21.818004,42.295994],[21.818224,42.29624],[21.818524,42.296541],[21.818817,42.296753],[21.819212,42.29693],[21.819809,42.29715],[21.820534,42.297341],[21.821049,42.297524],[21.821559,42.297753],[21.822003,42.297999],[21.822367,42.298214],[21.822714,42.298447],[21.823078,42.298615],[21.823362,42.298836],[21.823904,42.29921],[21.824228,42.299461],[21.824593,42.299704],[21.824877,42.300017],[21.825044,42.300402],[21.825282,42.300858],[21.825645,42.30126],[21.825396,42.301581],[21.824981,42.301829],[21.824616,42.302117],[21.824217,42.302357],[21.823811,42.302555],[21.823445,42.302949],[21.82376,42.303337],[21.824305,42.303471],[21.824717,42.303652],[21.825041,42.303977],[21.825381,42.304445],[21.825791,42.305145],[21.826283,42.305546],[21.826728,42.305665],[21.827271,42.305915],[21.827622,42.30616],[21.827937,42.306246],[21.828217,42.306554],[21.828739,42.306866],[21.829194,42.307259],[21.829459,42.307698],[21.829934,42.308081],[21.830303,42.308306],[21.830424,42.308619],[21.830898,42.308754],[21.831367,42.308935],[21.83185,42.309128],[21.832302,42.309321],[21.832796,42.309538],[21.833152,42.309809],[21.833583,42.310194],[21.834004,42.310555],[21.834396,42.310848],[21.834872,42.311169],[21.835452,42.311379],[21.835865,42.311643],[21.835533,42.312092],[21.835239,42.312638],[21.834899,42.313225],[21.83482,42.313572],[21.834613,42.314078],[21.83441,42.314465],[21.834212,42.314871],[21.834148,42.31535],[21.834153,42.315771],[21.834224,42.316229],[21.834325,42.31687],[21.834528,42.317387],[21.834581,42.317704],[21.834616,42.318043],[21.834406,42.318461],[21.834053,42.319094],[21.833702,42.319655],[21.833592,42.32009],[21.833847,42.320469],[21.834082,42.320882],[21.83413,42.321289],[21.834306,42.321603],[21.834626,42.321787],[21.835021,42.321885],[21.83546,42.321938],[21.836052,42.322181],[21.836585,42.322403],[21.837088,42.322745],[21.837623,42.323092],[21.838157,42.323445],[21.838705,42.323693],[21.83914,42.323769],[21.839728,42.323983],[21.840413,42.324125],[21.840896,42.324231],[21.841331,42.324322],[21.841735,42.32445],[21.842154,42.324554],[21.842524,42.324621],[21.843012,42.324805],[21.843413,42.325092],[21.843695,42.325423],[21.844073,42.325689],[21.844647,42.325716],[21.845272,42.325549],[21.845754,42.325516],[21.846291,42.325447],[21.846942,42.325464],[21.847321,42.325583],[21.847701,42.325618],[21.848082,42.32547],[21.848459,42.325443],[21.848972,42.32543],[21.849446,42.325462],[21.850048,42.325464],[21.850668,42.325546],[21.851046,42.325546],[21.851421,42.325601],[21.851883,42.32531],[21.852284,42.324869],[21.852379,42.324456],[21.852875,42.324295],[21.853468,42.324277],[21.854085,42.323968],[21.854457,42.323819],[21.854848,42.323635],[21.855257,42.323624],[21.855711,42.323687],[21.856427,42.323466],[21.856955,42.323284],[21.857385,42.323063],[21.85783,42.322762],[21.858149,42.322504],[21.858408,42.322133],[21.858302,42.321635],[21.858259,42.321224],[21.858366,42.320816],[21.858791,42.320603],[21.859268,42.320381],[21.859867,42.31977],[21.860097,42.31943],[21.860416,42.319246],[21.86067,42.319073],[21.860982,42.318949],[21.861294,42.318924],[21.861608,42.318917],[21.862178,42.31894],[21.862722,42.31885],[21.863026,42.318718],[21.8636,42.318478],[21.863998,42.318314],[21.864318,42.31811],[21.864658,42.317797],[21.865193,42.317553],[21.865591,42.317371],[21.865965,42.317091],[21.866341,42.316585],[21.866384,42.316032],[21.866147,42.3155],[21.866747,42.314937],[21.867174,42.31456],[21.867268,42.314262],[21.867466,42.313826],[21.867391,42.313093],[21.86743,42.312463],[21.867787,42.311969],[21.867774,42.311437],[21.867992,42.311024],[21.868308,42.310595],[21.868666,42.310099],[21.868917,42.309628],[21.869321,42.309514],[21.869709,42.309575],[21.870143,42.309743],[21.870656,42.309715],[21.871086,42.309414],[21.871336,42.309017],[21.871604,42.308615],[21.87197,42.308407],[21.872305,42.308334],[21.872763,42.308314],[21.873253,42.308375],[21.873507,42.308749],[21.873315,42.309318],[21.873271,42.30967],[21.873334,42.310137],[21.873606,42.310641],[21.874008,42.311011],[21.874562,42.310943],[21.874759,42.310477],[21.875108,42.310133],[21.875582,42.30998],[21.876084,42.309855],[21.876582,42.309962],[21.876925,42.310328],[21.876993,42.310658],[21.876949,42.310967],[21.877057,42.311483],[21.877396,42.311886],[21.877773,42.312057],[21.878233,42.312073],[21.878595,42.312105],[21.879148,42.312103],[21.879581,42.312141],[21.880008,42.312157],[21.880516,42.312302],[21.88088,42.312586],[21.88127,42.31292],[21.881589,42.313291],[21.881936,42.313467],[21.882384,42.313412],[21.882888,42.313305],[21.883194,42.313267],[21.883673,42.31312],[21.884128,42.312937],[21.88462,42.312702],[21.885069,42.312333],[21.885266,42.311892],[21.885294,42.311404],[21.885409,42.310999],[21.885803,42.3105],[21.886208,42.31008],[21.886432,42.309618],[21.886547,42.308989],[21.886637,42.308525],[21.886716,42.308047],[21.886872,42.307697],[21.887214,42.307342],[21.887793,42.307035],[21.888461,42.306851],[21.888604,42.3065],[21.888682,42.306019],[21.888928,42.305512],[21.8892,42.304921],[21.889594,42.304364],[21.889935,42.304073],[21.890268,42.303905],[21.89066,42.30369],[21.891016,42.303398],[21.891358,42.303099],[21.891678,42.302529],[21.891923,42.302032],[21.892043,42.301682],[21.892146,42.301223],[21.892535,42.300682],[21.892819,42.300358],[21.893059,42.300101],[21.893454,42.300227],[21.893846,42.300322],[21.894233,42.30045],[21.894622,42.300698],[21.895099,42.300912],[21.895645,42.301035],[21.89628,42.301113],[21.896804,42.301174],[21.897269,42.301215],[21.897775,42.301255],[21.898209,42.301262],[21.898578,42.301274],[21.899059,42.3013],[21.899389,42.301315],[21.899752,42.30146],[21.900151,42.301633],[21.900674,42.301919],[21.900965,42.302048],[21.901303,42.302145],[21.901754,42.302254],[21.902246,42.302376],[21.902719,42.302509],[21.903229,42.302637],[21.903687,42.30275],[21.904153,42.302821],[21.904604,42.302887],[21.904935,42.303011],[21.905338,42.30308],[21.905759,42.303242],[21.906282,42.303495],[21.906635,42.303627],[21.907088,42.303782],[21.907707,42.303864],[21.908431,42.303938],[21.909235,42.304073],[21.909974,42.304096],[21.910393,42.304184],[21.911812,42.304192],[21.912199,42.30426],[21.91265,42.304344],[21.912987,42.304325],[21.913372,42.304325],[21.913943,42.304341],[21.914559,42.304364],[21.91518,42.304469],[21.915784,42.304608],[21.916204,42.304768],[21.917479,42.305248],[21.918012,42.30551],[21.918626,42.305807],[21.919142,42.30603],[21.919513,42.30617],[21.919962,42.306179],[21.920382,42.306175],[21.921022,42.30616],[21.921472,42.306168],[21.922097,42.306143],[21.922628,42.306175],[21.923023,42.306258],[21.923521,42.306424],[21.924008,42.306725],[21.924557,42.306971],[21.925028,42.307295],[21.92536,42.307556],[21.925766,42.30788],[21.926107,42.308174],[21.926416,42.308445],[21.926775,42.308727],[21.927114,42.309025],[21.927488,42.309292],[21.92807,42.309593],[21.928573,42.309887],[21.928788,42.310328],[21.928901,42.310915],[21.929023,42.311581],[21.929224,42.31214],[21.929392,42.31267],[21.929456,42.31321],[21.929514,42.313877],[21.929572,42.314574],[21.929677,42.315164],[21.929767,42.315697],[21.929873,42.316425],[21.930073,42.316898],[21.930047,42.317352],[21.930023,42.317913],[21.930022,42.318329],[21.930174,42.318846],[21.930445,42.319263],[21.930691,42.319678],[21.93107,42.320312],[21.93122,42.32069],[21.931502,42.321273],[21.931766,42.321787],[21.931459,42.322159],[21.931155,42.32259],[21.931086,42.323086],[21.930862,42.323616],[21.930643,42.323963],[21.930478,42.324253],[21.930381,42.324781],[21.930712,42.325424],[21.931041,42.325942],[21.931338,42.326409],[21.931599,42.327039],[21.931981,42.327601],[21.932189,42.32814],[21.932399,42.32874],[21.932592,42.329304],[21.932926,42.329632],[21.933365,42.330022],[21.933451,42.330414],[21.933303,42.330697],[21.933132,42.331116],[21.932986,42.331776],[21.933177,42.332546],[21.933378,42.333035],[21.933575,42.333371],[21.933756,42.333698],[21.933789,42.334098],[21.933516,42.334581],[21.93363,42.33495],[21.933804,42.335447],[21.934266,42.335597],[21.93471,42.335955],[21.934614,42.336308],[21.934303,42.33638],[21.934028,42.336548],[21.93403,42.337019],[21.933522,42.337375],[21.933006,42.337574],[21.932679,42.337968],[21.93254,42.338301],[21.932619,42.338656],[21.933142,42.338866],[21.933723,42.339062],[21.934381,42.339045],[21.934682,42.339244],[21.934839,42.339587],[21.934539,42.339905],[21.934126,42.340181],[21.933557,42.340528],[21.933781,42.340752],[21.934147,42.340777],[21.934573,42.340736],[21.935002,42.340504],[21.93539,42.340511],[21.93576,42.340705],[21.936015,42.340929],[21.936376,42.341134],[21.936719,42.341322],[21.937089,42.341433],[21.937391,42.341627],[21.937805,42.341903],[21.938174,42.341889],[21.93878,42.341817],[21.939373,42.342101],[21.939826,42.342297],[21.940197,42.342388],[21.940575,42.342423],[21.941027,42.34244],[21.941442,42.342641],[21.941834,42.342799],[21.942339,42.34285],[21.942791,42.342899],[21.943239,42.342919],[21.943706,42.342987],[21.944086,42.343125],[21.944515,42.3433],[21.944806,42.343483],[21.945099,42.343662],[21.94539,42.343889],[21.945604,42.344208],[21.945959,42.34465],[21.946413,42.344546],[21.946702,42.344273],[21.947249,42.344154],[21.947594,42.344101],[21.948014,42.343928],[21.948229,42.343581],[21.948255,42.343243],[21.948223,42.342746],[21.948613,42.34247],[21.949023,42.342467],[21.949433,42.342258],[21.949648,42.341836],[21.949867,42.341522],[21.950145,42.341284],[21.950655,42.34123],[21.951171,42.34147],[21.951649,42.341418],[21.952082,42.340932],[21.952613,42.340745],[21.953089,42.34053],[21.953508,42.340426],[21.95398,42.340441],[21.954458,42.340581],[21.954992,42.340559],[21.955358,42.340307],[21.955741,42.340099],[21.95614,42.340061],[21.956447,42.340086],[21.957014,42.340064],[21.957382,42.339659],[21.957622,42.339248],[21.957959,42.338882],[21.958148,42.338476],[21.958668,42.338084],[21.959288,42.33791],[21.959721,42.337807],[21.960024,42.337698],[21.960312,42.337563],[21.96059,42.337403],[21.960858,42.337078],[21.961078,42.336539],[21.961387,42.335995],[21.961703,42.335682],[21.962067,42.335335],[21.962569,42.335072],[21.963128,42.335129],[21.963521,42.335337],[21.963945,42.335424],[21.964654,42.335387],[21.965204,42.335171],[21.96566,42.33479],[21.96591,42.334359],[21.966187,42.333987],[21.966601,42.33355],[21.967123,42.333105],[21.967594,42.332838],[21.968,42.33264],[21.968349,42.332373],[21.96869,42.33211],[21.968954,42.331879],[21.96963,42.331642],[21.970273,42.331471],[21.970614,42.330841],[21.97094,42.330498],[21.97141,42.330431],[21.971964,42.330429],[21.97249,42.330366],[21.972898,42.330115],[21.973183,42.329773],[21.97348,42.329285],[21.973729,42.32873],[21.97413,42.328292],[21.974621,42.328287],[21.975129,42.328424],[21.97573,42.328364],[21.976194,42.328215],[21.976642,42.327978],[21.976684,42.327444],[21.977039,42.327162],[21.977406,42.327238],[21.977763,42.327292],[21.978092,42.327068],[21.978295,42.326574],[21.978727,42.326304],[21.979175,42.326294],[21.979524,42.326381],[21.979962,42.326402],[21.980189,42.325986],[21.980366,42.325492],[21.980668,42.325301],[21.981087,42.325272],[21.981571,42.325421],[21.982089,42.325551],[21.9825,42.325443],[21.983005,42.325134],[21.983672,42.324964],[21.98421,42.324961],[21.984685,42.324991],[21.985088,42.325081],[21.985426,42.325165],[21.985876,42.325181],[21.986371,42.325051],[21.986676,42.324459],[21.986887,42.324059],[21.987065,42.323812],[21.987329,42.323696],[21.987641,42.323632],[21.988123,42.323605],[21.988499,42.323585],[21.988853,42.323521],[21.98941,42.323297],[21.989869,42.322872],[21.990179,42.322651],[21.990522,42.322552],[21.991121,42.322579],[21.991617,42.322716],[21.992003,42.322741],[21.992445,42.322762],[21.992875,42.322727],[21.993348,42.322511],[21.99372,42.322197],[21.994124,42.321829],[21.994544,42.321558],[21.994914,42.321417],[21.995415,42.321242],[21.995764,42.320998],[21.995996,42.320657],[21.996386,42.320698],[21.996805,42.320797],[21.997188,42.320692],[21.997376,42.320378],[21.997353,42.319959],[21.997285,42.319472],[21.997564,42.319141],[21.997888,42.318916],[21.998283,42.318797],[21.99869,42.318668],[21.999194,42.318556],[21.999789,42.318353],[22.000396,42.317955],[22.000793,42.317644],[22.0011,42.317352],[22.00145,42.317053],[22.001797,42.316711],[22.002219,42.316444],[22.002646,42.316267],[22.003031,42.316061],[22.003478,42.315916],[22.00391,42.315806],[22.004206,42.315693],[22.004523,42.315592],[22.004919,42.315534],[22.00527,42.315442],[22.005677,42.315331],[22.006092,42.315308],[22.006489,42.315252],[22.006844,42.31505],[22.007041,42.314737],[22.0072,42.314288],[22.007525,42.31394],[22.007702,42.313596],[22.007546,42.312976],[22.007599,42.312357],[22.007963,42.31211],[22.008289,42.311699],[22.008404,42.311316],[22.008587,42.310915],[22.009133,42.310646],[22.009731,42.31044],[22.010363,42.31028],[22.011049,42.310045],[22.011525,42.30971],[22.012003,42.309491],[22.012582,42.309286],[22.013201,42.309082],[22.013671,42.308848],[22.014213,42.308649],[22.014925,42.308489],[22.015326,42.308392],[22.015693,42.308327],[22.01622,42.308155],[22.016636,42.308128],[22.017063,42.308182],[22.017493,42.308139],[22.017776,42.307861],[22.017997,42.307521],[22.018545,42.307288],[22.018928,42.306895],[22.018919,42.306336],[22.018946,42.305912],[22.018972,42.305602],[22.019208,42.305066],[22.019656,42.304694],[22.01999,42.304572],[22.020324,42.304199],[22.020619,42.303905],[22.020981,42.303768],[22.021301,42.303729],[22.021644,42.303487],[22.021869,42.303109],[22.021918,42.302702],[22.021934,42.302204],[22.022097,42.301842],[22.022618,42.301788],[22.022959,42.301718],[22.023222,42.301434],[22.023378,42.301163],[22.023523,42.300865],[22.023859,42.300622],[22.024396,42.300567],[22.024906,42.3004],[22.025449,42.299973],[22.026037,42.299816],[22.026525,42.29979],[22.02699,42.299877],[22.027469,42.300072],[22.028035,42.299853],[22.02869,42.299436],[22.029347,42.299113],[22.029869,42.29897],[22.030596,42.299157],[22.031142,42.2992],[22.031508,42.298757],[22.031765,42.298345],[22.032092,42.298192],[22.032512,42.298353],[22.032949,42.29858],[22.033362,42.298746],[22.033739,42.298828],[22.034053,42.298899],[22.034353,42.299004],[22.034659,42.299149],[22.035114,42.299396],[22.035503,42.299667],[22.03585,42.299962],[22.036497,42.300322],[22.037123,42.300617],[22.03757,42.300921],[22.038056,42.301257],[22.038456,42.301619],[22.038844,42.302129],[22.039111,42.302452],[22.039311,42.302876],[22.039558,42.303318],[22.039839,42.303732],[22.040126,42.304359],[22.04057,42.304993],[22.040863,42.305472],[22.041163,42.305923],[22.041595,42.306128],[22.042111,42.306256],[22.042387,42.3064],[22.042686,42.306584],[22.043244,42.306764],[22.043832,42.306946],[22.044334,42.307158],[22.044777,42.307301],[22.045305,42.307406],[22.045926,42.307373],[22.046556,42.307347],[22.047234,42.307327],[22.047682,42.30731],[22.048179,42.307308],[22.048615,42.307351],[22.049121,42.307429],[22.049404,42.307571],[22.049727,42.30768],[22.050081,42.307716],[22.050515,42.307698],[22.050882,42.307686],[22.051272,42.307573],[22.051696,42.307318],[22.052081,42.307029],[22.052425,42.306782],[22.053117,42.306243],[22.053398,42.305943],[22.053641,42.305588],[22.053819,42.305214],[22.054091,42.304655],[22.054482,42.304019],[22.05512,42.303795],[22.055682,42.303792],[22.056045,42.303917],[22.05661,42.303912],[22.057163,42.303854],[22.057777,42.303806],[22.058407,42.303843],[22.059067,42.303949],[22.059624,42.304008],[22.060144,42.303837],[22.060576,42.303751],[22.061029,42.30365],[22.061451,42.303325],[22.061863,42.302963],[22.062344,42.302479],[22.062719,42.3019],[22.062929,42.301444],[22.06301,42.301056],[22.063277,42.3007],[22.063726,42.30019],[22.064092,42.299693],[22.064466,42.299369],[22.064972,42.299196],[22.065259,42.298794],[22.06552,42.29851],[22.0659,42.298501],[22.066476,42.298638],[22.066815,42.298756],[22.0671,42.298924],[22.067495,42.299057],[22.067923,42.299233],[22.068304,42.299461],[22.068644,42.299629],[22.069017,42.299816],[22.069469,42.299999],[22.069966,42.300208],[22.070417,42.30004],[22.070815,42.299877],[22.071332,42.299847],[22.071807,42.300185],[22.072125,42.300476],[22.072365,42.300831],[22.072859,42.300982],[22.073526,42.301244],[22.073767,42.301697],[22.073868,42.30205],[22.073997,42.302546],[22.074141,42.302969],[22.074474,42.303176],[22.075071,42.302954],[22.075477,42.302903],[22.076201,42.302856],[22.076785,42.302769],[22.07726,42.30255],[22.077577,42.302161],[22.078178,42.302008],[22.078811,42.302002],[22.079346,42.301957],[22.079992,42.301857],[22.080622,42.301836],[22.081128,42.301859],[22.081585,42.301826],[22.081955,42.301842],[22.082437,42.301901],[22.082872,42.302012],[22.083331,42.302076],[22.083836,42.302084],[22.084451,42.302174],[22.085062,42.302426],[22.085402,42.302624],[22.085711,42.302835],[22.086021,42.303143],[22.08634,42.303473],[22.086733,42.303709],[22.087399,42.303733],[22.088024,42.303898],[22.088565,42.304108],[22.08893,42.304276],[22.08943,42.304449],[22.089947,42.304619],[22.090572,42.304545],[22.091226,42.304344],[22.09172,42.304173],[22.092181,42.304373],[22.092596,42.304619],[22.093016,42.304844],[22.09347,42.305096],[22.093957,42.305375],[22.09457,42.305605],[22.095126,42.305643],[22.095654,42.305689],[22.096311,42.305822],[22.096824,42.306053],[22.097125,42.306219],[22.097441,42.306404],[22.097748,42.306546],[22.098002,42.306717],[22.09838,42.306456],[22.09884,42.306273],[22.099331,42.305832],[22.099674,42.305311],[22.10018,42.305153],[22.100684,42.305117],[22.101109,42.30528],[22.101486,42.305477],[22.101801,42.305626],[22.102224,42.305895],[22.102692,42.306334],[22.103069,42.306947],[22.103205,42.3074],[22.103403,42.30772],[22.103746,42.308008],[22.104054,42.308466],[22.10454,42.308823],[22.105034,42.30917],[22.105563,42.309528],[22.106314,42.309418],[22.106945,42.309227],[22.107535,42.30904],[22.108078,42.308856],[22.108685,42.308727],[22.109319,42.308727],[22.110038,42.30924],[22.110642,42.309513],[22.111216,42.309769],[22.11166,42.309956],[22.112018,42.310204],[22.112416,42.310442],[22.112667,42.31065],[22.112978,42.310955],[22.113393,42.311268],[22.113794,42.311658],[22.11407,42.312067],[22.114459,42.312105],[22.114883,42.31229],[22.11542,42.312562],[22.115897,42.312864],[22.116187,42.313158],[22.116454,42.313515],[22.11679,42.314049],[22.117255,42.314378],[22.11764,42.314664],[22.118054,42.314783],[22.118406,42.314722],[22.118725,42.314575],[22.119122,42.314344],[22.119612,42.314194],[22.119953,42.314148],[22.120353,42.31403],[22.120907,42.313831],[22.121486,42.313433],[22.121794,42.312973],[22.122005,42.312502],[22.122122,42.311951],[22.122152,42.311416],[22.122691,42.311044],[22.12329,42.311006],[22.123917,42.310895],[22.124352,42.310517],[22.124636,42.310217],[22.124926,42.309895],[22.125202,42.309608],[22.125447,42.309393],[22.125709,42.309212],[22.126082,42.308955],[22.126568,42.308739],[22.126973,42.308562],[22.127331,42.308388],[22.127778,42.308231],[22.128328,42.308119],[22.129052,42.308117],[22.129654,42.308117],[22.130247,42.308094],[22.130728,42.308048],[22.13116,42.307965],[22.131559,42.307838],[22.131901,42.307673],[22.132209,42.307388],[22.132531,42.307172],[22.132992,42.307224],[22.133351,42.307536],[22.13374,42.307739],[22.134087,42.307829],[22.134526,42.307956],[22.134841,42.308228],[22.13509,42.308716],[22.135483,42.3092],[22.135737,42.309633],[22.135971,42.309967],[22.136313,42.310229],[22.136704,42.310503],[22.137156,42.310702],[22.137522,42.310955],[22.137805,42.311121],[22.138252,42.311405],[22.138578,42.311674],[22.139015,42.311914],[22.139372,42.312084],[22.139753,42.312302],[22.14013,42.312567],[22.140333,42.312891],[22.140261,42.313305],[22.139839,42.313721],[22.139666,42.314119],[22.139858,42.314518],[22.140638,42.314629],[22.140792,42.315157],[22.14084,42.315618],[22.141244,42.315989],[22.141649,42.31638],[22.142146,42.316856],[22.142627,42.317331],[22.142958,42.317749],[22.143318,42.318121],[22.143744,42.318573],[22.144072,42.318905],[22.144494,42.319284],[22.144743,42.319664],[22.145004,42.319981],[22.145212,42.320324],[22.145421,42.320811],[22.145666,42.321356],[22.146143,42.321226],[22.146591,42.321161],[22.147167,42.321023],[22.147827,42.320651],[22.14831,42.320322],[22.148886,42.320179],[22.149509,42.320031],[22.150012,42.319885],[22.150396,42.31979],[22.150713,42.319545],[22.151205,42.31927],[22.151694,42.31917],[22.152028,42.319016],[22.152355,42.318943],[22.152805,42.318953],[22.153487,42.318924],[22.154249,42.318863],[22.154857,42.318823],[22.155195,42.318901],[22.155694,42.318925],[22.156096,42.31868],[22.156525,42.318455],[22.157067,42.318049],[22.157442,42.317913],[22.157694,42.317652],[22.158053,42.317535],[22.15841,42.317614],[22.158777,42.317763],[22.159101,42.317599],[22.159163,42.317075],[22.159206,42.316386],[22.159482,42.315827],[22.159792,42.315609],[22.160206,42.315457],[22.160847,42.315426],[22.161399,42.315436],[22.161862,42.315072],[22.161938,42.31449],[22.162009,42.314011],[22.162325,42.31377],[22.162602,42.313568],[22.163168,42.313338],[22.163855,42.313175],[22.164377,42.31308],[22.164911,42.312938],[22.165334,42.312785],[22.165714,42.312506],[22.1664,42.312289],[22.166679,42.312605],[22.166918,42.312947],[22.167213,42.31333],[22.167557,42.313685],[22.167908,42.314026],[22.168194,42.314259],[22.168617,42.314575],[22.169048,42.314854],[22.169445,42.315117],[22.169947,42.315302],[22.170482,42.31556],[22.170849,42.315909],[22.171037,42.316466],[22.171218,42.31716],[22.171333,42.317707],[22.171492,42.318066],[22.171706,42.318409],[22.1721,42.31884],[22.172419,42.319138],[22.172751,42.319347],[22.173098,42.319561],[22.173505,42.31971],[22.173773,42.319893],[22.174026,42.320071],[22.174217,42.320477],[22.174111,42.321015],[22.173735,42.321441],[22.17415,42.321646],[22.174595,42.321793],[22.175148,42.321913],[22.175596,42.32208],[22.175854,42.322353],[22.176285,42.322274],[22.17651,42.322712],[22.176854,42.322899],[22.178051,42.322937],[22.178534,42.322952],[22.178977,42.323352],[22.179113,42.323944],[22.179125,42.324524],[22.180073,42.324528],[22.180489,42.32444],[22.180979,42.324947],[22.181256,42.325171],[22.181679,42.325489],[22.18142,42.32626],[22.181139,42.326615],[22.181272,42.327261],[22.181436,42.327866],[22.181555,42.328213],[22.182264,42.328476],[22.182285,42.329123],[22.182253,42.329575],[22.182296,42.330105],[22.182163,42.330719],[22.181915,42.331245],[22.18178,42.33168],[22.181453,42.332253],[22.181869,42.333002],[22.182434,42.333176],[22.182877,42.333294],[22.183859,42.333382],[22.184366,42.333454],[22.18501,42.333515],[22.186255,42.333969],[22.186949,42.334168],[22.187608,42.334665],[22.188223,42.335278],[22.188736,42.335616],[22.189226,42.335758],[22.189846,42.33581],[22.190599,42.33617],[22.190813,42.336409],[22.191345,42.33651],[22.191803,42.336983],[22.192455,42.337452],[22.192873,42.337517],[22.193843,42.33828],[22.194115,42.338703],[22.194231,42.339251],[22.19438,42.339905],[22.194973,42.339901],[22.196007,42.340172],[22.19709,42.340588],[22.199746,42.3405],[22.200329,42.340359],[22.200956,42.340321],[22.201389,42.340336],[22.201882,42.340456],[22.202422,42.340143],[22.202915,42.33985],[22.203541,42.339459],[22.204121,42.338722],[22.2045,42.338371],[22.204845,42.338013],[22.20532,42.337605],[22.205651,42.337279],[22.20616,42.336589],[22.206491,42.336704],[22.207033,42.337043],[22.20775,42.337025],[22.208155,42.337185],[22.208466,42.337456],[22.209381,42.337464],[22.210953,42.33741],[22.212028,42.337387],[22.213008,42.337363],[22.213587,42.337406],[22.214294,42.337486],[22.214955,42.337536],[22.215544,42.337706],[22.216557,42.338142],[22.217898,42.338581],[22.218541,42.338713],[22.218881,42.338825],[22.219198,42.338642],[22.219677,42.338432],[22.220427,42.338188],[22.220983,42.337883],[22.221508,42.337654],[22.222009,42.337343],[22.222375,42.336997],[22.221781,42.336533],[22.221895,42.336051],[22.221656,42.335711],[22.221626,42.3354],[22.221837,42.335159],[22.222363,42.335146],[22.223077,42.335284],[22.223592,42.335366],[22.223926,42.335594],[22.224486,42.335533],[22.225048,42.335982],[22.22541,42.336006],[22.225728,42.33585],[22.226097,42.335819],[22.226439,42.336033],[22.227026,42.335646],[22.227805,42.335678],[22.228347,42.335629],[22.228839,42.335573],[22.229244,42.335739],[22.229662,42.335821],[22.23014,42.336007],[22.230551,42.336519],[22.230726,42.336864],[22.231147,42.337401],[22.231363,42.337773],[22.231761,42.338038],[22.232182,42.338131],[22.23297,42.338309],[22.233585,42.338486],[22.233988,42.338604],[22.234285,42.338984],[22.234461,42.339312],[22.234797,42.33969],[22.235332,42.339959],[22.235786,42.340187],[22.236287,42.340365],[22.236759,42.340649],[22.237197,42.340882],[22.2376,42.341045],[22.23804,42.341306],[22.238616,42.34158],[22.239315,42.341967],[22.239844,42.342385],[22.240136,42.342951],[22.240279,42.343678],[22.240386,42.344196],[22.24071,42.344559],[22.241255,42.344685],[22.241868,42.344872],[22.242504,42.345375],[22.243157,42.345818],[22.243593,42.346043],[22.244089,42.346235],[22.24356,42.346356],[22.242711,42.346459],[22.242011,42.346844],[22.241507,42.347694],[22.241087,42.348003],[22.240488,42.348198],[22.23986,42.348141],[22.239378,42.348103],[22.238655,42.348072],[22.238142,42.348114],[22.2372,42.348418],[22.236778,42.348799],[22.236349,42.349262],[22.236279,42.349738],[22.236856,42.35013],[22.23768,42.350353],[22.238157,42.350597],[22.23863,42.350901],[22.239037,42.351135],[22.239553,42.351296],[22.240451,42.351219],[22.240871,42.351318],[22.241698,42.351273],[22.242418,42.351223],[22.243001,42.35104],[22.243238,42.350842],[22.243601,42.350452],[22.243979,42.350033],[22.244559,42.349684],[22.244881,42.349461],[22.245282,42.349352],[22.24615,42.349432],[22.246942,42.349686],[22.247715,42.349751],[22.248213,42.349743],[22.248856,42.349785],[22.249786,42.349781],[22.250214,42.349848],[22.250857,42.349882],[22.251787,42.350224],[22.252324,42.350491],[22.252558,42.350945],[22.252449,42.351532],[22.252308,42.352135],[22.252609,42.352711],[22.253205,42.353653],[22.253101,42.35405],[22.253271,42.354561],[22.25333,42.355885],[22.252514,42.356857],[22.252316,42.357445],[22.251776,42.358536],[22.251625,42.359039],[22.251524,42.359615],[22.251649,42.360644],[22.252124,42.361109],[22.253702,42.361714],[22.254778,42.362473],[22.255249,42.362778],[22.255653,42.362919],[22.256029,42.363174],[22.25667,42.363526],[22.257291,42.364039],[22.257666,42.364325],[22.258726,42.364415],[22.259167,42.365051],[22.259417,42.365517],[22.259714,42.365891],[22.260071,42.366127],[22.260479,42.36636],[22.261383,42.366604],[22.262316,42.36665],[22.263119,42.366684],[22.263857,42.366623],[22.264509,42.366299],[22.26505,42.365999],[22.26564,42.365787],[22.266117,42.365562],[22.266449,42.365265],[22.266729,42.364845],[22.267057,42.364323],[22.267689,42.363857],[22.268082,42.363361],[22.268299,42.362949],[22.268641,42.362434],[22.269117,42.362133],[22.269527,42.361771],[22.27018,42.361511],[22.270578,42.36129],[22.272117,42.361195],[22.273066,42.361161],[22.273487,42.361366],[22.273945,42.361805],[22.274338,42.362141],[22.274938,42.362453],[22.275528,42.362926],[22.276266,42.363677],[22.276848,42.363917],[22.27729,42.364273],[22.277569,42.364655],[22.277874,42.365406],[22.278564,42.366127],[22.279208,42.366638],[22.27995,42.366743],[22.280433,42.367249],[22.280558,42.367794],[22.280602,42.368367],[22.280901,42.368877],[22.281906,42.369293],[22.282345,42.369587],[22.283316,42.36993],[22.284256,42.370255],[22.284647,42.370514],[22.285033,42.370611],[22.285297,42.370934],[22.285734,42.37112],[22.286804,42.371544],[22.287548,42.371845],[22.288536,42.372131],[22.289373,42.372265],[22.290114,42.372341],[22.290791,42.37244],[22.291452,42.372578],[22.292177,42.372681],[22.292759,42.372847],[22.293387,42.373287],[22.293797,42.37363],[22.294123,42.373543],[22.295296,42.372704],[22.295643,42.372482],[22.296295,42.372108],[22.297215,42.371498],[22.297699,42.370857],[22.297586,42.370075],[22.297536,42.369559],[22.297852,42.368858],[22.298216,42.368118],[22.298002,42.367653],[22.298172,42.367256],[22.29834,42.366882],[22.298637,42.366501],[22.29894,42.365969],[22.299064,42.364983],[22.298714,42.364681],[22.297897,42.364147],[22.297134,42.363735],[22.295535,42.362824],[22.295262,42.362461],[22.294947,42.361679],[22.294917,42.360556],[22.29479,42.359909],[22.29476,42.359169],[22.294655,42.35873],[22.294516,42.358246],[22.294149,42.357594],[22.293884,42.357227],[22.293797,42.356815],[22.293593,42.356342],[22.29328,42.355892],[22.293077,42.355457],[22.292681,42.354889],[22.292364,42.35432],[22.29203,42.35376],[22.291423,42.353123],[22.290811,42.352637],[22.291006,42.352367],[22.29096,42.352051],[22.291233,42.351646],[22.291474,42.351254],[22.291563,42.350491],[22.29175,42.350243],[22.292158,42.349834],[22.292693,42.349243],[22.293102,42.348846],[22.293633,42.348459],[22.294286,42.348204],[22.294674,42.347912],[22.294987,42.347527],[22.295341,42.347159],[22.296228,42.346583],[22.296831,42.346251],[22.297222,42.346115],[22.29756,42.346127],[22.298093,42.345875],[22.29854,42.345406],[22.299011,42.344484],[22.299593,42.344227],[22.30026,42.343903],[22.300882,42.343666],[22.301334,42.343392],[22.301869,42.343258],[22.302423,42.34288],[22.303694,42.342209],[22.303938,42.341961],[22.304359,42.341751],[22.304737,42.3414],[22.305567,42.341145],[22.306025,42.340765],[22.306171,42.34001],[22.306796,42.339985],[22.307032,42.339722],[22.307234,42.339043],[22.307795,42.339321],[22.308277,42.339401],[22.308717,42.339308],[22.30904,42.338997],[22.309158,42.338474],[22.309387,42.337921],[22.309786,42.336998],[22.310204,42.336254],[22.310514,42.3358],[22.311127,42.335114],[22.312036,42.334862],[22.312801,42.333767],[22.313982,42.333002],[22.316462,42.331772],[22.317175,42.332152],[22.317875,42.332165],[22.318888,42.333027],[22.319923,42.333374],[22.320421,42.333408],[22.320779,42.333127],[22.321016,42.333488],[22.321806,42.333549],[22.322697,42.333954],[22.323138,42.333563],[22.32369,42.333046],[22.32378,42.332371],[22.324094,42.331659],[22.324484,42.331118],[22.325474,42.330071],[22.32531,42.329564],[22.325478,42.329123],[22.326644,42.328188],[22.327279,42.328357],[22.327992,42.327637],[22.328367,42.327132],[22.329344,42.327049],[22.329908,42.32639],[22.330204,42.325958],[22.330353,42.325428],[22.330985,42.324534],[22.331422,42.323941],[22.330974,42.323637],[22.330516,42.323478],[22.330625,42.32306],[22.331301,42.322392],[22.33198,42.321884],[22.332877,42.32137],[22.33353,42.321313],[22.333872,42.320976],[22.334524,42.320645],[22.335177,42.320423],[22.335682,42.320071],[22.33616,42.319889],[22.336348,42.319622],[22.336769,42.31946],[22.33727,42.319575],[22.337553,42.320054],[22.338054,42.320223],[22.338591,42.320145],[22.339049,42.319767],[22.339666,42.31942],[22.34071,42.319435],[22.34129,42.319485],[22.341722,42.319431],[22.342167,42.319225],[22.342934,42.319004],[22.343746,42.318802],[22.345137,42.318428],[22.345905,42.318363],[22.34645,42.318345],[22.346809,42.317862],[22.347462,42.317806],[22.348255,42.317854],[22.348819,42.317997],[22.349448,42.318097],[22.350502,42.317833],[22.350584,42.317192],[22.351485,42.316912],[22.3521,42.316797],[22.352789,42.316746],[22.353006,42.316395],[22.353188,42.315807],[22.353207,42.315285],[22.353458,42.314587],[22.354034,42.314175],[22.354252,42.313805],[22.354668,42.313717],[22.355153,42.313196],[22.355362,42.312815],[22.356033,42.312328],[22.356494,42.311796],[22.356968,42.311764],[22.357487,42.311962],[22.358399,42.311825],[22.358959,42.311741],[22.35947,42.311653],[22.359837,42.311481],[22.360639,42.311392],[22.361307,42.311265],[22.361713,42.311005],[22.362316,42.310707],[22.362972,42.310369],[22.363471,42.310148],[22.363887,42.309976],[22.364636,42.309779],[22.365135,42.309645],[22.365572,42.30952],[22.366092,42.309362],[22.366592,42.309158],[22.367029,42.308953],[22.367622,42.308678],[22.368324,42.308557],[22.36885,42.308647],[22.36938,42.308742],[22.369817,42.308828],[22.370233,42.308938],[22.370961,42.308946],[22.371565,42.308773],[22.371898,42.308529],[22.37222,42.308262],[22.372616,42.307979],[22.373136,42.307719],[22.373719,42.307641],[22.374103,42.307696],[22.374519,42.30779],[22.375081,42.307986],[22.375684,42.308262],[22.376121,42.308482],[22.376537,42.308686],[22.376995,42.308883],[22.377703,42.309056],[22.378202,42.309025],[22.378816,42.308851],[22.379388,42.308537],[22.379721,42.308105],[22.380148,42.307648],[22.380668,42.307161],[22.381052,42.306909],[22.381365,42.306501],[22.381573,42.305833],[22.381697,42.305353],[22.381864,42.304889],[22.382311,42.304433],[22.382832,42.304166],[22.383477,42.303969],[22.38407,42.303631],[22.384548,42.303199],[22.384902,42.30279],[22.385235,42.302397],[22.385453,42.301996],[22.385661,42.301539],[22.386025,42.301029],[22.386379,42.300683],[22.386753,42.300345],[22.387326,42.299991],[22.3877,42.29948],[22.388116,42.298835],[22.388397,42.298261],[22.388543,42.297868],[22.38872,42.29724],[22.388741,42.29632],[22.388709,42.295871],[22.388741,42.2954],[22.388917,42.294944],[22.389542,42.294621],[22.390041,42.294378],[22.390457,42.294252],[22.391206,42.29404],[22.391955,42.293859],[22.392392,42.293811],[22.392871,42.293796],[22.393557,42.293639],[22.39414,42.29345],[22.394535,42.293308],[22.395055,42.29312],[22.395586,42.292915],[22.396096,42.292727],[22.396678,42.292506],[22.397365,42.292255],[22.397781,42.292145],[22.398218,42.291972],[22.398696,42.291815],[22.399175,42.29161],[22.39957,42.291374],[22.400163,42.291162],[22.400944,42.290793],[22.401485,42.290408],[22.401838,42.290132],[22.401942,42.289826],[22.40163,42.289346],[22.401152,42.289016],[22.400808,42.288505],[22.400517,42.287829],[22.400319,42.287318],[22.400101,42.286909],[22.399882,42.286343],[22.399675,42.285942],[22.399508,42.285517],[22.399445,42.285132],[22.399498,42.2847],[22.399654,42.284189],[22.400039,42.283749],[22.4006,42.283466],[22.40111,42.283277],[22.401443,42.283002],[22.401776,42.282726],[22.401963,42.282333],[22.402109,42.281995],[22.402192,42.281626],[22.402255,42.281225],[22.402483,42.280769],[22.402952,42.280438],[22.403482,42.280116],[22.404002,42.279676],[22.404315,42.279157],[22.404523,42.27856],[22.404668,42.278143],[22.404939,42.277742],[22.405365,42.277309],[22.405833,42.276971],[22.406208,42.276735],[22.406655,42.276476],[22.407186,42.276201],[22.407748,42.275997],[22.408403,42.275761],[22.408912,42.275572],[22.409365,42.275305],[22.409683,42.274794],[22.409766,42.274314],[22.409849,42.273882],[22.410026,42.273347],[22.410265,42.272836],[22.410723,42.272443],[22.411222,42.272144],[22.411701,42.27194],[22.412252,42.271704],[22.41272,42.271484],[22.413136,42.271209],[22.41349,42.270855],[22.413684,42.270357],[22.413761,42.269865],[22.413823,42.269409],[22.41399,42.268772],[22.414281,42.268088],[22.414676,42.267663],[22.415071,42.267286],[22.415467,42.267034],[22.415925,42.266775],[22.416725,42.266256],[22.417287,42.265832],[22.418005,42.265399],[22.41864,42.265108],[22.419337,42.264825],[22.419972,42.264424],[22.420502,42.264083],[22.420949,42.264258],[22.421334,42.264487],[22.421813,42.26455],[22.422395,42.264612],[22.422915,42.264628],[22.423394,42.264597],[22.42407,42.2644],[22.424341,42.263787],[22.424226,42.263221],[22.424102,42.262608],[22.424184,42.262018],[22.424414,42.261484],[22.424621,42.260996],[22.424663,42.260595],[22.424767,42.260068],[22.424663,42.259542],[22.424517,42.258866],[22.42433,42.258339],[22.424403,42.257922],[22.424538,42.257388],[22.42457,42.256916],[22.424632,42.256342],[22.425048,42.256122],[22.425579,42.256248],[22.426328,42.256389],[22.42691,42.256452],[22.42741,42.256468],[22.42793,42.256452],[22.42843,42.256436],[22.428991,42.25664],[22.429469,42.256798],[22.429906,42.256892],[22.430468,42.256971],[22.430863,42.257081],[22.431654,42.257278],[22.432299,42.257521],[22.432819,42.25771],[22.433277,42.257835],[22.433735,42.257977],[22.434203,42.258079],[22.434692,42.257977],[22.434942,42.257474],[22.435067,42.256743],[22.43515,42.2562],[22.435285,42.255752],[22.435607,42.255351],[22.43594,42.255005],[22.436294,42.254691],[22.436627,42.254392],[22.436981,42.254093],[22.437314,42.253779],[22.437792,42.253347],[22.438375,42.253024],[22.438958,42.252718],[22.439186,42.252128],[22.439197,42.251633],[22.439145,42.251043],[22.439103,42.250555],[22.439072,42.250186],[22.43904,42.249816],[22.43903,42.249479],[22.43901,42.248984],[22.438999,42.248543],[22.43903,42.248166],[22.439325,42.247793],[22.43979,42.247678],[22.440268,42.247513],[22.440685,42.247183],[22.440747,42.24684],[22.440857,42.246404],[22.441381,42.246114],[22.441808,42.24598],[22.442182,42.24587],[22.44264,42.245626],[22.443108,42.245328],[22.443608,42.245021],[22.444076,42.244816],[22.444617,42.244691],[22.44547,42.244588],[22.446115,42.244541],[22.446531,42.244345],[22.446916,42.24407],[22.447332,42.243779],[22.447779,42.243535],[22.448091,42.243338],[22.448518,42.243102],[22.448861,42.242961],[22.449163,42.242851],[22.449538,42.242678],[22.44986,42.242356],[22.45013,42.242033],[22.450297,42.241664],[22.450443,42.241278],[22.450443,42.240776],[22.450318,42.240261],[22.450141,42.239872],[22.449912,42.239526],[22.449621,42.239077],[22.449267,42.238558],[22.448965,42.238086],[22.448716,42.237725],[22.448497,42.237355],[22.44831,42.236868],[22.448362,42.236428],[22.448736,42.236011],[22.449049,42.235657],[22.449392,42.235311],[22.449797,42.235013],[22.450287,42.234856],[22.450672,42.234659],[22.450942,42.234407],[22.45114,42.234109],[22.451296,42.233668],[22.451441,42.233065],[22.451618,42.23256],[22.451982,42.23212],[22.452451,42.231679],[22.45296,42.231294],[22.453387,42.231003],[22.453741,42.23076],[22.454125,42.230508],[22.45449,42.230146],[22.454874,42.229816],[22.455114,42.229431],[22.455447,42.228959],[22.455686,42.228636],[22.455883,42.228212],[22.456112,42.227741],[22.456289,42.227394],[22.456477,42.226907],[22.45656,42.226482],[22.456612,42.226121],[22.456622,42.225594],[22.456664,42.225036],[22.456685,42.224423],[22.456768,42.223982],[22.456903,42.223613],[22.457059,42.223094],[22.457205,42.222693],[22.457392,42.22217],[22.457975,42.221938],[22.458412,42.22182],[22.459046,42.221687],[22.459639,42.221529],[22.459764,42.221152],[22.459701,42.220822],[22.459556,42.220468],[22.459514,42.220083],[22.459421,42.219572],[22.459327,42.219124],[22.459359,42.218487],[22.459493,42.218039],[22.459858,42.217756],[22.460503,42.217245],[22.460867,42.216859],[22.461075,42.216631],[22.461512,42.21649],[22.462108,42.216188],[22.462053,42.215727],[22.461845,42.215268],[22.462126,42.214721],[22.46251,42.214469],[22.462822,42.214296],[22.463124,42.214108],[22.463426,42.213919],[22.463614,42.21366],[22.463936,42.213282],[22.464362,42.212897],[22.464831,42.212465],[22.465257,42.212127],[22.465663,42.211773],[22.466131,42.211396],[22.46663,42.211057],[22.466984,42.210837],[22.4674,42.210405],[22.467681,42.209815],[22.467733,42.209501],[22.467816,42.209195],[22.467899,42.208785],[22.468045,42.208348],[22.468149,42.207905],[22.468281,42.207472],[22.468461,42.207032],[22.468659,42.206623],[22.468857,42.206152],[22.469044,42.205664],[22.46921,42.205098],[22.469345,42.204619],[22.469606,42.204006],[22.469723,42.203379],[22.469553,42.202693],[22.469293,42.202221],[22.469179,42.201781],[22.469023,42.201178],[22.469439,42.20123],[22.469876,42.201356],[22.470313,42.201466],[22.470895,42.201497],[22.471478,42.201497],[22.471957,42.20145],[22.47256,42.201387],[22.472976,42.201324],[22.47358,42.201144],[22.474183,42.200963],[22.474911,42.200915],[22.475452,42.200963],[22.47591,42.200978],[22.476409,42.200963],[22.476909,42.200931],[22.477533,42.200884],[22.478095,42.200743],[22.478656,42.200837],[22.479093,42.200915],[22.47978,42.200963],[22.480571,42.2009],[22.481049,42.200853],[22.481715,42.200853],[22.482079,42.201034],[22.482485,42.201222],[22.483078,42.20123],[22.483608,42.201199],[22.484087,42.201144],[22.484586,42.20123],[22.485023,42.201324],[22.485491,42.20138],[22.486137,42.201253],[22.486792,42.200963],[22.48726,42.200759],[22.487687,42.200617],[22.488883,42.2002],[22.489434,42.200019],[22.489913,42.199776],[22.490464,42.199406],[22.490849,42.199202],[22.491223,42.199029],[22.491619,42.198919],[22.491993,42.19873],[22.492389,42.198604],[22.492846,42.198415],[22.493513,42.198282],[22.494199,42.198148],[22.494834,42.198085],[22.495447,42.197818],[22.495905,42.197645],[22.496457,42.197433],[22.497081,42.197118],[22.497809,42.196843],[22.498579,42.19671],[22.49913,42.196584],[22.499671,42.196497],[22.500087,42.196434],[22.500729,42.196348],[22.501408,42.19594],[22.50197,42.195515],[22.502204,42.195161],[22.502626,42.194595],[22.503047,42.194099],[22.503422,42.193639],[22.503609,42.193179],[22.503867,42.192595],[22.504171,42.19194],[22.504078,42.191515],[22.504171,42.190984],[22.503984,42.190524],[22.503422,42.189957],[22.503094,42.189639],[22.502579,42.189214],[22.502204,42.188895],[22.5019,42.188276],[22.501689,42.187833],[22.501479,42.18732],[22.501502,42.186648],[22.501642,42.186028],[22.501666,42.185409],[22.501689,42.184647],[22.501994,42.183497],[22.502157,42.183054],[22.502368,42.182559],[22.502649,42.181992],[22.503023,42.181284],[22.503492,42.180629],[22.504031,42.180081],[22.504405,42.179797],[22.504663,42.17932],[22.504851,42.178665],[22.505038,42.177957],[22.505179,42.177231],[22.505202,42.176718],[22.505272,42.176134],[22.505342,42.175638],[22.505342,42.175231],[22.505295,42.17477],[22.505342,42.174275],[22.505249,42.173708],[22.505108,42.173018],[22.505202,42.172292],[22.505108,42.171584],[22.505342,42.171053],[22.505413,42.170523],[22.50567,42.169814],[22.505811,42.169177],[22.506092,42.168682],[22.506513,42.168186],[22.506935,42.167726],[22.507544,42.167018],[22.507871,42.166557],[22.508293,42.166062],[22.508668,42.165637],[22.509183,42.165354],[22.509792,42.165035],[22.510448,42.164504],[22.510869,42.163832],[22.511337,42.163194],[22.511993,42.16238],[22.512321,42.162132],[22.512789,42.161778],[22.513352,42.160964],[22.514241,42.160221],[22.514803,42.159619],[22.515412,42.159088],[22.516021,42.158592],[22.516771,42.158061],[22.515506,42.157778],[22.514991,42.15753],[22.514148,42.157247],[22.513211,42.156787],[22.512649,42.156362],[22.511806,42.156008],[22.511056,42.155406],[22.510588,42.154309],[22.511384,42.15353],[22.51204,42.152928],[22.513117,42.152291],[22.513867,42.152008],[22.514616,42.151654],[22.514991,42.151477],[22.515553,42.150981],[22.516162,42.150627],[22.516864,42.150273],[22.51752,42.150061],[22.518129,42.149742],[22.518878,42.149423],[22.519721,42.148963],[22.520284,42.148715],[22.520986,42.148432],[22.521548,42.148184],[22.522204,42.147972],[22.522672,42.147724],[22.523328,42.147299],[22.52389,42.147052],[22.524218,42.146804],[22.524546,42.146414],[22.524757,42.145689],[22.524967,42.144998],[22.525295,42.144432],[22.525576,42.143901],[22.525717,42.143441],[22.526138,42.142733],[22.526513,42.142166],[22.526935,42.141671],[22.52745,42.141033],[22.527778,42.140467],[22.52834,42.139901],[22.529698,42.139228],[22.530869,42.138909],[22.531946,42.138662],[22.532836,42.138308],[22.533867,42.138024],[22.534663,42.137599],[22.535787,42.137316],[22.53663,42.137033],[22.537895,42.136626],[22.53855,42.13636],[22.539066,42.136183],[22.539487,42.136042],[22.540002,42.135936],[22.540471,42.135829],[22.541407,42.135652],[22.541969,42.135546],[22.542672,42.135475],[22.543515,42.13544],[22.544077,42.135298],[22.544827,42.135298],[22.545389,42.135298],[22.546513,42.135051],[22.547356,42.13498],[22.548012,42.134767],[22.54862,42.134449],[22.549323,42.133918],[22.549932,42.133351],[22.55026,42.132785],[22.550681,42.132219],[22.551243,42.131546],[22.551712,42.131121],[22.552227,42.130555],[22.552649,42.130094],[22.553304,42.129386],[22.554007,42.128855],[22.554756,42.128572],[22.555412,42.12836],[22.555974,42.128324],[22.55677,42.128183],[22.557286,42.127793],[22.557473,42.127192],[22.557707,42.126767],[22.558082,42.1262],[22.55855,42.125669],[22.558925,42.125315],[22.559393,42.125103],[22.559955,42.124961],[22.560752,42.124678],[22.56122,42.124572],[22.561922,42.124395],[22.562438,42.124218],[22.562766,42.123899],[22.563117,42.123262],[22.563421,42.122377],[22.563609,42.121881],[22.563796,42.121457],[22.564124,42.120784],[22.564499,42.120147],[22.564733,42.119722],[22.565107,42.119262],[22.565201,42.11866],[22.565857,42.118235],[22.566653,42.11781],[22.567871,42.117456],[22.568948,42.116925],[22.569932,42.116465],[22.570962,42.116111],[22.572039,42.115616],[22.572508,42.11512],[22.573117,42.114553],[22.574288,42.113668],[22.57499,42.113279],[22.575412,42.11289],[22.575927,42.112571],[22.576489,42.112252],[22.577051,42.11204],[22.577473,42.111721],[22.577988,42.111509],[22.578409,42.111226],[22.579346,42.110801],[22.580236,42.110412],[22.581126,42.109916],[22.582016,42.109597],[22.582859,42.109314],[22.583608,42.109031],[22.584545,42.108889],[22.585435,42.108996],[22.586419,42.109314],[22.587309,42.109562],[22.588339,42.109881],[22.589416,42.109987],[22.590259,42.109987],[22.590681,42.109987],[22.591243,42.10942],[22.591899,42.108854],[22.592461,42.108465],[22.593023,42.107934],[22.593491,42.107048],[22.5941,42.106128],[22.594615,42.105526],[22.595412,42.10496],[22.595646,42.104535],[22.595786,42.103969],[22.595786,42.10319],[22.595927,42.10273],[22.596583,42.102269],[22.597238,42.101809],[22.597894,42.101207],[22.598643,42.100676],[22.599159,42.10011],[22.599486,42.099685],[22.599955,42.098977],[22.60033,42.09834],[22.600611,42.09795],[22.601219,42.09788],[22.602437,42.097809],[22.603561,42.09788],[22.604451,42.097915],[22.605622,42.097915],[22.606372,42.097773],[22.606981,42.097384],[22.607683,42.096995],[22.608339,42.096818],[22.608807,42.096605],[22.609557,42.096357],[22.610212,42.096039],[22.61054,42.095685],[22.611055,42.095154],[22.612226,42.094481],[22.613257,42.094871],[22.614194,42.095225],[22.615037,42.095508],[22.616067,42.096039],[22.616957,42.096428],[22.617566,42.096747],[22.618034,42.096818],[22.619439,42.096322],[22.620704,42.096003],[22.622016,42.095508],[22.623514,42.095154],[22.624685,42.094871],[22.62609,42.094517],[22.62773,42.094198],[22.629041,42.09395],[22.630072,42.093809],[22.630727,42.093596],[22.63129,42.092906],[22.631711,42.09218],[22.632367,42.091472],[22.63314,42.090818],[22.633819,42.090445],[22.634147,42.090021],[22.634568,42.089596],[22.634896,42.089348],[22.635692,42.089065],[22.636582,42.088817],[22.637378,42.088817],[22.638081,42.088817],[22.638643,42.088428],[22.639533,42.087578],[22.640423,42.08687],[22.641125,42.086516],[22.641687,42.085702],[22.642203,42.085419],[22.642999,42.085242],[22.643748,42.085029],[22.64431,42.084746],[22.644779,42.084215],[22.6452,42.083755],[22.645716,42.082905],[22.646231,42.082162],[22.646746,42.081489],[22.647449,42.080852],[22.648479,42.080462],[22.649509,42.080427],[22.650353,42.080356],[22.650774,42.080179],[22.651102,42.079719],[22.651196,42.079259],[22.651055,42.078834],[22.650961,42.078409],[22.650727,42.077737],[22.650727,42.077206],[22.650961,42.07671],[22.651758,42.076214],[22.653022,42.075896],[22.654146,42.075435],[22.655083,42.075365],[22.656114,42.075188],[22.657612,42.074161],[22.658502,42.073772],[22.659158,42.073488],[22.660188,42.073241],[22.660704,42.073099],[22.6615,42.07278],[22.662109,42.072462],[22.662811,42.072108],[22.663561,42.071577],[22.664123,42.071187],[22.664732,42.070692],[22.665341,42.070302],[22.666465,42.069984],[22.667261,42.069984],[22.668151,42.070196],[22.668853,42.070409],[22.669509,42.070444],[22.670165,42.070161],[22.670821,42.069665],[22.671617,42.068992],[22.672554,42.06832],[22.673256,42.06747],[22.673397,42.066727],[22.673444,42.066302],[22.673912,42.065842],[22.674334,42.065452],[22.674755,42.065028],[22.675177,42.06478],[22.676113,42.064497],[22.67705,42.064178],[22.678268,42.064355],[22.678736,42.064497],[22.679205,42.064178],[22.679345,42.063753],[22.680001,42.06347],[22.681172,42.063293],[22.681921,42.063258],[22.682764,42.063293],[22.683467,42.063576],[22.684029,42.064143],[22.684685,42.064603],[22.685715,42.064072],[22.686511,42.063222],[22.687542,42.064213],[22.688244,42.064709],[22.688806,42.064709],[22.689837,42.064497],[22.690258,42.064355],[22.691055,42.064001],[22.692366,42.063612],[22.69349,42.063399],[22.694802,42.063541],[22.695785,42.063647],[22.696628,42.063576],[22.697425,42.063399],[22.698642,42.06347],[22.699486,42.063966],[22.700048,42.064532],[22.700891,42.064709],[22.701546,42.06478],[22.702343,42.065063],[22.703233,42.065205],[22.703982,42.065311],[22.704731,42.065417],[22.705481,42.0657],[22.706511,42.065877],[22.707542,42.065983],[22.708713,42.066337],[22.709603,42.066762],[22.710352,42.066975],[22.711336,42.06747],[22.712179,42.067647],[22.71335,42.067576],[22.714708,42.067399],[22.715738,42.067753],[22.716675,42.068178],[22.717331,42.068851],[22.717752,42.069382],[22.718876,42.070019],[22.718268,42.068638],[22.717752,42.068107],[22.717612,42.067222],[22.717659,42.066444],[22.717752,42.065452],[22.718033,42.064851],[22.71808,42.063859],[22.719111,42.063258],[22.719673,42.062797],[22.720328,42.06262],[22.721218,42.062337],[22.721921,42.061877],[22.722577,42.06131],[22.722998,42.060779],[22.723513,42.060036],[22.724544,42.058939],[22.725434,42.058868],[22.726277,42.058832],[22.727354,42.058868],[22.727916,42.058549],[22.728525,42.057947],[22.728525,42.057346],[22.728338,42.056602],[22.728244,42.055823],[22.728338,42.055292],[22.728619,42.054903],[22.72904,42.05462],[22.729555,42.054336],[22.730071,42.053805],[22.730726,42.05285],[22.730773,42.052106],[22.731242,42.051009],[22.73171,42.050372],[22.732272,42.049593],[22.73274,42.049062],[22.733021,42.04846],[22.73363,42.047787],[22.734567,42.047115],[22.735785,42.04669],[22.736769,42.046513],[22.73808,42.04623],[22.739064,42.045557],[22.740188,42.045061],[22.741499,42.044743],[22.742436,42.044601],[22.74342,42.044672],[22.744403,42.045097],[22.745153,42.045663],[22.746277,42.046336],[22.74726,42.046654],[22.748103,42.0463],[22.748759,42.046017],[22.749508,42.046123],[22.74993,42.0463],[22.750727,42.046531],[22.751195,42.046088],[22.751944,42.045274],[22.752834,42.044601],[22.754005,42.043929],[22.755129,42.043575],[22.756206,42.043362],[22.757518,42.043327],[22.758736,42.043504],[22.760141,42.043575],[22.761171,42.043327],[22.762155,42.04315],[22.762764,42.042973],[22.7637,42.042796],[22.764403,42.042513],[22.765387,42.042194],[22.766698,42.041734],[22.768056,42.041344],[22.769602,42.041026],[22.77082,42.040743],[22.771382,42.040566],[22.77171,42.040105],[22.771663,42.039326],[22.772881,42.03876],[22.774286,42.038548],[22.775691,42.038477],[22.77644,42.038406],[22.777283,42.038264],[22.777939,42.038158],[22.778829,42.038123],[22.778782,42.037167],[22.779532,42.036707],[22.780281,42.036601],[22.781592,42.036671],[22.78267,42.037061],[22.783934,42.037592],[22.784543,42.037946],[22.785293,42.037698],[22.786042,42.037273],[22.787447,42.037273],[22.788384,42.037344],[22.789742,42.037379],[22.79082,42.037592],[22.791756,42.037804],[22.792646,42.037981],[22.793208,42.038441],[22.79363,42.038902],[22.794098,42.039468],[22.794801,42.040105],[22.795316,42.040495],[22.795878,42.040813],[22.79644,42.04099],[22.797002,42.041097],[22.797377,42.041451],[22.797611,42.041946],[22.797705,42.042725],[22.797939,42.043539],[22.798173,42.044318],[22.798314,42.045132],[22.798641,42.045805],[22.799321,42.046354],[22.799842,42.045452],[22.800488,42.044204],[22.801207,42.043227],[22.802787,42.041436],[22.805803,42.038288],[22.808245,42.035519],[22.811405,42.031937],[22.815356,42.027975],[22.816648,42.026835],[22.818516,42.025261],[22.820168,42.024013],[22.821963,42.022873],[22.823759,42.022113],[22.825339,42.021353],[22.827637,42.020811],[22.829361,42.020539],[22.830725,42.020431],[22.831803,42.020376],[22.83288,42.020159],[22.834891,42.019996],[22.836687,42.019888],[22.837836,42.019834],[22.838769,42.019888],[22.840206,42.019996],[22.841858,42.020051],[22.843222,42.020214],[22.844874,42.020539],[22.84588,42.020756],[22.84667,42.021082],[22.847675,42.021733],[22.848825,42.022385],[22.849758,42.022982],[22.850548,42.023742],[22.851195,42.024176],[22.852344,42.024393],[22.85299,42.024556],[22.853421,42.024556],[22.854211,42.024501],[22.85457,42.02423],[22.855001,42.023362],[22.855791,42.022765],[22.856222,42.022276],[22.85694,42.021679],[22.858018,42.021353],[22.859526,42.021191],[22.860531,42.021191],[22.861465,42.021353],[22.862614,42.02157],[22.863476,42.021896],[22.864338,42.022113],[22.865056,42.022276],[22.865559,42.022276],[22.866062,42.021679],[22.866636,42.020648],[22.866995,42.019019],[22.867355,42.017988],[22.867498,42.01712],[22.86757,42.016414],[22.867498,42.015654],[22.867283,42.014949],[22.866852,42.0137],[22.866565,42.012778],[22.866277,42.011909],[22.865774,42.011149],[22.865487,42.010715],[22.864697,42.009955],[22.863907,42.009195],[22.863045,42.008436],[22.862183,42.007676],[22.861322,42.00697],[22.86046,42.006156],[22.859598,42.00545],[22.859239,42.005016],[22.859095,42.004582],[22.859167,42.003958],[22.859526,42.003279],[22.859957,42.002737],[22.860819,42.002628],[22.861752,42.002248],[22.863189,42.001922],[22.863979,42.001814],[22.864913,42.001542],[22.866277,42.001],[22.867355,42.000511],[22.86836,41.999914],[22.869294,41.999209],[22.869938,41.998809],[22.870717,41.998537],[22.871615,41.998039],[22.872393,41.997813],[22.873411,41.997677],[22.87407,41.997632],[22.874908,41.997542],[22.875327,41.99727],[22.875387,41.996501],[22.875387,41.995867],[22.875268,41.994962],[22.875088,41.994374],[22.874789,41.993876],[22.874369,41.993424],[22.87395,41.992745],[22.87383,41.992157],[22.87419,41.991659],[22.874609,41.991252],[22.874908,41.990799],[22.875148,41.990347],[22.874968,41.989759],[22.875148,41.98899],[22.874968,41.988401],[22.874848,41.987632],[22.874669,41.986863],[22.874609,41.986275],[22.874489,41.985686],[22.87407,41.985189],[22.87389,41.984533],[22.87431,41.983899],[22.874729,41.983288],[22.874489,41.9827],[22.87425,41.982112],[22.87407,41.981478],[22.87383,41.981071],[22.87383,41.980483],[22.87389,41.979804],[22.87395,41.978808],[22.87419,41.97813],[22.874669,41.977722],[22.875268,41.977541],[22.875866,41.977406],[22.876525,41.977179],[22.877184,41.976863],[22.877782,41.976546],[22.878022,41.976048],[22.877842,41.975143],[22.877483,41.974148],[22.877543,41.973424],[22.877303,41.972745],[22.876824,41.971976],[22.876345,41.971252],[22.875986,41.970618],[22.875806,41.97003],[22.876106,41.969397],[22.876405,41.968763],[22.876525,41.968084],[22.876525,41.967451],[22.876345,41.966998],[22.876405,41.96641],[22.876285,41.965596],[22.876285,41.964962],[22.876106,41.964102],[22.875926,41.963062],[22.875866,41.961976],[22.875747,41.961252],[22.875327,41.96012],[22.875148,41.959442],[22.874609,41.958763],[22.87431,41.95831],[22.87413,41.957632],[22.87401,41.956772],[22.873711,41.956003],[22.873411,41.955233],[22.873591,41.954419],[22.87401,41.954057],[22.874429,41.953514],[22.874549,41.952654],[22.874549,41.951795],[22.874549,41.951071],[22.874669,41.950392],[22.874609,41.949623],[22.874789,41.94908],[22.875088,41.948582],[22.875687,41.948265],[22.876046,41.948039],[22.876046,41.947496],[22.875268,41.947043],[22.874789,41.9465],[22.874429,41.946003],[22.8741,41.945324],[22.87431,41.944871],[22.874669,41.944645],[22.875148,41.944328],[22.876106,41.943966],[22.876824,41.94374],[22.877603,41.943514],[22.877782,41.943061],[22.877663,41.942156],[22.877423,41.941523],[22.877243,41.940889],[22.877004,41.940256],[22.876465,41.939713],[22.875806,41.93917],[22.875387,41.938763],[22.874848,41.938174],[22.874369,41.937541],[22.87383,41.937088],[22.873351,41.93641],[22.873531,41.935867],[22.87419,41.935505],[22.874908,41.935052],[22.875567,41.934465],[22.876226,41.933921],[22.876735,41.933627],[22.877184,41.933378],[22.877543,41.932926],[22.877902,41.932156],[22.878082,41.931478],[22.878381,41.930889],[22.878681,41.93012],[22.87886,41.929532],[22.87898,41.928989],[22.87904,41.928084],[22.8791,41.927224],[22.87916,41.926364],[22.879339,41.92564],[22.879878,41.925143],[22.880417,41.924781],[22.881016,41.924283],[22.881375,41.923695],[22.881914,41.923106],[22.882273,41.922563],[22.882812,41.921839],[22.883351,41.921296],[22.88395,41.920934],[22.884848,41.920753],[22.885926,41.920618],[22.886944,41.920482],[22.888201,41.920437],[22.889339,41.920301],[22.890297,41.920075],[22.891195,41.919577],[22.891494,41.918627],[22.891674,41.917812],[22.891913,41.917133],[22.892153,41.916681],[22.892752,41.9165],[22.89335,41.916409],[22.89359,41.915912],[22.894009,41.915097],[22.894249,41.914238],[22.894308,41.913537],[22.894009,41.91288],[22.89371,41.912473],[22.89335,41.911794],[22.89347,41.911251],[22.89353,41.910618],[22.89371,41.910165],[22.894129,41.909848],[22.894608,41.909532],[22.895027,41.90917],[22.895326,41.908717],[22.895506,41.908219],[22.895626,41.907676],[22.895985,41.907043],[22.896344,41.906409],[22.897003,41.905957],[22.897482,41.90564],[22.898081,41.905142],[22.89862,41.90469],[22.898979,41.904056],[22.899218,41.903468],[22.898979,41.902789],[22.89862,41.902246],[22.89838,41.901703],[22.898081,41.90116],[22.897662,41.900346],[22.897183,41.899667],[22.897003,41.899079],[22.896644,41.8984],[22.896943,41.897812],[22.897183,41.897269],[22.897362,41.896726],[22.897362,41.896047],[22.897123,41.895323],[22.897123,41.894871],[22.897602,41.894464],[22.898081,41.894011],[22.898799,41.893649],[22.899398,41.893197],[22.900236,41.892925],[22.900775,41.892473],[22.901314,41.891975],[22.901434,41.891568],[22.901015,41.89107],[22.900236,41.890663],[22.899518,41.890029],[22.899039,41.889305],[22.898859,41.888807],[22.898919,41.888129],[22.898799,41.887405],[22.898979,41.886862],[22.899278,41.886228],[22.899757,41.885866],[22.900057,41.885414],[22.900236,41.884916],[22.900296,41.884192],[22.900356,41.883423],[22.900536,41.883015],[22.900835,41.882699],[22.901254,41.882065],[22.901314,41.881477],[22.901075,41.880753],[22.901015,41.880119],[22.900955,41.87926],[22.901015,41.878355],[22.901374,41.877767],[22.901613,41.877405],[22.901733,41.876907],[22.901913,41.876454],[22.902332,41.876047],[22.902811,41.875957],[22.90341,41.875866],[22.904068,41.875821],[22.904787,41.875776],[22.905625,41.87573],[22.906164,41.875504],[22.906583,41.875459],[22.907182,41.875368],[22.907541,41.875685],[22.90808,41.876319],[22.908499,41.876862],[22.909098,41.877224],[22.909757,41.87745],[22.910655,41.877586],[22.911254,41.877586],[22.911793,41.877495],[22.912511,41.877088],[22.91311,41.876997],[22.913649,41.876907],[22.914397,41.876771],[22.915027,41.876424],[22.915385,41.876002],[22.915625,41.875504],[22.915962,41.875035],[22.916273,41.874653],[22.9167,41.874359],[22.917301,41.874192],[22.91802,41.87392],[22.918439,41.873558],[22.918738,41.873015],[22.918978,41.872518],[22.919217,41.871929],[22.919457,41.871341],[22.919936,41.870662],[22.920475,41.870029],[22.921253,41.869531],[22.921972,41.869033],[22.92251,41.86849],[22.922989,41.867947],[22.923768,41.867585],[22.924247,41.867042],[22.924486,41.866499],[22.924606,41.865775],[22.924786,41.865097],[22.924786,41.864599],[22.925145,41.863965],[22.925564,41.863649],[22.926343,41.863422],[22.927061,41.863151],[22.92754,41.862698],[22.92772,41.862291],[22.92748,41.861929],[22.927121,41.861477],[22.926822,41.860979],[22.926702,41.860481],[22.926762,41.859984],[22.927001,41.859531],[22.927241,41.859124],[22.9276,41.858671],[22.928109,41.858151],[22.928498,41.857585],[22.928738,41.857133],[22.929157,41.856635],[22.929815,41.856409],[22.930294,41.855866],[22.930534,41.855187],[22.930474,41.854418],[22.930354,41.853739],[22.930354,41.853287],[22.930534,41.852608],[22.930774,41.851929],[22.930893,41.851431],[22.931133,41.850888],[22.931312,41.850391],[22.931612,41.850029],[22.932211,41.849712],[22.932989,41.84944],[22.933228,41.848852],[22.933468,41.848354],[22.934007,41.847947],[22.934845,41.847766],[22.935564,41.847495],[22.936761,41.847404],[22.93712,41.847042],[22.936881,41.846544],[22.936402,41.845911],[22.936103,41.845277],[22.935803,41.844825],[22.935624,41.844191],[22.935564,41.843467],[22.935564,41.843015],[22.935744,41.842359],[22.936222,41.84202],[22.936701,41.841658],[22.93712,41.84116],[22.93724,41.840753],[22.937659,41.840052],[22.937779,41.839486],[22.938078,41.839078],[22.938438,41.83849],[22.938917,41.837811],[22.939336,41.837314],[22.939875,41.836703],[22.940054,41.836137],[22.939875,41.835594],[22.939815,41.835142],[22.939815,41.834599],[22.940054,41.834146],[22.940474,41.833784],[22.940833,41.833332],[22.941132,41.832789],[22.941611,41.832291],[22.941971,41.831748],[22.94227,41.831069],[22.942509,41.830617],[22.942749,41.829576],[22.942869,41.828897],[22.942929,41.828264],[22.942929,41.827766],[22.942749,41.827132],[22.942509,41.826544],[22.94227,41.826001],[22.941791,41.825096],[22.941432,41.824508],[22.941192,41.823784],[22.940953,41.823151],[22.940833,41.822562],[22.940713,41.821929],[22.940713,41.82125],[22.940773,41.820707],[22.940713,41.819938],[22.940653,41.81944],[22.940713,41.818942],[22.940593,41.818173],[22.940713,41.817359],[22.940893,41.81668],[22.941192,41.816001],[22.941611,41.815639],[22.94221,41.815141],[22.943048,41.814689],[22.943827,41.814327],[22.944605,41.813693],[22.945084,41.812969],[22.945204,41.812245],[22.945264,41.811069],[22.945563,41.810481],[22.945743,41.809666],[22.945982,41.808987],[22.946342,41.808173],[22.946461,41.807539],[22.946521,41.807132],[22.946761,41.806544],[22.94688,41.806046],[22.94718,41.805594],[22.947599,41.805232],[22.948437,41.804689],[22.949036,41.804417],[22.949635,41.80401],[22.950413,41.803558],[22.951072,41.803105],[22.95191,41.802788],[22.952509,41.802336],[22.952928,41.801883],[22.952928,41.80134],[22.952988,41.800707],[22.952988,41.800119],[22.952928,41.799621],[22.952988,41.799214],[22.953167,41.798625],[22.953467,41.797992],[22.953766,41.797404],[22.954066,41.796861],[22.954365,41.796363],[22.954724,41.795639],[22.955024,41.795005],[22.955563,41.794508],[22.955922,41.794055],[22.956521,41.793467],[22.957239,41.792879],[22.957658,41.792336],[22.958257,41.791747],[22.958856,41.791204],[22.959694,41.790707],[22.960293,41.790254],[22.96094,41.789927],[22.961601,41.789633],[22.962568,41.789304],[22.963406,41.789304],[22.964065,41.789349],[22.964544,41.789394],[22.964784,41.788987],[22.964844,41.788535],[22.964784,41.787992],[22.964724,41.787403],[22.964604,41.786725],[22.964544,41.786001],[22.964544,41.785367],[22.964424,41.784643],[22.964484,41.78401],[22.964664,41.783376],[22.964844,41.782743],[22.964903,41.782019],[22.965083,41.781431],[22.965203,41.780526],[22.965203,41.779802],[22.965143,41.779123],[22.964604,41.778444],[22.963766,41.777992],[22.963107,41.777539],[22.962448,41.777041],[22.962209,41.776408],[22.962508,41.77582],[22.962748,41.775277],[22.963107,41.774869],[22.963616,41.774055],[22.964005,41.773557],[22.964544,41.773286],[22.965263,41.773059],[22.965802,41.772833],[22.96652,41.772471],[22.967298,41.772064],[22.968137,41.771566],[22.969035,41.771068],[22.969694,41.770661],[22.970232,41.770435],[22.97125,41.770661],[22.97161,41.771114],[22.972268,41.771792],[22.972927,41.772109],[22.973945,41.772019],[22.974963,41.771702],[22.975981,41.77134],[22.976939,41.770933],[22.977717,41.770616],[22.979034,41.770344],[22.980052,41.770163],[22.980891,41.769756],[22.981968,41.769575],[22.983166,41.76953],[22.984304,41.769756],[22.984962,41.770073],[22.985741,41.770435],[22.98622,41.770933],[22.987118,41.771249],[22.987956,41.77143],[22.988734,41.771476],[22.989303,41.771408],[22.989513,41.770978],[22.989692,41.770571],[22.989932,41.770073],[22.990112,41.769485],[22.990471,41.768987],[22.99089,41.768444],[22.991309,41.767991],[22.991728,41.767675],[22.992207,41.767358],[22.992626,41.767177],[22.993704,41.767087],[22.994602,41.767177],[22.995321,41.767403],[22.99592,41.767494],[22.996459,41.767946],[22.997117,41.768444],[22.997776,41.768851],[22.998255,41.769168],[22.998734,41.769439],[22.999452,41.769666],[23.000291,41.769801],[23.001428,41.769485],[23.002147,41.769077],[23.003165,41.768715],[23.003858,41.768804],[23.004602,41.768896],[23.00568,41.768942],[23.006458,41.769123],[23.007296,41.769213],[23.008194,41.769168],[23.008434,41.76867],[23.008494,41.768127],[23.008673,41.767584],[23.008913,41.767041],[23.009272,41.766498],[23.009871,41.76582],[23.010111,41.765096],[23.01041,41.764145],[23.010505,41.763281],[23.010583,41.762517],[23.011009,41.761838],[23.011428,41.76134],[23.011847,41.761023],[23.012386,41.760752],[23.012565,41.760163],[23.012685,41.75962],[23.013104,41.759123],[23.013823,41.75867],[23.014541,41.758263],[23.01544,41.757856],[23.015859,41.757403],[23.015919,41.756724],[23.015978,41.756227],[23.015739,41.755593],[23.015679,41.755141],[23.015559,41.754688],[23.015889,41.754236],[23.015679,41.753534],[23.01532,41.752923],[23.01526,41.75238],[23.01508,41.751883],[23.01502,41.751385],[23.01514,41.750887],[23.01544,41.750344],[23.015859,41.750027],[23.016278,41.749801],[23.016757,41.749665],[23.017236,41.749484],[23.017535,41.749168],[23.017962,41.748674],[23.018541,41.748458],[23.019526,41.748373],[23.020453,41.74846],[23.021264,41.748245],[23.021786,41.74738],[23.022192,41.746774],[23.022308,41.746298],[23.022367,41.745692],[23.022599,41.745],[23.022947,41.744265],[23.023179,41.743443],[23.02347,41.742577],[23.023644,41.741798],[23.023877,41.740976],[23.023993,41.740067],[23.02411,41.739418],[23.024342,41.738899],[23.02469,41.73851],[23.025153,41.738034],[23.025849,41.737516],[23.026602,41.737127],[23.02695,41.736651],[23.02724,41.735873],[23.027472,41.735007],[23.027763,41.734142],[23.027995,41.733493],[23.028111,41.732801],[23.028343,41.732281],[23.028749,41.731719],[23.029155,41.731287],[23.029676,41.730768],[23.030256,41.730292],[23.030835,41.72999],[23.031298,41.729558],[23.031299,41.728562],[23.031068,41.727826],[23.031185,41.727134],[23.031301,41.726658],[23.031359,41.725835],[23.031649,41.725143],[23.032113,41.724365],[23.032866,41.723543],[23.033272,41.723024],[23.033678,41.722635],[23.03391,41.722203],[23.033621,41.72151],[23.033042,41.721076],[23.032464,41.720426],[23.032059,41.719906],[23.031422,41.719386],[23.031307,41.718953],[23.031365,41.718218],[23.031308,41.717612],[23.031309,41.717049],[23.031425,41.71653],[23.031657,41.71614],[23.031976,41.715297],[23.03189,41.714366],[23.032122,41.713587],[23.03218,41.712981],[23.032528,41.712203],[23.03305,41.711511],[23.033629,41.710862],[23.034035,41.71017],[23.034093,41.709391],[23.033573,41.708698],[23.032416,41.708134],[23.031606,41.70757],[23.030622,41.70718],[23.029754,41.707049],[23.029002,41.706745],[23.028482,41.705533],[23.028136,41.704537],[23.027847,41.703844],[23.027384,41.703194],[23.027038,41.702761],[23.02669,41.702544],[23.025938,41.702457],[23.024954,41.702629],[23.023854,41.702801],[23.022986,41.702886],[23.022465,41.702756],[23.022119,41.702366],[23.021598,41.701846],[23.020904,41.701196],[23.020268,41.700459],[23.01998,41.69994],[23.019575,41.69916],[23.019229,41.698467],[23.01894,41.697644],[23.018652,41.696908],[23.018189,41.696302],[23.017438,41.695738],[23.017033,41.695132],[23.016397,41.694482],[23.015646,41.693961],[23.014894,41.693181],[23.014547,41.692705],[23.013825,41.691925],[23.013276,41.691275],[23.01293,41.690409],[23.012583,41.689629],[23.012179,41.689023],[23.011427,41.688459],[23.01085,41.687852],[23.010503,41.687159],[23.009578,41.686552],[23.009116,41.686162],[23.008596,41.685556],[23.008423,41.684906],[23.008655,41.684473],[23.008771,41.683998],[23.008483,41.683218],[23.008021,41.682525],[23.007732,41.682092],[23.006864,41.682047],[23.005823,41.682003],[23.005071,41.682002],[23.004261,41.681654],[23.003625,41.681177],[23.003163,41.680398],[23.002586,41.679834],[23.001718,41.679444],[23.001429,41.67914],[23.000967,41.67849],[22.999984,41.678056],[22.999696,41.677753],[22.999291,41.677146],[22.998945,41.67667],[22.99773,41.676452],[22.997153,41.675628],[22.996749,41.674979],[22.996229,41.674545],[22.995419,41.674198],[22.99461,41.67372],[22.99409,41.673243],[22.993802,41.672637],[22.993456,41.671901],[22.993457,41.671295],[22.993168,41.670515],[22.992707,41.669562],[22.992014,41.668523],[22.991611,41.6677],[22.990976,41.666833],[22.990687,41.6664],[22.989936,41.666009],[22.990111,41.664797],[22.990228,41.663845],[22.988841,41.663497],[22.987858,41.663279],[22.987569,41.662543],[22.987571,41.661591],[22.987803,41.660899],[22.9874,41.660162],[22.987053,41.659902],[22.986418,41.659079],[22.985898,41.658558],[22.985494,41.658168],[22.983991,41.658036],[22.982487,41.657904],[22.981679,41.656994],[22.981507,41.655998],[22.981566,41.655176],[22.982088,41.654268],[22.983014,41.65362],[22.983767,41.652885],[22.98452,41.652367],[22.984579,41.651415],[22.98435,41.650246],[22.984351,41.649466],[22.984237,41.648557],[22.98418,41.648038],[22.983949,41.647561],[22.983025,41.647257],[22.982273,41.646996],[22.981695,41.646909],[22.980827,41.647513],[22.980537,41.648119],[22.980016,41.648464],[22.979437,41.64855],[22.978455,41.648332],[22.97753,41.648114],[22.976258,41.647679],[22.975681,41.647332],[22.975276,41.646985],[22.97464,41.646984],[22.974177,41.647243],[22.973656,41.647632],[22.972789,41.647587],[22.971864,41.647326],[22.970476,41.647281],[22.969666,41.647452],[22.968798,41.648187],[22.968046,41.648315],[22.966773,41.648357],[22.965386,41.648224],[22.963825,41.647919],[22.96238,41.647484],[22.961282,41.647135],[22.960531,41.646918],[22.96001,41.64683],[22.959836,41.647393],[22.959546,41.647955],[22.959025,41.648041],[22.958448,41.647304],[22.958276,41.646481],[22.958163,41.645572],[22.957933,41.644792],[22.957587,41.644229],[22.956547,41.643924],[22.955564,41.643749],[22.954755,41.643402],[22.954178,41.643098],[22.953658,41.642621],[22.952964,41.642663],[22.952155,41.642748],[22.951519,41.642574],[22.951115,41.64201],[22.951117,41.641231],[22.95083,41.640105],[22.950775,41.639066],[22.950777,41.638071],[22.950778,41.637378],[22.950896,41.636556],[22.950781,41.635906],[22.949974,41.634823],[22.949108,41.634085],[22.948474,41.633262],[22.948129,41.632569],[22.948073,41.631876],[22.948653,41.631011],[22.949753,41.630234],[22.950679,41.6295],[22.951722,41.628679],[22.952649,41.627469],[22.952882,41.626604],[22.953288,41.625825],[22.953348,41.625003],[22.953003,41.624094],[22.952427,41.62301],[22.952197,41.622317],[22.952835,41.62128],[22.953358,41.620242],[22.95417,41.619031],[22.954171,41.618295],[22.953653,41.617212],[22.953308,41.616389],[22.952905,41.615393],[22.953138,41.614614],[22.953429,41.613576],[22.9532,41.61258],[22.95222,41.61141],[22.951413,41.610586],[22.951067,41.610109],[22.9513,41.609287],[22.951418,41.608248],[22.951015,41.607295],[22.950671,41.606299],[22.951019,41.605391],[22.951484,41.604266],[22.951948,41.603358],[22.951142,41.602275],[22.950451,41.600888],[22.949991,41.599892],[22.949646,41.599026],[22.949994,41.598334],[22.949996,41.597381],[22.949826,41.595866],[22.950175,41.594871],[22.95064,41.593444],[22.950874,41.592102],[22.950935,41.590804],[22.951053,41.589635],[22.951518,41.588381],[22.952098,41.58717],[22.952563,41.586132],[22.953199,41.585527],[22.954586,41.585486],[22.956088,41.585489],[22.957532,41.585578],[22.959035,41.585364],[22.960365,41.584761],[22.96106,41.58342],[22.961062,41.582641],[22.961064,41.581818],[22.962567,41.580955],[22.963666,41.580221],[22.963609,41.579745],[22.964941,41.578492],[22.965809,41.577671],[22.965636,41.577065],[22.965291,41.576415],[22.964715,41.575721],[22.964889,41.575116],[22.96541,41.574424],[22.965932,41.573603],[22.966106,41.572954],[22.965935,41.572131],[22.965763,41.571525],[22.965706,41.570962],[22.965765,41.570226],[22.965998,41.569491],[22.966172,41.568885],[22.966289,41.568322],[22.966752,41.567587],[22.9671,41.566592],[22.967911,41.565468],[22.968779,41.564561],[22.969589,41.563956],[22.970283,41.563481],[22.971207,41.56331],[22.972218,41.563376],[22.972421,41.562792],[22.97248,41.562013],[22.972423,41.561364],[22.972309,41.560887],[22.972714,41.560239],[22.972888,41.559806],[22.9726,41.559373],[22.972082,41.558766],[22.97139,41.558072],[22.970987,41.557336],[22.970584,41.556599],[22.970181,41.556123],[22.969893,41.555516],[22.969779,41.55504],[22.969433,41.554606],[22.968914,41.554238],[22.968916,41.55309],[22.969322,41.552009],[22.969382,41.55084],[22.969442,41.549629],[22.969271,41.548546],[22.969099,41.54807],[22.969504,41.547291],[22.969737,41.546296],[22.969854,41.545863],[22.969856,41.544738],[22.969743,41.543591],[22.969455,41.542963],[22.968763,41.542659],[22.968243,41.542528],[22.967261,41.542743],[22.96576,41.542956],[22.964432,41.542997],[22.963278,41.542692],[22.961893,41.54243],[22.960796,41.542342],[22.959988,41.542081],[22.960111,41.538445],[22.959997,41.537796],[22.959075,41.537145],[22.958904,41.535976],[22.958675,41.535066],[22.958445,41.53433],[22.958909,41.533595],[22.959545,41.53286],[22.959431,41.532167],[22.95978,41.531172],[22.960301,41.530221],[22.960765,41.529097],[22.961692,41.527237],[22.962388,41.525507],[22.962901,41.52459],[22.963835,41.523431],[22.964818,41.522611],[22.96557,41.521616],[22.966091,41.521098],[22.966726,41.520839],[22.967419,41.520667],[22.967824,41.520278],[22.968344,41.51976],[22.968807,41.518982],[22.969501,41.51829],[22.970311,41.517469],[22.970889,41.516778],[22.970718,41.515998],[22.970776,41.515435],[22.971066,41.514917],[22.970894,41.514224],[22.970434,41.513487],[22.970032,41.512188],[22.969977,41.510716],[22.969979,41.50972],[22.970154,41.509028],[22.969578,41.508075],[22.96935,41.506819],[22.969411,41.505261],[22.969413,41.504092],[22.969126,41.503486],[22.967511,41.502704],[22.96659,41.502053],[22.965322,41.501272],[22.963881,41.500663],[22.962267,41.499925],[22.961575,41.499707],[22.96146,41.499101],[22.960822,41.4985],[22.960246,41.497893],[22.959727,41.497198],[22.959497,41.496591],[22.959324,41.496027],[22.958748,41.495462],[22.958114,41.494811],[22.957711,41.494204],[22.957711,41.49377],[22.958289,41.493249],[22.958981,41.492772],[22.959789,41.492381],[22.960482,41.492077],[22.961001,41.49147],[22.961002,41.490862],[22.960541,41.490472],[22.960138,41.489734],[22.95985,41.48904],[22.960139,41.488389],[22.960428,41.487607],[22.960775,41.48674],[22.961122,41.485568],[22.961527,41.484656],[22.961816,41.483571],[22.961759,41.482573],[22.961298,41.481792],[22.961415,41.481011],[22.961588,41.480013],[22.961532,41.479188],[22.961359,41.478364],[22.961302,41.477496],[22.961476,41.476845],[22.962464,41.476275],[22.963784,41.475847],[22.96511,41.475413],[22.966034,41.474805],[22.966899,41.474414],[22.967245,41.474154],[22.967015,41.47346],[22.966785,41.472852],[22.966382,41.472158],[22.966152,41.471203],[22.966037,41.470335],[22.965808,41.468773],[22.965751,41.468295],[22.96506,41.467427],[22.964426,41.466212],[22.964138,41.465865],[22.964139,41.465388],[22.96437,41.464954],[22.964716,41.464042],[22.965467,41.462827],[22.965756,41.461786],[22.96616,41.461004],[22.96668,41.460267],[22.967489,41.459434],[22.968714,41.458484],[22.970091,41.457361],[22.971354,41.45644],[22.972923,41.455375],[22.974377,41.454367],[22.975218,41.45393],[22.97591,41.453192],[22.976635,41.452006],[22.977209,41.450999],[22.977872,41.449981],[22.97832,41.449012],[22.979026,41.448288],[22.97943,41.447507],[22.979373,41.446595],[22.979163,41.4455],[22.978934,41.444607],[22.978338,41.443818],[22.977589,41.442863],[22.977243,41.442169],[22.976552,41.441561],[22.975515,41.441128],[22.974593,41.44065],[22.97412,41.439829],[22.973623,41.439052],[22.973039,41.438177],[22.972521,41.437135],[22.971945,41.43605],[22.970966,41.434965],[22.970218,41.433794],[22.969469,41.432926],[22.969041,41.43197],[22.968354,41.43079],[22.96736,41.430876],[22.966289,41.43102],[22.96518,41.43128],[22.964492,41.431423],[22.963689,41.431308],[22.963116,41.430992],[22.962543,41.430301],[22.961855,41.429811],[22.961435,41.429466],[22.960748,41.428832],[22.959831,41.427998],[22.958986,41.42685],[22.958122,41.425678],[22.957579,41.424744],[22.95651,41.423219],[22.955556,41.421923],[22.954678,41.420714],[22.953762,41.41962],[22.953113,41.418785],[22.95254,41.418256],[22.952599,41.417475],[22.9526,41.416651],[22.952658,41.416087],[22.952947,41.415132],[22.953409,41.41422],[22.954159,41.412962],[22.954343,41.412049],[22.95531,41.411392],[22.956195,41.410921],[22.95734,41.410373],[22.95885,41.409746],[22.960047,41.409158],[22.960847,41.408362],[22.960905,41.407581],[22.960503,41.406583],[22.960504,41.405802],[22.961023,41.404934],[22.961191,41.404103],[22.961613,41.403125],[22.962351,41.402113],[22.962761,41.400678],[22.963563,41.399466],[22.964139,41.398116],[22.96479,41.396878],[22.965409,41.395863],[22.96567,41.395064],[22.966044,41.394388],[22.966092,41.393509],[22.96552,41.392531],[22.965176,41.391869],[22.964528,41.391034],[22.964108,41.390285],[22.963802,41.389614],[22.9634,41.388659],[22.963343,41.387531],[22.962826,41.386012],[22.962597,41.384753],[22.962138,41.383582],[22.962023,41.38267],[22.961909,41.381195],[22.961826,41.379777],[22.96217,41.378568],[22.962745,41.377215],[22.963124,41.376074],[22.963297,41.375162],[22.963414,41.37347],[22.963415,41.371994],[22.963704,41.370822],[22.963302,41.369868],[22.963325,41.368982],[22.963517,41.368176],[22.964129,41.367197],[22.96455,41.366506],[22.964856,41.365815],[22.965091,41.36505],[22.964804,41.364313],[22.964747,41.363358],[22.964806,41.36262],[22.964749,41.361839],[22.96475,41.360884],[22.964808,41.360016],[22.964809,41.359192],[22.964752,41.35828],[22.964638,41.357282],[22.964753,41.356674],[22.964754,41.35585],[22.964582,41.355069],[22.96441,41.354418],[22.964104,41.353502],[22.963376,41.353189],[22.962701,41.352954],[22.961661,41.352836],[22.960726,41.352601],[22.959322,41.352522],[22.958282,41.352483],[22.957139,41.352522],[22.956047,41.352561],[22.954279,41.352482],[22.952824,41.352482],[22.9522,41.352443],[22.951576,41.352561],[22.951004,41.352404],[22.950381,41.352051],[22.949966,41.351384],[22.949239,41.350718],[22.9482,41.349856],[22.94685,41.348797],[22.945896,41.347849],[22.945019,41.346899],[22.944098,41.346327],[22.943059,41.3457],[22.941968,41.344916],[22.940878,41.344092],[22.939943,41.343348],[22.93932,41.342681],[22.938438,41.341936],[22.937659,41.341387],[22.936724,41.340838],[22.935633,41.340564],[22.934385,41.340602],[22.933186,41.340628],[22.932649,41.340708],[22.931458,41.340925],[22.928802,41.341091],[22.927894,41.340346],[22.927568,41.339683],[22.927367,41.339274],[22.926277,41.338965],[22.921499,41.339601],[22.916249,41.340982],[22.914066,41.341167],[22.903375,41.340237],[22.896403,41.338611],[22.889895,41.339773],[22.885248,41.34047],[22.877346,41.34047],[22.871303,41.34047],[22.864098,41.34047],[22.857126,41.338378],[22.852013,41.338611],[22.844576,41.338611],[22.838534,41.337913],[22.833886,41.337216],[22.830167,41.335822],[22.82273,41.334195],[22.815758,41.339075],[22.812504,41.343491],[22.807623,41.34047],[22.805764,41.338378],[22.80193,41.338829],[22.7967,41.33954],[22.796003,41.337216],[22.796235,41.334195],[22.792284,41.330709],[22.788798,41.328152],[22.784771,41.32681],[22.782523,41.326061],[22.780199,41.32699],[22.769044,41.326061],[22.763001,41.32211],[22.75998,41.314673],[22.757423,41.309095],[22.75737,41.307923],[22.757191,41.303982],[22.758121,41.299566],[22.762536,41.296545],[22.76486,41.291897],[22.763001,41.287481],[22.759515,41.282136],[22.756726,41.275628],[22.760445,41.267959],[22.758585,41.260057],[22.758585,41.250761],[22.756494,41.242161],[22.755099,41.231936],[22.755099,41.218456],[22.752775,41.204744],[22.752078,41.193356],[22.748824,41.179644],[22.7465,41.16384],[22.742782,41.15803],[22.735809,41.149431],[22.727443,41.145712],[22.717682,41.143388],[22.713963,41.141529],[22.711872,41.140367],[22.704202,41.143853],[22.698159,41.150128],[22.692117,41.155241],[22.684447,41.161981],[22.67794,41.169418],[22.672361,41.177321],[22.666087,41.18313],[22.656326,41.183362],[22.650283,41.179876],[22.645403,41.174763],[22.642614,41.168256],[22.642149,41.160819],[22.635177,41.152452],[22.622859,41.138973],[22.616817,41.131768],[22.61316,41.129627],[22.607288,41.12619],[22.5959,41.120148],[22.587534,41.117126],[22.577307,41.118056],[22.569173,41.121774],[22.564061,41.126887],[22.561504,41.130606],[22.552208,41.130374],[22.538263,41.129676],[22.525713,41.128282],[22.508747,41.125958],[22.492247,41.122704],[22.47807,41.120612],[22.469935,41.11945],[22.465287,41.117126],[22.457618,41.120148],[22.450413,41.12131],[22.443906,41.118986],[22.436701,41.118986],[22.430891,41.119915],[22.423919,41.119683],[22.416714,41.118753],[22.413228,41.122704],[22.406256,41.126887],[22.401375,41.129211],[22.401608,41.133162],[22.403699,41.136416],[22.398819,41.138508],[22.393706,41.135951],[22.389522,41.132465],[22.382085,41.132233],[22.377669,41.135022],[22.372324,41.13781],[22.368606,41.137578],[22.364887,41.13386],[22.35838,41.133627],[22.352802,41.135486],[22.349316,41.135022],[22.343506,41.131535],[22.336998,41.129211],[22.334442,41.128049],[22.334674,41.122007],[22.331421,41.119683],[22.326772,41.122472],[22.325378,41.128747],[22.325378,41.135951],[22.323286,41.139902],[22.321427,41.144783],[22.323286,41.149663],[22.322589,41.151058],[22.315849,41.148734],[22.312363,41.146642],[22.304926,41.146874],[22.296095,41.151755],[22.288193,41.153382],[22.281453,41.154079],[22.274946,41.155706],[22.272157,41.160354],[22.2696,41.16384],[22.261234,41.164537],[22.249846,41.165932],[22.242408,41.165002],[22.235901,41.163375],[22.230091,41.165002],[22.22521,41.165235],[22.22033,41.166861],[22.216146,41.168721],[22.215615,41.16878],[22.214055,41.168953],[22.210801,41.165467],[22.207315,41.162446],[22.204061,41.160819],[22.197321,41.160819],[22.188258,41.161748],[22.180356,41.158495],[22.172221,41.157798],[22.16827,41.153382],[22.16339,41.146874],[22.158509,41.140135],[22.154791,41.137346],[22.151769,41.133395],[22.148284,41.128747],[22.141544,41.125958],[22.134107,41.125261],[22.130156,41.125028],[22.123416,41.124796],[22.116444,41.129676],[22.108542,41.13386],[22.102267,41.135022],[22.097154,41.136648],[22.092273,41.136648],[22.087393,41.139205],[22.08042,41.143156],[22.078097,41.14641],[22.079491,41.149431],[22.077399,41.152917],[22.073448,41.155241],[22.068568,41.156403],[22.065081,41.159657],[22.061363,41.161284],[22.060666,41.155706],[22.059504,41.150593],[22.054856,41.147572],[22.050672,41.147572],[22.045792,41.145945],[22.041841,41.142459],[22.034172,41.136881],[22.030221,41.134092],[22.023713,41.132233],[22.013255,41.130838],[22.005353,41.129909],[22.0,41.12712],[21.991176,41.126887],[21.984436,41.127352],[21.978161,41.127817],[21.974443,41.129211],[21.970957,41.125028],[21.964681,41.119683],[21.958871,41.116661],[21.954456,41.115964],[21.950969,41.113175],[21.945159,41.109689],[21.93656,41.107133],[21.929588,41.103647],[21.927817,41.101928],[21.921686,41.095977],[21.916108,41.093653],[21.911925,41.092956],[21.910763,41.086448],[21.908992,41.081726],[21.908672,41.080871],[21.90565,41.073899],[21.905883,41.068321],[21.909136,41.061581],[21.910763,41.054609],[21.911925,41.05089],[21.910298,41.048334],[21.904721,41.042756],[21.897516,41.03927],[21.892403,41.039502],[21.887058,41.040432],[21.883339,41.040664],[21.882177,41.037411],[21.884269,41.031833],[21.883571,41.028114],[21.877994,41.02672],[21.874275,41.024163],[21.871486,41.022304],[21.864049,41.02091],[21.859866,41.016029],[21.851964,41.012543],[21.847316,41.004409],[21.849175,41.000225],[21.845224,40.996972],[21.838019,40.99395],[21.828956,40.989767],[21.821751,40.987908],[21.814779,40.985816],[21.808272,40.980006],[21.804321,40.976985],[21.801067,40.973266],[21.800137,40.965829],[21.800602,40.960716],[21.802926,40.9563],[21.80525,40.951652],[21.802461,40.946539],[21.801299,40.944215],[21.79944,40.940264],[21.793397,40.939335],[21.791306,40.936313],[21.789214,40.933292],[21.787239,40.931665],[21.785263,40.930038],[21.777361,40.929341],[21.768297,40.928876],[21.762022,40.92632],[21.753656,40.926785],[21.747381,40.928876],[21.738317,40.929573],[21.731112,40.930271],[21.723675,40.934919],[21.716703,40.93794],[21.710196,40.941194],[21.705547,40.942356],[21.698575,40.941426],[21.688582,40.941194],[21.683469,40.93887],[21.681609,40.934222],[21.675799,40.929109],[21.671151,40.92539],[21.667665,40.920974],[21.666038,40.917953],[21.668594,40.914235],[21.671151,40.90796],[21.671151,40.902847],[21.669989,40.90029],[21.668827,40.898198],[21.659763,40.899825],[21.654418,40.899825],[21.648143,40.900058],[21.643727,40.898663],[21.639079,40.895642],[21.633733,40.895642],[21.631874,40.890994],[21.62862,40.88774],[21.623508,40.88774],[21.620021,40.887508],[21.616535,40.884254],[21.613281,40.881697],[21.610028,40.879141],[21.607936,40.879141],[21.603753,40.879838],[21.601894,40.876817],[21.599105,40.872866],[21.598175,40.870077],[21.593992,40.867056],[21.591435,40.866591],[21.585857,40.868915],[21.580047,40.866591],[21.574934,40.865894],[21.570983,40.866126],[21.56773,40.868218],[21.565871,40.871704],[21.564476,40.874493],[21.558898,40.877282],[21.553088,40.880303],[21.54844,40.884719],[21.544257,40.890064],[21.539609,40.893318],[21.535658,40.899128],[21.532404,40.903079],[21.529847,40.906565],[21.526361,40.908657],[21.521248,40.908657],[21.515903,40.908192],[21.505658,40.909974],[21.505212,40.910051],[21.497543,40.911213],[21.493127,40.911213],[21.489641,40.911213],[21.481274,40.909819],[21.474069,40.907262],[21.4664,40.90703],[21.461055,40.907262],[21.455244,40.910284],[21.449202,40.912608],[21.4413,40.915164],[21.431539,40.916791],[21.422475,40.917256],[21.416897,40.917023],[21.409228,40.912143],[21.400164,40.905868],[21.389706,40.899825],[21.380177,40.892156],[21.373437,40.885881],[21.362746,40.878211],[21.351358,40.877049],[21.343456,40.873331],[21.335322,40.871704],[21.326491,40.869845],[21.308595,40.865894],[21.301158,40.865429],[21.291397,40.865197],[21.284657,40.864499],[21.27815,40.86357],[21.273967,40.864964],[21.265135,40.862175],[21.25886,40.858224],[21.252585,40.861246],[21.251191,40.864499],[21.245613,40.869148],[21.239066,40.874262],[21.238176,40.874958],[21.230042,40.877049],[21.222372,40.878909],[21.211914,40.882627],[21.204244,40.882627],[21.197505,40.877514],[21.187279,40.876585],[21.179377,40.87612],[21.17194,40.872401],[21.168918,40.867288],[21.162876,40.863337],[21.157763,40.859619],[21.147769,40.856365],[21.135452,40.854971],[21.127317,40.854971],[21.111514,40.854041],[21.093851,40.853344],[21.079442,40.854738],[21.058525,40.854273],[21.043883,40.854041],[21.029474,40.854971],[21.008093,40.854971],[20.983611,40.855833],[20.980567,40.855222],[20.979573,40.863074],[20.978747,40.87209],[20.977976,40.879527],[20.977282,40.886209],[20.977282,40.887782],[20.977109,40.890009],[20.977282,40.891712],[20.977802,40.893678],[20.97851,40.895478],[20.979337,40.897174],[20.979016,40.89787],[20.977976,40.899049],[20.976589,40.899836],[20.974258,40.901549],[20.972131,40.902888],[20.971305,40.903602],[20.970596,40.904316],[20.970347,40.905011],[20.969651,40.90628],[20.96896,40.909007],[20.968007,40.910383],[20.96714,40.910907],[20.964972,40.911496],[20.960638,40.910972],[20.959598,40.911889],[20.956824,40.915427],[20.956477,40.915689],[20.955263,40.916803],[20.95405,40.917392],[20.952663,40.918047],[20.951969,40.918571],[20.950582,40.91962],[20.947635,40.92224],[20.946421,40.922764],[20.944608,40.922616],[20.942434,40.922109],[20.941567,40.923026],[20.940006,40.924074],[20.938273,40.924336],[20.936712,40.924467],[20.934213,40.923866],[20.932087,40.922973],[20.931378,40.922616],[20.929488,40.921545],[20.928044,40.92093],[20.926653,40.920741],[20.924576,40.92093],[20.923016,40.921061],[20.919028,40.922306],[20.916774,40.923026],[20.915734,40.923288],[20.914174,40.92224],[20.912596,40.920473],[20.912005,40.919045],[20.911769,40.917706],[20.911746,40.915755],[20.908712,40.916344],[20.906198,40.916737],[20.903164,40.917196],[20.901691,40.917392],[20.898396,40.918113],[20.896229,40.918703],[20.894322,40.92034],[20.892328,40.922175],[20.891375,40.922961],[20.888341,40.92355],[20.88574,40.924402],[20.883399,40.925123],[20.875858,40.927612],[20.866322,40.930756],[20.85748,40.93377],[20.851498,40.935735],[20.847154,40.937345],[20.844083,40.934132],[20.838929,40.928988],[20.837022,40.926891],[20.835721,40.925057],[20.834074,40.922764],[20.83208,40.919685],[20.829908,40.916813],[20.828353,40.914248],[20.827573,40.913003],[20.827746,40.909728],[20.827573,40.907893],[20.827399,40.906976],[20.826359,40.905338],[20.825232,40.904683],[20.822805,40.903832],[20.820291,40.90239],[20.816043,40.89977],[20.815523,40.899377],[20.814315,40.898603],[20.812489,40.897543],[20.810669,40.896822],[20.807895,40.896232],[20.804947,40.896167],[20.801133,40.89656],[20.797839,40.897346],[20.794285,40.898525],[20.790644,40.900098],[20.788477,40.900753],[20.78709,40.901146],[20.785356,40.901539],[20.783795,40.90167],[20.781021,40.901932],[20.780068,40.901801],[20.778854,40.901342],[20.77686,40.901408],[20.775127,40.902063],[20.773913,40.902849],[20.773393,40.902587],[20.760823,40.901211],[20.759523,40.901015],[20.757789,40.901146],[20.753628,40.902587],[20.752935,40.90298],[20.750763,40.904851],[20.749818,40.905119],[20.748774,40.905076],[20.747928,40.905119],[20.737071,40.9094],[20.73239,40.9113],[20.731696,40.911693],[20.725888,40.928267],[20.720774,40.943203],[20.717913,40.951196],[20.715139,40.959057],[20.708551,40.978317],[20.70485,40.989241],[20.702344,40.998573],[20.702106,40.9997],[20.701986,41.000602],[20.701696,41.002126],[20.701268,41.004029],[20.701032,41.0051],[20.700567,41.007441],[20.70019,41.00901],[20.697276,41.016166],[20.693796,41.025296],[20.689627,41.036324],[20.683216,41.052822],[20.676598,41.070327],[20.671295,41.083423],[20.66972,41.087268],[20.654092,41.086821],[20.632189,41.086373],[20.630907,41.086738],[20.629691,41.087788],[20.628128,41.08792],[20.627259,41.087657],[20.62639,41.087657],[20.626043,41.088051],[20.620136,41.088445],[20.615967,41.08897],[20.613535,41.089233],[20.602242,41.091202],[20.597204,41.092121],[20.595641,41.092515],[20.594425,41.094353],[20.59373,41.09606],[20.593382,41.097372],[20.593209,41.098554],[20.592645,41.10042],[20.591817,41.101673],[20.589908,41.104199],[20.587997,41.105644],[20.586607,41.106825],[20.585565,41.107482],[20.585043,41.108269],[20.583647,41.110173],[20.582611,41.111945],[20.582264,41.113389],[20.582611,41.114308],[20.58487,41.116146],[20.585912,41.116409],[20.58626,41.117328],[20.587128,41.118116],[20.587823,41.118772],[20.587997,41.120348],[20.588865,41.121267],[20.588865,41.122054],[20.587997,41.122973],[20.587997,41.123892],[20.589213,41.124418],[20.593593,41.125383],[20.594772,41.125993],[20.595467,41.126649],[20.596509,41.127175],[20.596857,41.127831],[20.596336,41.13177],[20.595013,41.133256],[20.593474,41.134777],[20.593209,41.135314],[20.594077,41.136365],[20.594425,41.13689],[20.593556,41.137546],[20.590429,41.138597],[20.590429,41.139384],[20.590776,41.139778],[20.590603,41.141747],[20.589734,41.14306],[20.588865,41.143848],[20.588518,41.144242],[20.586086,41.14713],[20.58487,41.147918],[20.583654,41.148443],[20.583132,41.148968],[20.58209,41.151988],[20.582227,41.15294],[20.582785,41.156058],[20.582438,41.156977],[20.578675,41.160276],[20.578094,41.16039],[20.577136,41.160992],[20.576705,41.161572],[20.575489,41.163804],[20.574446,41.165051],[20.573751,41.16551],[20.573404,41.165773],[20.57323,41.166429],[20.57323,41.166955],[20.572361,41.167217],[20.571667,41.167874],[20.570972,41.168267],[20.569756,41.168465],[20.569234,41.168793],[20.569756,41.169712],[20.569582,41.170368],[20.568887,41.170893],[20.568713,41.171812],[20.567546,41.173071],[20.566976,41.173519],[20.56577,41.175129],[20.564717,41.177195],[20.563501,41.178902],[20.562455,41.179602],[20.559679,41.181396],[20.558463,41.182446],[20.55829,41.183103],[20.558984,41.183497],[20.559853,41.184416],[20.559853,41.187041],[20.560201,41.187567],[20.560548,41.18796],[20.559853,41.189667],[20.559679,41.190586],[20.558637,41.191768],[20.558637,41.193081],[20.558116,41.193606],[20.5569,41.193606],[20.555684,41.193081],[20.555162,41.192424],[20.554167,41.191144],[20.553812,41.190876],[20.551681,41.191591],[20.549951,41.192555],[20.549256,41.193343],[20.548735,41.193606],[20.547866,41.193475],[20.546353,41.19517],[20.544459,41.196512],[20.542654,41.196888],[20.541618,41.196602],[20.541786,41.194919],[20.53779,41.195313],[20.537095,41.197151],[20.535879,41.198332],[20.534836,41.198726],[20.534663,41.199514],[20.53362,41.199382],[20.533273,41.199776],[20.531536,41.202665],[20.531536,41.204765],[20.531536,41.205553],[20.532057,41.206538],[20.531536,41.208113],[20.532057,41.208835],[20.531883,41.209754],[20.531536,41.210411],[20.531188,41.21133],[20.530841,41.212249],[20.529451,41.21343],[20.529103,41.214218],[20.528582,41.215137],[20.528235,41.216056],[20.527055,41.216554],[20.526324,41.217106],[20.524934,41.217894],[20.523892,41.218682],[20.523544,41.219075],[20.523197,41.219469],[20.523023,41.220782],[20.52337,41.22157],[20.523023,41.222489],[20.522676,41.223671],[20.522154,41.224327],[20.521807,41.225377],[20.521286,41.226428],[20.520765,41.227215],[20.520243,41.22774],[20.519375,41.228134],[20.518854,41.228266],[20.518332,41.228266],[20.517811,41.228528],[20.517464,41.229447],[20.516595,41.230235],[20.515727,41.23076],[20.515379,41.231679],[20.515205,41.232467],[20.515379,41.232992],[20.515727,41.233648],[20.516248,41.234173],[20.516769,41.234699],[20.516943,41.235486],[20.516595,41.23693],[20.516248,41.237587],[20.5164,41.238385],[20.516992,41.239458],[20.516769,41.239819],[20.516943,41.240607],[20.519375,41.243364],[20.521286,41.245595],[20.521459,41.246383],[20.520938,41.246908],[20.520243,41.247565],[20.519027,41.248221],[20.518506,41.249403],[20.51868,41.249928],[20.517116,41.252028],[20.516248,41.253341],[20.516074,41.253867],[20.514858,41.255311],[20.514337,41.256361],[20.51451,41.257017],[20.51451,41.258462],[20.514858,41.259118],[20.516074,41.259906],[20.515553,41.260431],[20.514337,41.260693],[20.513294,41.262006],[20.512426,41.26345],[20.512078,41.264369],[20.511905,41.265288],[20.512252,41.265814],[20.512493,41.266837],[20.512426,41.26752],[20.512426,41.268308],[20.512138,41.269342],[20.512078,41.27054],[20.512078,41.271196],[20.511664,41.272205],[20.511072,41.273726],[20.510717,41.276857],[20.510599,41.277484],[20.510688,41.278023],[20.51121,41.278942],[20.512252,41.279993],[20.512773,41.280386],[20.512947,41.281043],[20.513294,41.281962],[20.513816,41.282618],[20.51451,41.283537],[20.514684,41.284719],[20.51415,41.285983],[20.514163,41.286688],[20.51451,41.287082],[20.513914,41.287504],[20.510717,41.289204],[20.509415,41.289831],[20.508777,41.291283],[20.508777,41.292596],[20.508604,41.293121],[20.507735,41.293909],[20.507214,41.295484],[20.507214,41.296797],[20.507214,41.297585],[20.508083,41.298767],[20.508777,41.299292],[20.509299,41.299423],[20.509296,41.301015],[20.509472,41.301918],[20.508256,41.302968],[20.506693,41.304149],[20.506928,41.305935],[20.50704,41.3073],[20.507047,41.308888],[20.50704,41.310451],[20.506573,41.311483],[20.504087,41.314521],[20.501246,41.317656],[20.500265,41.318985],[20.49947,41.320251],[20.498878,41.321414],[20.498701,41.322267],[20.498875,41.323711],[20.49957,41.326074],[20.499396,41.327125],[20.498701,41.327781],[20.497485,41.328438],[20.496443,41.3287],[20.495748,41.328831],[20.495053,41.328831],[20.493663,41.32975],[20.493316,41.330407],[20.4921,41.331457],[20.491419,41.33224],[20.491057,41.332901],[20.492447,41.333164],[20.493489,41.333426],[20.493837,41.334608],[20.494532,41.335264],[20.497485,41.336446],[20.498875,41.337628],[20.498875,41.338415],[20.497833,41.339072],[20.497311,41.339597],[20.496964,41.341829],[20.497102,41.343066],[20.496964,41.343929],[20.497659,41.345374],[20.498759,41.346376],[20.500091,41.346555],[20.502311,41.346734],[20.503732,41.346019],[20.505824,41.34498],[20.506345,41.344455],[20.507388,41.343798],[20.508256,41.343273],[20.50982,41.342485],[20.511383,41.341697],[20.511905,41.340778],[20.513121,41.339597],[20.515553,41.337365],[20.516248,41.336709],[20.51729,41.336709],[20.520591,41.338284],[20.521846,41.34074],[20.524569,41.34244],[20.525753,41.343066],[20.526582,41.343961],[20.5267,41.346108],[20.526498,41.347212],[20.527366,41.348262],[20.526937,41.353892],[20.52895,41.354966],[20.532146,41.356576],[20.533099,41.357189],[20.535224,41.35756],[20.536764,41.358276],[20.537269,41.35929],[20.537442,41.360472],[20.536747,41.361522],[20.536574,41.362441],[20.536574,41.362966],[20.537829,41.364181],[20.540222,41.366248],[20.540396,41.366642],[20.540396,41.367824],[20.540743,41.368349],[20.543512,41.369371],[20.544565,41.370318],[20.545406,41.372234],[20.546824,41.372813],[20.548387,41.373206],[20.551167,41.376357],[20.551688,41.377801],[20.551688,41.379114],[20.550971,41.379928],[20.548366,41.381718],[20.546476,41.383053],[20.545608,41.384234],[20.545781,41.384891],[20.54665,41.385416],[20.54804,41.385679],[20.549082,41.386335],[20.550298,41.388436],[20.550124,41.389617],[20.549951,41.390668],[20.551167,41.391455],[20.551688,41.392768],[20.552209,41.393425],[20.552383,41.394737],[20.552035,41.39605],[20.552209,41.396707],[20.553078,41.398413],[20.554989,41.400777],[20.555684,41.401039],[20.556552,41.401433],[20.557768,41.401564],[20.559022,41.401938],[20.561153,41.402833],[20.560201,41.407341],[20.560027,41.408391],[20.558984,41.412592],[20.5569,41.414037],[20.557247,41.416794],[20.556031,41.417319],[20.551862,41.419682],[20.550646,41.420338],[20.548213,41.421914],[20.545086,41.423489],[20.542307,41.425196],[20.541438,41.42559],[20.538485,41.427034],[20.539353,41.428478],[20.539701,41.429135],[20.540396,41.433336],[20.540048,41.43478],[20.539527,41.43583],[20.538658,41.436355],[20.537269,41.436618],[20.536053,41.436026],[20.529897,41.436384],[20.52893,41.435699],[20.527714,41.436093],[20.527366,41.436618],[20.526845,41.436618],[20.525976,41.436749],[20.524934,41.437931],[20.523023,41.438587],[20.520765,41.438325],[20.519201,41.438062],[20.517985,41.437143],[20.516769,41.437406],[20.516074,41.437931],[20.515032,41.438325],[20.514163,41.437668],[20.513121,41.437668],[20.512252,41.440163],[20.511557,41.44095],[20.509651,41.442289],[20.508951,41.442788],[20.508083,41.444101],[20.508083,41.445677],[20.50843,41.446596],[20.509178,41.447389],[20.510167,41.447909],[20.511383,41.448959],[20.511905,41.449747],[20.512252,41.450666],[20.511557,41.451585],[20.510862,41.452372],[20.510862,41.453423],[20.510341,41.453817],[20.509472,41.454473],[20.50843,41.455129],[20.507735,41.456967],[20.507735,41.457755],[20.506866,41.459068],[20.506172,41.46025],[20.505477,41.461563],[20.504955,41.462875],[20.504608,41.463532],[20.504608,41.464057],[20.503913,41.465239],[20.503566,41.466289],[20.50235,41.467339],[20.502176,41.468258],[20.502523,41.468915],[20.50235,41.470096],[20.50235,41.471146],[20.50235,41.472328],[20.503218,41.474166],[20.503044,41.475479],[20.502176,41.476267],[20.50235,41.477186],[20.501655,41.477842],[20.501481,41.478367],[20.50096,41.479155],[20.500439,41.480205],[20.500091,41.481124],[20.498878,41.48282],[20.497931,41.48443],[20.497485,41.485457],[20.496273,41.487651],[20.495922,41.488082],[20.495748,41.488739],[20.495053,41.489658],[20.494358,41.490446],[20.493663,41.491365],[20.492621,41.492021],[20.491057,41.492809],[20.489494,41.493203],[20.48793,41.493465],[20.487062,41.493597],[20.485498,41.493728],[20.484108,41.493728],[20.482371,41.494384],[20.481676,41.495828],[20.480807,41.497273],[20.479591,41.497929],[20.478896,41.498192],[20.47736,41.498135],[20.475943,41.497404],[20.475212,41.496872],[20.4739,41.496422],[20.472348,41.496241],[20.470439,41.496512],[20.469246,41.497053],[20.468888,41.497684],[20.468647,41.498585],[20.469168,41.499898],[20.469843,41.501381],[20.470559,41.502102],[20.471275,41.502463],[20.472468,41.502914],[20.472945,41.503274],[20.4739,41.504086],[20.474257,41.504627],[20.474854,41.505348],[20.475689,41.505799],[20.476405,41.50616],[20.47724,41.506971],[20.477002,41.507512],[20.476644,41.507963],[20.476167,41.508234],[20.475451,41.508324],[20.473661,41.508775],[20.473068,41.509124],[20.471633,41.509496],[20.471036,41.509766],[20.469962,41.509857],[20.46865,41.509586],[20.467456,41.509135],[20.466144,41.508775],[20.464951,41.508504],[20.463996,41.508504],[20.462803,41.508684],[20.462087,41.509135],[20.461491,41.509676],[20.460775,41.510307],[20.45982,41.510758],[20.458746,41.511119],[20.457315,41.51166],[20.455764,41.512562],[20.45457,41.513553],[20.453735,41.514635],[20.453735,41.515447],[20.453616,41.516619],[20.453377,41.517341],[20.4529,41.518062],[20.452423,41.518873],[20.452661,41.520136],[20.453377,41.521849],[20.454451,41.523562],[20.455406,41.524374],[20.45636,41.525095],[20.457076,41.525365],[20.458031,41.526087],[20.458508,41.526808],[20.459462,41.52789],[20.460059,41.528431],[20.460655,41.528702],[20.461729,41.528882],[20.46328,41.528882],[20.466144,41.528702],[20.468769,41.528972],[20.469723,41.529243],[20.471036,41.529874],[20.47199,41.531317],[20.472587,41.531767],[20.473124,41.532399],[20.472945,41.534292],[20.472348,41.535464],[20.471871,41.537177],[20.471333,41.539437],[20.470818,41.541602],[20.47032,41.541956],[20.470081,41.542497],[20.469604,41.542858],[20.469008,41.543038],[20.46853,41.543129],[20.468053,41.54367],[20.467814,41.544842],[20.467337,41.545112],[20.465428,41.545383],[20.463996,41.545653],[20.462445,41.545924],[20.461849,41.546555],[20.461849,41.547276],[20.462445,41.548719],[20.462087,41.54926],[20.46111,41.549565],[20.459582,41.549801],[20.458746,41.549801],[20.458031,41.549981],[20.457434,41.550703],[20.457076,41.551244],[20.456778,41.552236],[20.456838,41.553183],[20.457911,41.553949],[20.459701,41.555031],[20.460536,41.555391],[20.461371,41.555662],[20.461968,41.555932],[20.463042,41.556383],[20.463833,41.556544],[20.465017,41.55717],[20.466502,41.557736],[20.467576,41.558096],[20.468292,41.558187],[20.469127,41.558457],[20.47032,41.558998],[20.471275,41.558998],[20.47211,41.558908],[20.473064,41.559088],[20.4739,41.558908],[20.474854,41.558547],[20.476264,41.558512],[20.478553,41.558908],[20.480223,41.558728],[20.481947,41.558691],[20.484552,41.559139],[20.485354,41.559088],[20.486666,41.558367],[20.488098,41.558006],[20.490007,41.559088],[20.492632,41.56026],[20.49466,41.561162],[20.496808,41.561703],[20.498837,41.561974],[20.501461,41.562244],[20.503848,41.562785],[20.504444,41.562966],[20.507308,41.564138],[20.508501,41.564318],[20.512558,41.563777],[20.514506,41.563433],[20.5164,41.563344],[20.518166,41.563326],[20.520552,41.564679],[20.522103,41.56558],[20.523535,41.56558],[20.524609,41.56558],[20.526518,41.567294],[20.527114,41.567925],[20.528427,41.569187],[20.529978,41.570179],[20.532006,41.57099],[20.534512,41.572253],[20.537614,41.574507],[20.541194,41.576761],[20.542029,41.577753],[20.542864,41.578204],[20.543699,41.578294],[20.544176,41.577933],[20.54517,41.577838],[20.546709,41.577928],[20.548233,41.578655],[20.550262,41.580007],[20.550739,41.580548],[20.552171,41.580638],[20.553722,41.580909],[20.556585,41.58172],[20.557659,41.582171],[20.557301,41.582802],[20.556943,41.583343],[20.556585,41.584516],[20.556705,41.585327],[20.556705,41.586409],[20.556347,41.587491],[20.556108,41.588663],[20.555989,41.590016],[20.55575,41.591008],[20.555631,41.59236],[20.555273,41.592991],[20.55396,41.594254],[20.553244,41.595426],[20.552887,41.596328],[20.553125,41.597861],[20.553364,41.598311],[20.554796,41.600385],[20.554915,41.600836],[20.554796,41.601648],[20.554438,41.602369],[20.552648,41.604082],[20.551932,41.604533],[20.551335,41.604984],[20.55062,41.605525],[20.549784,41.605976],[20.549307,41.606246],[20.547995,41.606877],[20.547637,41.607599],[20.547279,41.60841],[20.546921,41.609853],[20.547159,41.612648],[20.54704,41.614091],[20.546682,41.614992],[20.546086,41.615533],[20.54525,41.616345],[20.544773,41.616886],[20.544176,41.617788],[20.543461,41.618329],[20.542864,41.618599],[20.542446,41.619231],[20.542267,41.619862],[20.541015,41.620538],[20.542267,41.621124],[20.543461,41.621485],[20.543699,41.622026],[20.543699,41.622747],[20.543222,41.623017],[20.542387,41.623378],[20.541671,41.623919],[20.539404,41.626534],[20.538091,41.628337],[20.535944,41.630141],[20.535705,41.630772],[20.535228,41.631133],[20.533557,41.632215],[20.53141,41.633387],[20.529381,41.634018],[20.527472,41.634559],[20.52604,41.63492],[20.525205,41.6351],[20.524489,41.636182],[20.524489,41.636903],[20.525086,41.637625],[20.526398,41.639248],[20.527234,41.64051],[20.527234,41.642674],[20.527353,41.644658],[20.527234,41.64601],[20.527472,41.646912],[20.527114,41.647543],[20.526398,41.648805],[20.525981,41.649798],[20.526518,41.650969],[20.5267,41.65192],[20.526463,41.652278],[20.524012,41.654576],[20.523535,41.654847],[20.521149,41.656921],[20.520671,41.657371],[20.520075,41.658363],[20.517927,41.660257],[20.516972,41.661429],[20.516615,41.661699],[20.516615,41.662331],[20.517569,41.663322],[20.518524,41.664585],[20.519597,41.665396],[20.520433,41.666839],[20.521626,41.669454],[20.522103,41.670265],[20.523296,41.671618],[20.523535,41.672339],[20.523773,41.67297],[20.524332,41.67393],[20.525043,41.675451],[20.525753,41.676704],[20.525921,41.677659],[20.52616,41.679282],[20.527114,41.682438],[20.528665,41.685684],[20.529501,41.688028],[20.52962,41.689561],[20.529381,41.689922],[20.52795,41.690643],[20.527592,41.692537],[20.527711,41.694521],[20.527711,41.695242],[20.528069,41.696324],[20.527711,41.697496],[20.527711,41.698668],[20.527234,41.700021],[20.527234,41.701373],[20.527472,41.702816],[20.527472,41.704169],[20.526821,41.705903],[20.526518,41.706513],[20.524847,41.707595],[20.5227,41.709669],[20.521864,41.711292],[20.52091,41.712735],[20.520075,41.713546],[20.518046,41.714989],[20.516972,41.716071],[20.516495,41.717694],[20.516137,41.719677],[20.515779,41.720489],[20.515541,41.721481],[20.514467,41.722292],[20.51399,41.722833],[20.514228,41.723374],[20.514348,41.724096],[20.514944,41.724997],[20.514586,41.725629],[20.514467,41.726711],[20.514586,41.728875],[20.514944,41.731039],[20.515063,41.73185],[20.515183,41.732481],[20.516376,41.733293],[20.51745,41.733744],[20.518882,41.734736],[20.518882,41.735998],[20.518882,41.73708],[20.519001,41.739064],[20.519239,41.740236],[20.519478,41.741228],[20.519478,41.74231],[20.519001,41.743301],[20.518762,41.744564],[20.518882,41.746097],[20.51912,41.7479],[20.519597,41.748982],[20.519478,41.749884],[20.519239,41.750515],[20.519478,41.751236],[20.520075,41.751777],[20.521864,41.752769],[20.523177,41.754031],[20.524131,41.755204],[20.524847,41.757638],[20.525444,41.759351],[20.526756,41.761245],[20.528069,41.762958],[20.529381,41.764761],[20.530694,41.766745],[20.53141,41.767557],[20.533557,41.768368],[20.534512,41.768999],[20.535347,41.770442],[20.535824,41.772065],[20.535824,41.773057],[20.53487,41.773868],[20.53262,41.775346],[20.532126,41.776123],[20.532126,41.776754],[20.53308,41.777565],[20.535343,41.778433],[20.538211,41.779369],[20.540552,41.779596],[20.542802,41.779506],[20.543699,41.77991],[20.544534,41.78027],[20.545489,41.781443],[20.546324,41.782525],[20.547279,41.784779],[20.547159,41.787213],[20.546443,41.790099],[20.549784,41.789738],[20.553602,41.789107],[20.557301,41.788295],[20.561597,41.787123],[20.563386,41.786492],[20.565653,41.785951],[20.56804,41.785951],[20.569113,41.786221],[20.570784,41.787213],[20.571738,41.788385],[20.572335,41.789107],[20.572574,41.790549],[20.572812,41.791902],[20.572163,41.793553],[20.572282,41.794895],[20.572574,41.795599],[20.573647,41.797042],[20.573702,41.797937],[20.571738,41.799115],[20.571022,41.799566],[20.570545,41.799837],[20.56971,41.801279],[20.568848,41.804021],[20.568636,41.805878],[20.568375,41.808763],[20.567682,41.813452],[20.567443,41.815346],[20.567204,41.816428],[20.566599,41.817531],[20.565415,41.819321],[20.563983,41.820846],[20.561239,41.822559],[20.560403,41.82319],[20.559568,41.824002],[20.559807,41.825354],[20.560642,41.826617],[20.561477,41.829682],[20.561716,41.831756],[20.561597,41.835092],[20.561477,41.836174],[20.561716,41.836986],[20.56281,41.838736],[20.563386,41.840683],[20.563625,41.843208],[20.563267,41.845913],[20.562193,41.84988],[20.560797,41.854215],[20.560087,41.858599],[20.559732,41.861551],[20.559449,41.863495],[20.559449,41.864758],[20.560679,41.868351],[20.561271,41.869067],[20.563864,41.869356],[20.56625,41.870258],[20.568278,41.87116],[20.569471,41.871971],[20.570187,41.873143],[20.571261,41.874225],[20.573702,41.874972],[20.576189,41.87524],[20.580806,41.875688],[20.586653,41.875668],[20.588801,41.875939],[20.59059,41.876119],[20.592595,41.876729],[20.594286,41.877328],[20.595498,41.876498],[20.596918,41.874679],[20.604113,41.86781],[20.614341,41.860423],[20.619247,41.85779],[20.621271,41.857759],[20.626132,41.860092],[20.632018,41.861113],[20.636405,41.863531],[20.640047,41.867188],[20.648426,41.874532],[20.663353,41.875274],[20.670554,41.873412],[20.67848,41.86853],[20.680439,41.863216],[20.681196,41.861449],[20.681272,41.859588],[20.682007,41.85948],[20.682283,41.858614],[20.682822,41.857886],[20.683482,41.857728],[20.684867,41.857641],[20.686769,41.858739],[20.689175,41.859352],[20.690157,41.859435],[20.691567,41.859976],[20.693181,41.860019],[20.694901,41.860851],[20.696489,41.861315],[20.697895,41.862468],[20.700824,41.862894],[20.701927,41.863765],[20.70361,41.863541],[20.705931,41.864659],[20.717191,41.864417],[20.727972,41.864277],[20.735815,41.877156],[20.736036,41.878017],[20.73607,41.878594],[20.736391,41.87911],[20.736574,41.879766],[20.736744,41.880622],[20.736848,41.881757],[20.736728,41.882335],[20.736373,41.883292],[20.736732,41.883928],[20.736831,41.884655],[20.736559,41.885012],[20.736634,41.885478],[20.736679,41.885912],[20.736351,41.886396],[20.736557,41.886757],[20.73686,41.887112],[20.737482,41.888159],[20.737733,41.88855],[20.738074,41.889362],[20.738834,41.890466],[20.739197,41.890881],[20.739465,41.891383],[20.739816,41.891751],[20.740466,41.892799],[20.741131,41.893456],[20.742592,41.893449],[20.743992,41.89374],[20.746578,41.894569],[20.749706,41.894863],[20.75149,41.896491],[20.751678,41.897318],[20.751792,41.898238],[20.752542,41.899063],[20.752653,41.899575],[20.752642,41.900119],[20.752871,41.900603],[20.753253,41.900993],[20.753578,41.90159],[20.753912,41.902803],[20.75416,41.903838],[20.754671,41.904497],[20.754833,41.904888],[20.755432,41.905389],[20.755637,41.905894],[20.756019,41.906228],[20.756779,41.906386],[20.757362,41.906676],[20.758349,41.907384],[20.759306,41.908298],[20.76081,41.909307],[20.762374,41.910161],[20.763579,41.910972],[20.764787,41.911509],[20.766748,41.912233],[20.768139,41.913814],[20.768814,41.9144],[20.769524,41.914887],[20.769726,41.915334],[20.770425,41.91562],[20.771373,41.916143],[20.772112,41.916358],[20.772786,41.916549],[20.774224,41.917369],[20.775222,41.917742],[20.776524,41.918485],[20.775889,41.918849],[20.775577,41.919348],[20.772157,41.921073],[20.770593,41.924497],[20.770185,41.925516],[20.771041,41.925886],[20.772742,41.926313],[20.772944,41.926758],[20.771541,41.927194],[20.770646,41.927643],[20.770224,41.927944],[20.769692,41.9289],[20.768829,41.929123],[20.768341,41.930004],[20.768054,41.930321],[20.767612,41.931015],[20.76736,41.931707],[20.766856,41.932439],[20.766646,41.933001],[20.765849,41.933878],[20.765134,41.934813],[20.764529,41.93508],[20.763525,41.935762],[20.76328,41.936156],[20.763023,41.936784],[20.762675,41.937428],[20.762352,41.937963],[20.762394,41.938898],[20.761705,41.939516],[20.761092,41.940114],[20.76061,41.940362],[20.76021,41.940684],[20.759583,41.941305],[20.758758,41.941953],[20.758353,41.942441],[20.758192,41.943229],[20.757262,41.943948],[20.757123,41.944694],[20.755742,41.945659],[20.754785,41.946846],[20.755764,41.947464],[20.756832,41.94827],[20.757467,41.948857],[20.757457,41.949168],[20.757903,41.950084],[20.758864,41.950578],[20.759059,41.951067],[20.759608,41.951168],[20.761215,41.951936],[20.763253,41.952512],[20.764228,41.952923],[20.765232,41.953225],[20.766032,41.953625],[20.766188,41.954552],[20.766405,41.954902],[20.766411,41.955482],[20.766541,41.956241],[20.766561,41.957578],[20.766635,41.958032],[20.766933,41.958718],[20.767207,41.959715],[20.767208,41.960274],[20.767162,41.960904],[20.767009,41.961655],[20.767132,41.962188],[20.767117,41.962759],[20.766455,41.963023],[20.766082,41.963254],[20.764785,41.964461],[20.76377,41.96631],[20.763736,41.966954],[20.763537,41.967587],[20.762622,41.969023],[20.762374,41.969363],[20.761707,41.969972],[20.760958,41.970548],[20.760477,41.970817],[20.760189,41.971171],[20.760015,41.971603],[20.758509,41.973656],[20.757889,41.974893],[20.75772,41.975602],[20.757132,41.976339],[20.756433,41.976997],[20.755985,41.977301],[20.755262,41.978509],[20.754197,41.979681],[20.753577,41.980129],[20.752628,41.980627],[20.750982,41.981186],[20.750405,41.981567],[20.749895,41.981755],[20.7496,41.982244],[20.748761,41.982377],[20.749243,41.982676],[20.749382,41.983099],[20.749313,41.983546],[20.748884,41.984139],[20.748171,41.985954],[20.748157,41.986594],[20.748207,41.988273],[20.748328,41.989234],[20.748329,41.990135],[20.748072,41.991457],[20.748311,41.993215],[20.748262,41.995418],[20.748685,41.996756],[20.749253,41.997712],[20.749211,41.998169],[20.74931,41.99881],[20.749585,41.999814],[20.7496,42.000268],[20.749451,42.000931],[20.749107,42.001267],[20.749421,42.0017],[20.749636,42.003304],[20.750115,42.004533],[20.749981,42.006416],[20.750099,42.007271],[20.750708,42.009013],[20.751035,42.010518],[20.751267,42.012519],[20.751662,42.013865],[20.751832,42.014706],[20.751899,42.01528],[20.751444,42.015282],[20.750897,42.015494],[20.750652,42.015887],[20.750756,42.016399],[20.750511,42.016782],[20.75058,42.017186],[20.750525,42.017974],[20.750561,42.018706],[20.74986,42.019096],[20.749467,42.019468],[20.749378,42.020358],[20.749511,42.021055],[20.749901,42.021526],[20.749647,42.0219],[20.749662,42.022358],[20.749554,42.02299],[20.749432,42.023611],[20.749078,42.023901],[20.748331,42.024324],[20.748142,42.024829],[20.748154,42.025705],[20.748371,42.026662],[20.748751,42.027008],[20.749936,42.027804],[20.751128,42.028418],[20.75133,42.028833],[20.751677,42.029189],[20.752851,42.029764],[20.753254,42.030232],[20.753567,42.03084],[20.753546,42.031268],[20.754283,42.032958],[20.75463,42.033339],[20.755724,42.034378],[20.757261,42.035688],[20.758023,42.036481],[20.758595,42.037226],[20.759382,42.037858],[20.759662,42.038229],[20.761113,42.038887],[20.761726,42.039653],[20.763551,42.040833],[20.763604,42.041471],[20.763913,42.042788],[20.763843,42.043692],[20.765071,42.045305],[20.763981,42.044996],[20.763405,42.044918],[20.762995,42.04498],[20.761898,42.045672],[20.760699,42.046673],[20.760117,42.047456],[20.759398,42.048147],[20.75892,42.048975],[20.758989,42.049803],[20.758906,42.050969],[20.758643,42.052291],[20.758158,42.05337],[20.758977,42.053654],[20.760129,42.053849],[20.76103,42.054547],[20.763387,42.055559],[20.763689,42.055853],[20.765131,42.056825],[20.766328,42.057292],[20.766896,42.057608],[20.768795,42.05811],[20.769291,42.058347],[20.771288,42.059602],[20.773131,42.061526],[20.776312,42.06414],[20.778624,42.064778],[20.778681,42.065425],[20.778499,42.066],[20.778461,42.066422],[20.778575,42.066828],[20.778857,42.067143],[20.780193,42.068122],[20.78244,42.070272],[20.78326,42.070912],[20.785078,42.07154],[20.785986,42.071754],[20.785522,42.072332],[20.785,42.072619],[20.784608,42.07294],[20.784356,42.073329],[20.784342,42.073759],[20.783924,42.074582],[20.78382,42.075273],[20.783939,42.075685],[20.784155,42.076666],[20.784126,42.077099],[20.784353,42.077689],[20.784447,42.078473],[20.784648,42.078892],[20.790843,42.083138],[20.792807,42.083652],[20.79407,42.083666],[20.795754,42.083441],[20.79676,42.083185],[20.797486,42.08307],[20.797929,42.082876],[20.798535,42.082954],[20.799633,42.083239],[20.80015,42.083022],[20.800417,42.082653],[20.80102,42.082153],[20.802024,42.081745],[20.802593,42.081637],[20.803182,42.081746],[20.804224,42.082134],[20.804815,42.08224],[20.807779,42.082541],[20.808368,42.082567],[20.809938,42.082294],[20.812503,42.082511],[20.81403,42.082809],[20.816628,42.083521],[20.818812,42.083821],[20.820754,42.084208],[20.82581,42.084053],[20.827156,42.084636],[20.82852,42.085473],[20.82901,42.085613],[20.829586,42.085594],[20.83013,42.085437],[20.83131,42.085436],[20.832462,42.0856],[20.834145,42.085969],[20.834501,42.086299],[20.835001,42.08708],[20.835883,42.088365],[20.835711,42.089069],[20.83593,42.089452],[20.83668,42.089751],[20.837065,42.090121],[20.837715,42.090937],[20.837886,42.091448],[20.83864,42.092012],[20.840043,42.093973],[20.840441,42.094278],[20.840477,42.094789],[20.841274,42.095983],[20.841596,42.096301],[20.841989,42.097034],[20.841664,42.097316],[20.842465,42.097916],[20.843424,42.098641],[20.844188,42.098541],[20.84477,42.098524],[20.845698,42.098597],[20.846601,42.098792],[20.848167,42.099401],[20.849558,42.09904],[20.851747,42.098661],[20.853891,42.098064],[20.855658,42.098241],[20.857488,42.098658],[20.859124,42.099082],[20.860632,42.09965],[20.861412,42.098714],[20.867315,42.098037],[20.869125,42.098065],[20.869612,42.097951],[20.87046,42.097506],[20.871143,42.097296],[20.872778,42.097251],[20.874885,42.096916],[20.875812,42.09648],[20.87668,42.096433],[20.877151,42.096208],[20.878152,42.096307],[20.879077,42.096191],[20.880387,42.096192],[20.882106,42.096739],[20.883204,42.096347],[20.883699,42.096086],[20.884235,42.096168],[20.885322,42.097015],[20.88753,42.096439],[20.88927,42.096787],[20.889988,42.097179],[20.891542,42.097442],[20.891703,42.097862],[20.892858,42.099217],[20.895199,42.100674],[20.896086,42.101477],[20.89715,42.103578],[20.89842,42.104946],[20.901878,42.106711],[20.90478,42.108455],[20.905105,42.109056],[20.905874,42.109547],[20.906411,42.110257],[20.907127,42.110958],[20.907752,42.111742],[20.908425,42.112448],[20.9093,42.112866],[20.909873,42.113393],[20.91234,42.114577],[20.913875,42.114901],[20.914487,42.115211],[20.914951,42.11666],[20.915312,42.116859],[20.915958,42.11762],[20.916611,42.118587],[20.916809,42.119201],[20.916823,42.119639],[20.916446,42.120544],[20.916334,42.121076],[20.916584,42.122392],[20.916697,42.123059],[20.918684,42.124499],[20.91921,42.124989],[20.919362,42.125527],[20.919408,42.127391],[20.920008,42.128584],[20.920842,42.127977],[20.921351,42.127747],[20.923542,42.12702],[20.924439,42.12685],[20.926221,42.126985],[20.927939,42.127327],[20.928452,42.127646],[20.929225,42.12839],[20.929622,42.128838],[20.929887,42.129369],[20.930403,42.129864],[20.931657,42.130672],[20.932253,42.130694],[20.933141,42.131083],[20.933754,42.131195],[20.934162,42.131432],[20.935209,42.132446],[20.935728,42.132671],[20.935935,42.132943],[20.937753,42.13391],[20.938495,42.134477],[20.94035,42.135648],[20.941025,42.136385],[20.941389,42.137028],[20.941919,42.137296],[20.9428,42.137434],[20.944823,42.138091],[20.945505,42.137775],[20.946066,42.137615],[20.947825,42.137411],[20.948629,42.137198],[20.951724,42.138058],[20.954255,42.137888],[20.955298,42.137137],[20.956526,42.136442],[20.95728,42.136402],[20.959981,42.136493],[20.960778,42.136293],[20.96171,42.13627],[20.96324,42.136804],[20.964396,42.136301],[20.965524,42.136205],[20.96636,42.136269],[20.967491,42.136464],[20.968219,42.136369],[20.9693,42.136473],[20.970367,42.136796],[20.970606,42.137138],[20.971757,42.137866],[20.972271,42.138524],[20.972722,42.138867],[20.973139,42.138878],[20.974669,42.138955],[20.975982,42.139229],[20.976421,42.139163],[20.977058,42.139179],[20.97839,42.139552],[20.979567,42.139764],[20.980346,42.139346],[20.981002,42.139098],[20.982079,42.139012],[20.982608,42.139063],[20.983526,42.139416],[20.983673,42.139855],[20.985037,42.141021],[20.986308,42.142226],[20.987353,42.142586],[20.988064,42.14256],[20.989565,42.143014],[20.990307,42.143281],[20.991193,42.143756],[20.991726,42.143761],[20.992545,42.143545],[20.993819,42.143785],[20.994812,42.143885],[20.995739,42.144911],[20.996807,42.145105],[20.997391,42.145193],[20.999053,42.145085],[20.999448,42.144974],[21.000606,42.145186],[21.001144,42.145307],[21.001935,42.145662],[21.002925,42.146285],[21.003827,42.146761],[21.004467,42.147208],[21.005664,42.147586],[21.006685,42.148122],[21.008798,42.15008],[21.009231,42.150506],[21.010748,42.150136],[21.013188,42.150241],[21.015269,42.150438],[21.016647,42.150464],[21.017169,42.150675],[21.019239,42.150803],[21.01981,42.151092],[21.020427,42.151516],[21.021765,42.151971],[21.0227,42.152034],[21.024656,42.151892],[21.026438,42.152253],[21.026781,42.152495],[21.026986,42.153028],[21.027449,42.153347],[21.027508,42.153686],[21.027849,42.154683],[21.028338,42.15522],[21.028148,42.155989],[21.028579,42.156342],[21.030305,42.156634],[21.031621,42.157052],[21.032006,42.157251],[21.032719,42.157744],[21.033574,42.158585],[21.033864,42.159212],[21.034961,42.159644],[21.036846,42.160794],[21.037591,42.161074],[21.041649,42.163806],[21.042288,42.164571],[21.042857,42.164912],[21.043251,42.166094],[21.043896,42.165649],[21.044739,42.165343],[21.04519,42.165277],[21.046737,42.16528],[21.048503,42.1657],[21.04884,42.166005],[21.049344,42.166253],[21.051473,42.170171],[21.051922,42.170457],[21.052297,42.17081],[21.05259,42.171207],[21.053006,42.172025],[21.053533,42.172583],[21.054464,42.17406],[21.054619,42.174443],[21.055416,42.175321],[21.056041,42.175442],[21.057091,42.175749],[21.057984,42.176562],[21.058862,42.178165],[21.060237,42.179614],[21.060436,42.180271],[21.060927,42.181023],[21.061475,42.181417],[21.062461,42.181575],[21.064259,42.182173],[21.064776,42.18241],[21.066201,42.183586],[21.066713,42.184752],[21.0673,42.185425],[21.06797,42.185837],[21.069345,42.186468],[21.07168,42.186862],[21.072545,42.187075],[21.073542,42.187064],[21.074234,42.187152],[21.0749,42.187307],[21.075603,42.187667],[21.07809,42.188457],[21.078765,42.188622],[21.080709,42.188804],[21.081442,42.189143],[21.082956,42.18961],[21.083662,42.189984],[21.084942,42.190977],[21.085739,42.191704],[21.087143,42.192318],[21.087521,42.192549],[21.088155,42.193375],[21.088476,42.193671],[21.088957,42.193653],[21.090298,42.193961],[21.091129,42.194118],[21.092374,42.195323],[21.092652,42.195978],[21.092969,42.196274],[21.093726,42.196469],[21.0944,42.197302],[21.094241,42.198243],[21.094481,42.198932],[21.094878,42.199693],[21.096612,42.200962],[21.096896,42.201456],[21.097071,42.202005],[21.097623,42.202554],[21.098251,42.202804],[21.099397,42.202925],[21.100269,42.203379],[21.100902,42.203557],[21.10146,42.204089],[21.102405,42.204493],[21.103,42.20503],[21.103283,42.205449],[21.103772,42.205887],[21.106305,42.205661],[21.10894,42.206171],[21.109525,42.206165],[21.110642,42.205846],[21.111295,42.205882],[21.111836,42.205827],[21.113722,42.20609],[21.114584,42.206382],[21.115092,42.206387],[21.116248,42.206598],[21.117019,42.206584],[21.119157,42.206679],[21.119563,42.206159],[21.119886,42.205616],[21.120447,42.204875],[21.121271,42.203987],[21.124031,42.202712],[21.125197,42.202278],[21.129241,42.201897],[21.130971,42.201868],[21.134847,42.201381],[21.135996,42.201061],[21.138533,42.200576],[21.14022,42.200039],[21.145496,42.199706],[21.149282,42.199088],[21.150199,42.198829],[21.15403,42.198046],[21.154864,42.197684],[21.15629,42.197663],[21.158097,42.198121],[21.160041,42.197577],[21.160607,42.19752],[21.161753,42.197084],[21.162838,42.196191],[21.16317,42.195549],[21.163694,42.194934],[21.164831,42.193221],[21.165456,42.192793],[21.165934,42.192304],[21.166527,42.191974],[21.166849,42.191499],[21.167343,42.190889],[21.167952,42.191018],[21.168296,42.190209],[21.167786,42.18988],[21.168252,42.189179],[21.168988,42.188499],[21.169884,42.188268],[21.169975,42.187875],[21.170216,42.187332],[21.17117,42.18681],[21.170895,42.186641],[21.171134,42.185918],[21.170411,42.185821],[21.170189,42.18625],[21.169595,42.185938],[21.169233,42.185339],[21.16948,42.18453],[21.169759,42.184024],[21.170114,42.183707],[21.170083,42.182937],[21.170569,42.182512],[21.170834,42.182178],[21.171487,42.180983],[21.171893,42.180452],[21.172364,42.180109],[21.173108,42.180322],[21.174027,42.179608],[21.173479,42.179207],[21.174408,42.178018],[21.174738,42.177749],[21.175128,42.17687],[21.176099,42.175344],[21.176458,42.174617],[21.176754,42.17369],[21.176492,42.173261],[21.17732,42.173003],[21.177932,42.172807],[21.178426,42.171809],[21.178351,42.171289],[21.178874,42.170791],[21.178601,42.170241],[21.178964,42.169552],[21.179454,42.168582],[21.179897,42.168423],[21.180216,42.167905],[21.18037,42.167374],[21.180598,42.166749],[21.18114,42.166394],[21.181931,42.166191],[21.182836,42.166129],[21.183705,42.16561],[21.184437,42.165556],[21.18519,42.165149],[21.18593,42.164444],[21.186576,42.163988],[21.185478,42.163527],[21.18444,42.163454],[21.184523,42.163001],[21.185463,42.163001],[21.186174,42.16338],[21.186588,42.162814],[21.186206,42.162308],[21.186837,42.161821],[21.18726,42.161675],[21.188042,42.161249],[21.188482,42.160789],[21.189564,42.160272],[21.190427,42.160028],[21.190969,42.15972],[21.191478,42.159146],[21.191682,42.158587],[21.191481,42.157938],[21.191596,42.157297],[21.191625,42.156691],[21.191829,42.156383],[21.192065,42.156082],[21.192156,42.15554],[21.192661,42.155115],[21.193875,42.154787],[21.194186,42.15424],[21.195022,42.154106],[21.194924,42.153509],[21.195365,42.152229],[21.196288,42.151744],[21.196976,42.151352],[21.197566,42.151021],[21.19822,42.151012],[21.199319,42.150763],[21.199931,42.151068],[21.199613,42.150174],[21.199665,42.149681],[21.199971,42.149075],[21.199868,42.148628],[21.199998,42.147869],[21.200738,42.147814],[21.201748,42.147318],[21.202188,42.147434],[21.202641,42.147777],[21.203025,42.147495],[21.203152,42.14693],[21.203053,42.145669],[21.203402,42.144812],[21.204036,42.144732],[21.20495,42.145066],[21.205443,42.14442],[21.205772,42.143932],[21.205514,42.143207],[21.205894,42.142047],[21.20646,42.141678],[21.207657,42.141307],[21.208583,42.1407],[21.208493,42.140038],[21.208071,42.138993],[21.208062,42.138425],[21.208928,42.137817],[21.208846,42.137327],[21.209661,42.136906],[21.210393,42.136885],[21.210842,42.136635],[21.211024,42.136086],[21.210862,42.13569],[21.210576,42.135169],[21.212148,42.134535],[21.212423,42.134979],[21.212771,42.134887],[21.213271,42.134459],[21.213693,42.133228],[21.214392,42.132892],[21.214628,42.131985],[21.214524,42.131374],[21.214937,42.131104],[21.215174,42.130702],[21.215211,42.129985],[21.215922,42.129785],[21.216422,42.128822],[21.215857,42.12851],[21.215324,42.127902],[21.215808,42.127149],[21.21587,42.126544],[21.216415,42.12597],[21.216134,42.125054],[21.216303,42.124425],[21.216921,42.124035],[21.216717,42.123598],[21.216153,42.123058],[21.216141,42.122544],[21.215771,42.121918],[21.216026,42.121284],[21.215954,42.119941],[21.215444,42.119335],[21.215268,42.118843],[21.215495,42.118147],[21.215039,42.117457],[21.215097,42.116387],[21.214568,42.115926],[21.21494,42.115379],[21.215045,42.114674],[21.215213,42.114164],[21.214496,42.113506],[21.214674,42.113032],[21.214339,42.112411],[21.213302,42.11182],[21.213084,42.111397],[21.212617,42.111053],[21.213176,42.109789],[21.213874,42.109123],[21.214357,42.108418],[21.214191,42.107781],[21.214558,42.107426],[21.215011,42.107336],[21.215315,42.106776],[21.2152,42.106384],[21.21574,42.105945],[21.216354,42.105376],[21.216582,42.104763],[21.216525,42.104252],[21.217377,42.103504],[21.218054,42.103307],[21.219057,42.102164],[21.22018,42.102167],[21.220418,42.101904],[21.220257,42.101438],[21.220283,42.100799],[21.221134,42.100409],[21.221635,42.099722],[21.221603,42.098818],[21.222066,42.097418],[21.22139,42.09622],[21.222189,42.095131],[21.222253,42.094612],[21.222165,42.094074],[21.222473,42.093631],[21.22297,42.093673],[21.223172,42.094303],[21.223461,42.09491],[21.224436,42.095574],[21.22488,42.095463],[21.22569,42.095385],[21.226099,42.095731],[21.226986,42.096052],[21.227245,42.0967],[21.227562,42.097104],[21.228002,42.097142],[21.228403,42.096762],[21.228842,42.096637],[21.229209,42.09677],[21.229204,42.096333],[21.229792,42.096113],[21.229811,42.096442],[21.229959,42.096874],[21.230478,42.097366],[21.230901,42.097549],[21.231477,42.097631],[21.231993,42.098043],[21.233526,42.098227],[21.233624,42.097866],[21.233499,42.097448],[21.233532,42.096623],[21.233415,42.095443],[21.23525,42.095182],[21.237445,42.094689],[21.239135,42.093892],[21.239677,42.093822],[21.240409,42.094026],[21.241883,42.093592],[21.243161,42.093478],[21.244266,42.093654],[21.244784,42.093565],[21.245167,42.093147],[21.245796,42.092674],[21.250913,42.092297],[21.251862,42.092397],[21.253219,42.092764],[21.256101,42.093096],[21.256879,42.092786],[21.25752,42.093912],[21.265854,42.094315],[21.268358,42.094677],[21.272441,42.095907],[21.273579,42.096559],[21.274017,42.096967],[21.274506,42.097688],[21.275433,42.097881],[21.275639,42.098465],[21.276148,42.098828],[21.278017,42.099779],[21.278558,42.100204],[21.278533,42.10062],[21.279004,42.101015],[21.279561,42.10073],[21.280676,42.100795],[21.280928,42.101284],[21.28128,42.102057],[21.282043,42.101647],[21.283372,42.10129],[21.288785,42.104226],[21.289218,42.104552],[21.291348,42.105095],[21.291021,42.105389],[21.291732,42.105533],[21.292332,42.105787],[21.2929,42.106373],[21.292458,42.106566],[21.292061,42.107112],[21.292479,42.107554],[21.293167,42.108013],[21.292551,42.108624],[21.293436,42.109253],[21.293787,42.108873],[21.294057,42.10924],[21.294174,42.109774],[21.294691,42.109768],[21.294704,42.110091],[21.295344,42.110599],[21.294935,42.111156],[21.294744,42.111538],[21.294665,42.111959],[21.297455,42.112408],[21.298162,42.111869],[21.29837,42.110866],[21.298883,42.111025],[21.29936,42.110927],[21.299244,42.110032],[21.299652,42.109459],[21.300271,42.108513],[21.301214,42.107675],[21.301508,42.107124],[21.302396,42.106261],[21.303078,42.106225],[21.303428,42.105981],[21.303333,42.105459],[21.303498,42.104675],[21.304872,42.104987],[21.306072,42.10552],[21.3066,42.105454],[21.306942,42.105573],[21.307493,42.105783],[21.308073,42.105806],[21.308709,42.106138],[21.31502,42.106918],[21.315695,42.107205],[21.317196,42.107533],[21.318298,42.107228],[21.318726,42.10737],[21.319235,42.10737],[21.31969,42.107568],[21.320271,42.107669],[21.321257,42.108],[21.320532,42.108513],[21.320188,42.108843],[21.31975,42.109979],[21.319445,42.110527],[21.318632,42.111554],[21.317529,42.112472],[21.316802,42.112927],[21.315925,42.113586],[21.31509,42.114566],[21.314798,42.115135],[21.3147,42.115597],[21.315504,42.116588],[21.316081,42.116991],[21.316655,42.117523],[21.315839,42.119185],[21.315235,42.119995],[21.314198,42.120691],[21.31397,42.120907],[21.312884,42.120642],[21.312132,42.121097],[21.311661,42.122131],[21.311558,42.124721],[21.311148,42.125281],[21.310492,42.125819],[21.310624,42.127088],[21.310441,42.127802],[21.309894,42.128298],[21.308799,42.129023],[21.308769,42.129473],[21.308523,42.130061],[21.30796,42.130338],[21.30724,42.130328],[21.306316,42.130807],[21.30569,42.13162],[21.305232,42.132091],[21.305485,42.132716],[21.304792,42.133225],[21.30463,42.13361],[21.30659,42.134003],[21.305349,42.136174],[21.304534,42.136921],[21.302344,42.138518],[21.302562,42.139145],[21.30358,42.139902],[21.302665,42.14073],[21.302523,42.14139],[21.303088,42.141687],[21.303825,42.14201],[21.304413,42.142179],[21.304759,42.142595],[21.305556,42.142819],[21.306232,42.143276],[21.306986,42.143531],[21.307641,42.143522],[21.308259,42.143643],[21.309306,42.144065],[21.309644,42.144595],[21.30993,42.14483],[21.310508,42.144833],[21.310893,42.146074],[21.310267,42.146189],[21.310468,42.1468],[21.310242,42.148193],[21.310389,42.14885],[21.311897,42.150165],[21.312193,42.150991],[21.314509,42.152811],[21.31593,42.154232],[21.316221,42.154872],[21.316368,42.156126],[21.316643,42.156662],[21.31668,42.157156],[21.318814,42.158825],[21.319271,42.159262],[21.320479,42.159777],[21.320656,42.160409],[21.320989,42.160765],[21.321218,42.161419],[21.320613,42.162654],[21.319908,42.163173],[21.318894,42.164151],[21.318573,42.1648],[21.31822,42.166034],[21.318083,42.167089],[21.317638,42.167642],[21.317786,42.168876],[21.317632,42.169586],[21.317339,42.170045],[21.318521,42.170089],[21.318759,42.17051],[21.319735,42.170845],[21.320424,42.171143],[21.320173,42.171557],[21.31953,42.171874],[21.319117,42.172337],[21.318199,42.172915],[21.319143,42.173005],[21.320519,42.173848],[21.321656,42.173836],[21.3223,42.174096],[21.322586,42.174504],[21.322686,42.175154],[21.322876,42.175439],[21.324195,42.175799],[21.324629,42.175687],[21.324976,42.175441],[21.325369,42.17575],[21.326247,42.17627],[21.326853,42.176141],[21.326535,42.176918],[21.327497,42.177795],[21.327911,42.178389],[21.328656,42.178955],[21.328698,42.179433],[21.328115,42.180166],[21.328389,42.180643],[21.328529,42.181107],[21.329085,42.181451],[21.329151,42.182194],[21.329401,42.183188],[21.329842,42.183603],[21.331112,42.183851],[21.331268,42.184183],[21.332022,42.184937],[21.33225,42.185467],[21.332293,42.186173],[21.332327,42.186853],[21.332487,42.187235],[21.333058,42.187486],[21.334161,42.188249],[21.334414,42.189159],[21.334767,42.189637],[21.335202,42.190324],[21.335369,42.191157],[21.335283,42.192584],[21.334683,42.193388],[21.333666,42.194068],[21.333414,42.194414],[21.332685,42.195059],[21.332505,42.195646],[21.331738,42.196778],[21.331749,42.197389],[21.331337,42.198274],[21.331062,42.199071],[21.33122,42.199561],[21.331184,42.200154],[21.331421,42.200494],[21.331603,42.201109],[21.33201,42.201901],[21.333034,42.203157],[21.333743,42.203759],[21.333781,42.204319],[21.333933,42.204824],[21.334351,42.205002],[21.335026,42.205098],[21.335706,42.205064],[21.33576,42.205827],[21.335067,42.206608],[21.335078,42.207328],[21.336301,42.207025],[21.336718,42.206725],[21.336755,42.206317],[21.337323,42.20565],[21.337394,42.205043],[21.337816,42.204515],[21.337921,42.204041],[21.338337,42.20368],[21.338886,42.203672],[21.340446,42.204736],[21.341353,42.205055],[21.341852,42.205046],[21.342486,42.204847],[21.343253,42.204818],[21.344141,42.204649],[21.344826,42.204599],[21.345803,42.204795],[21.345814,42.205641],[21.345718,42.206363],[21.346097,42.207335],[21.347008,42.207977],[21.348077,42.208313],[21.349034,42.208913],[21.350885,42.210623],[21.351202,42.211351],[21.351146,42.212187],[21.351372,42.212618],[21.351437,42.213137],[21.351654,42.213524],[21.352464,42.214299],[21.352462,42.214612],[21.352616,42.214883],[21.353245,42.215228],[21.354642,42.215276],[21.355775,42.21522],[21.3562,42.215184],[21.356156,42.215789],[21.356564,42.216465],[21.35657,42.217565],[21.357165,42.217958],[21.357132,42.218989],[21.357714,42.219608],[21.357798,42.220257],[21.358379,42.220769],[21.358958,42.221121],[21.359922,42.221542],[21.36037,42.222063],[21.361389,42.222166],[21.362114,42.221879],[21.363331,42.22185],[21.363624,42.221742],[21.364808,42.221699],[21.365162,42.221815],[21.365721,42.221647],[21.366105,42.221401],[21.366741,42.221167],[21.36753,42.221669],[21.367852,42.222561],[21.368229,42.223109],[21.36864,42.223129],[21.369068,42.223356],[21.370194,42.223598],[21.3709,42.223967],[21.371287,42.224254],[21.371567,42.224953],[21.371839,42.225535],[21.37163,42.22607],[21.371075,42.226605],[21.370082,42.227036],[21.369681,42.227288],[21.370414,42.227841],[21.37091,42.228008],[21.371491,42.22838],[21.372235,42.228941],[21.372529,42.229563],[21.372716,42.230033],[21.373115,42.230433],[21.374176,42.23076],[21.37491,42.230985],[21.374915,42.231517],[21.374673,42.231895],[21.37438,42.232185],[21.374366,42.232648],[21.374162,42.233138],[21.374159,42.233662],[21.374517,42.234109],[21.374756,42.234683],[21.374863,42.235157],[21.375285,42.235756],[21.376057,42.236389],[21.37687,42.237058],[21.377228,42.237409],[21.37717,42.237926],[21.377526,42.237894],[21.378466,42.237542],[21.379095,42.237434],[21.379727,42.237157],[21.380805,42.237888],[21.381287,42.238638],[21.381421,42.238993],[21.381997,42.238975],[21.383037,42.239722],[21.383654,42.239993],[21.384374,42.240103],[21.384223,42.240562],[21.384763,42.240927],[21.385182,42.241162],[21.385667,42.241496],[21.385106,42.24175],[21.384321,42.24193],[21.383986,42.242362],[21.383618,42.242995],[21.382944,42.243041],[21.382852,42.243344],[21.38233,42.243994],[21.382275,42.244751],[21.38302,42.245171],[21.383162,42.245575],[21.383675,42.245526],[21.38422,42.245273],[21.384553,42.24585],[21.385102,42.24648],[21.385792,42.246542],[21.386391,42.246686],[21.387545,42.245883],[21.388336,42.245312],[21.390818,42.245558],[21.390707,42.24595],[21.390969,42.246421],[21.392605,42.246772],[21.396024,42.247654],[21.39646,42.247691],[21.397354,42.247532],[21.397462,42.248021],[21.397698,42.248301],[21.398124,42.248703],[21.398788,42.249073],[21.399251,42.249191],[21.400197,42.249192],[21.400749,42.249116],[21.401293,42.249157],[21.402132,42.248861],[21.402886,42.248434],[21.403368,42.247819],[21.403261,42.247497],[21.403501,42.246955],[21.403854,42.246799],[21.405249,42.246768],[21.40635,42.247164],[21.406955,42.247332],[21.408394,42.246931],[21.409323,42.247071],[21.410509,42.246337],[21.410878,42.245934],[21.411176,42.244891],[21.411594,42.244501],[21.412268,42.244389],[21.413822,42.243922],[21.414689,42.243857],[21.415423,42.243938],[21.416027,42.244189],[21.415905,42.24469],[21.415908,42.245188],[21.416778,42.245922],[21.417241,42.245617],[21.418016,42.244826],[21.418551,42.245038],[21.419965,42.244049],[21.420147,42.243639],[21.419331,42.243415],[21.419544,42.242559],[21.419833,42.24226],[21.420258,42.242377],[21.421164,42.242466],[21.421976,42.242387],[21.421777,42.241387]]],"type":"Polygon"}
+  ],
+  "geometry": {"coordinates":[[[21.421777,42.241387],[21.420279,42.241454],[21.420315,42.241034],[21.421748,42.241072],[21.422452,42.240767],[21.422973,42.240392],[21.424367,42.239796],[21.424825,42.239233],[21.425492,42.238289],[21.426079,42.238067],[21.426208,42.237357],[21.426978,42.236201],[21.42801,42.236508],[21.428533,42.23674],[21.429071,42.236803],[21.429773,42.236668],[21.430096,42.236122],[21.429996,42.235511],[21.430538,42.234719],[21.430923,42.234073],[21.432564,42.232339],[21.433041,42.232325],[21.433941,42.231691],[21.434312,42.23201],[21.435478,42.232455],[21.435537,42.233107],[21.436563,42.232587],[21.437597,42.233738],[21.438884,42.233484],[21.439248,42.233992],[21.439956,42.233821],[21.440313,42.234176],[21.442518,42.235052],[21.443122,42.234866],[21.444318,42.234931],[21.443442,42.236672],[21.443563,42.237336],[21.443177,42.238366],[21.442754,42.238718],[21.442176,42.239494],[21.442509,42.239828],[21.442802,42.240586],[21.44353,42.241165],[21.443037,42.241622],[21.442008,42.241929],[21.441572,42.242627],[21.440942,42.24348],[21.440506,42.244128],[21.439656,42.244967],[21.439431,42.245339],[21.437555,42.246409],[21.437057,42.246787],[21.43659,42.247033],[21.436267,42.247706],[21.434839,42.249758],[21.434829,42.250476],[21.434873,42.251322],[21.434653,42.252009],[21.434568,42.252542],[21.433876,42.253708],[21.433441,42.254904],[21.433431,42.255495],[21.432902,42.258423],[21.432506,42.259304],[21.437013,42.260553],[21.440422,42.26234],[21.440595,42.26329],[21.441024,42.267574],[21.439968,42.269362],[21.441241,42.271979],[21.44006,42.272962],[21.439988,42.274265],[21.440463,42.274477],[21.441213,42.274252],[21.444213,42.275397],[21.444105,42.27608],[21.443795,42.276378],[21.444858,42.277898],[21.448275,42.279051],[21.448767,42.279004],[21.449564,42.277868],[21.450245,42.276731],[21.451923,42.276736],[21.452661,42.276491],[21.455761,42.276671],[21.456656,42.276503],[21.45911,42.276737],[21.46408,42.277776],[21.466094,42.278644],[21.466443,42.279622],[21.468457,42.280055],[21.470801,42.280035],[21.472661,42.279613],[21.474196,42.2795],[21.475596,42.279228],[21.479548,42.277083],[21.48368,42.275391],[21.485971,42.274331],[21.486659,42.273906],[21.488942,42.273913],[21.489733,42.27353],[21.492008,42.273284],[21.492502,42.273563],[21.493003,42.273725],[21.493516,42.274118],[21.494301,42.27429],[21.49512,42.274131],[21.49564,42.274609],[21.49623,42.2746],[21.496563,42.27431],[21.497036,42.274051],[21.49725,42.273496],[21.498214,42.27282],[21.499119,42.272831],[21.500008,42.272599],[21.500463,42.271399],[21.500895,42.271308],[21.503898,42.269804],[21.504996,42.270908],[21.50591,42.271136],[21.507216,42.271881],[21.50751,42.271455],[21.507985,42.271113],[21.50847,42.270918],[21.509392,42.270668],[21.51044,42.270533],[21.511138,42.270538],[21.511517,42.270255],[21.512094,42.269497],[21.512166,42.269152],[21.511572,42.268634],[21.511047,42.268352],[21.510801,42.267372],[21.511121,42.26602],[21.511437,42.265731],[21.513834,42.264907],[21.514335,42.263795],[21.515401,42.263355],[21.51589,42.263263],[21.516595,42.262986],[21.516978,42.263129],[21.517399,42.263163],[21.519273,42.262147],[21.519505,42.261722],[21.519592,42.261029],[21.520159,42.260607],[21.518599,42.260623],[21.518391,42.260214],[21.517759,42.259605],[21.517862,42.258956],[21.517993,42.257953],[21.518509,42.257314],[21.519018,42.255173],[21.519907,42.253512],[21.5203,42.25246],[21.520385,42.25137],[21.519302,42.24958],[21.519635,42.24834],[21.520234,42.247775],[21.520552,42.247286],[21.520719,42.246694],[21.52043,42.245553],[21.520575,42.244851],[21.521309,42.244759],[21.521226,42.243467],[21.521002,42.24283],[21.520933,42.242197],[21.521277,42.241469],[21.523505,42.241181],[21.524156,42.241236],[21.526557,42.241068],[21.527506,42.241009],[21.528727,42.241142],[21.529548,42.240846],[21.532035,42.240617],[21.533552,42.241593],[21.533023,42.242032],[21.532403,42.242512],[21.532909,42.243279],[21.534507,42.244435],[21.534834,42.244765],[21.53437,42.245492],[21.535059,42.245902],[21.535368,42.246188],[21.535956,42.246337],[21.536663,42.246895],[21.53727,42.248479],[21.537873,42.249302],[21.538533,42.250014],[21.538723,42.250397],[21.539075,42.250629],[21.540433,42.250912],[21.541216,42.251465],[21.542547,42.252232],[21.542823,42.252402],[21.542847,42.252041],[21.542406,42.251686],[21.542906,42.251459],[21.543777,42.251249],[21.544244,42.251102],[21.544405,42.25177],[21.54429,42.252215],[21.543776,42.25325],[21.544259,42.25345],[21.544907,42.253629],[21.545181,42.253294],[21.54618,42.253535],[21.54757,42.253154],[21.548685,42.253405],[21.549505,42.253599],[21.550129,42.252945],[21.550434,42.252324],[21.551463,42.252476],[21.55189,42.25216],[21.552389,42.252298],[21.553713,42.250424],[21.55571,42.25045],[21.557714,42.25086],[21.558704,42.251439],[21.558947,42.251747],[21.558485,42.252879],[21.563046,42.250737],[21.567964,42.250919],[21.569046,42.250744],[21.570775,42.251829],[21.575373,42.254198],[21.575794,42.254995],[21.575878,42.25541],[21.57622,42.255854],[21.57665,42.256004],[21.578238,42.25679],[21.580327,42.259443],[21.580861,42.259734],[21.581712,42.260097],[21.581721,42.259719],[21.582323,42.259474],[21.583226,42.25923],[21.58359,42.259343],[21.583501,42.259842],[21.584372,42.260227],[21.584574,42.260521],[21.585153,42.260814],[21.585623,42.261401],[21.586239,42.261994],[21.586443,42.262519],[21.587002,42.262783],[21.587413,42.262404],[21.587747,42.262022],[21.588104,42.261631],[21.588623,42.261456],[21.589302,42.261481],[21.589842,42.261257],[21.590223,42.26104],[21.590815,42.260754],[21.591341,42.260464],[21.591821,42.260251],[21.591946,42.259914],[21.591782,42.25946],[21.591756,42.259041],[21.592209,42.258841],[21.592306,42.258474],[21.592669,42.258362],[21.592989,42.25823],[21.593355,42.257954],[21.593912,42.257513],[21.594472,42.257325],[21.595152,42.257227],[21.5958,42.257175],[21.596281,42.256985],[21.596665,42.256771],[21.597366,42.256428],[21.598036,42.256069],[21.598675,42.255734],[21.599567,42.255207],[21.600204,42.254795],[21.600588,42.254554],[21.601012,42.254446],[21.600863,42.254875],[21.600733,42.255429],[21.600539,42.256126],[21.600465,42.256724],[21.601185,42.256672],[21.601858,42.256527],[21.602657,42.256401],[21.603491,42.256207],[21.604,42.255894],[21.604479,42.255608],[21.605148,42.255054],[21.605482,42.254803],[21.605948,42.254765],[21.606525,42.254879],[21.607231,42.254997],[21.607939,42.255184],[21.608583,42.255371],[21.609726,42.255842],[21.610677,42.256263],[21.611868,42.256733],[21.61248,42.256969],[21.613073,42.257027],[21.613472,42.256798],[21.613789,42.256413],[21.614525,42.256103],[21.615036,42.255921],[21.615515,42.255692],[21.616059,42.255522],[21.616635,42.255398],[21.617128,42.25504],[21.617365,42.254726],[21.617681,42.254322],[21.618031,42.253937],[21.618542,42.253555],[21.619081,42.25322],[21.619491,42.252995],[21.620201,42.252583],[21.62073,42.252358],[21.621225,42.252285],[21.621801,42.252445],[21.622404,42.252657],[21.622898,42.252605],[21.623381,42.252396],[21.624,42.252132],[21.624598,42.251942],[21.625334,42.251766],[21.626024,42.251678],[21.626877,42.251518],[21.628418,42.251152],[21.62895,42.251008],[21.629303,42.2509],[21.62968,42.250982],[21.630101,42.251229],[21.630692,42.251475],[21.631247,42.251503],[21.631685,42.25157],[21.63217,42.251671],[21.632607,42.251667],[21.633207,42.251663],[21.633852,42.251606],[21.634382,42.251591],[21.634933,42.251553],[21.635418,42.251549],[21.635879,42.251452],[21.636643,42.251101],[21.637266,42.250778],[21.637725,42.250495],[21.638092,42.250275],[21.638608,42.25004],[21.639346,42.249979],[21.640014,42.249958],[21.640647,42.249815],[21.641336,42.24976],[21.641972,42.2498],[21.642789,42.249733],[21.643412,42.249729],[21.643999,42.249752],[21.644518,42.249725],[21.644979,42.249722],[21.645395,42.249775],[21.645971,42.249752],[21.646605,42.249775],[21.647274,42.249737],[21.647688,42.249771],[21.648218,42.249729],[21.648622,42.249676],[21.649095,42.249699],[21.649693,42.249594],[21.650127,42.249325],[21.650494,42.249065],[21.651068,42.248772],[21.651664,42.248495],[21.652191,42.24815],[21.652614,42.247857],[21.653131,42.247715],[21.653523,42.247562],[21.654073,42.247334],[21.654532,42.247082],[21.654922,42.247089],[21.655443,42.247212],[21.656094,42.247692],[21.656534,42.247994],[21.656988,42.24843],[21.657441,42.248797],[21.657905,42.248932],[21.658432,42.248703],[21.659004,42.248375],[21.659372,42.248184],[21.659784,42.248032],[21.660244,42.247822],[21.660635,42.247665],[21.661116,42.247436],[21.661598,42.247166],[21.66208,42.246996],[21.662495,42.246952],[21.662932,42.246845],[21.663368,42.246679],[21.663572,42.246365],[21.663805,42.245887],[21.663885,42.245522],[21.664102,42.245223],[21.663974,42.244774],[21.663529,42.244501],[21.663534,42.243918],[21.663866,42.243561],[21.664427,42.243258],[21.664981,42.243031],[21.665314,42.242661],[21.665469,42.24306],[21.665864,42.243124],[21.666183,42.242596],[21.666623,42.242792],[21.666839,42.243212],[21.667492,42.243164],[21.667963,42.243058],[21.668473,42.24276],[21.668714,42.243137],[21.669232,42.243128],[21.669871,42.242985],[21.669797,42.242492],[21.670016,42.242059],[21.670384,42.241928],[21.670754,42.242072],[21.671236,42.242046],[21.671681,42.241909],[21.672115,42.242218],[21.672568,42.242611],[21.672928,42.242855],[21.673221,42.243233],[21.673483,42.242889],[21.673662,42.242544],[21.674015,42.242184],[21.674538,42.241934],[21.675026,42.241696],[21.675459,42.241226],[21.675903,42.240792],[21.676605,42.240822],[21.677277,42.240902],[21.677714,42.240902],[21.678223,42.241035],[21.678823,42.241119],[21.67947,42.24128],[21.67947,42.241829],[21.679273,42.242351],[21.679297,42.242698],[21.679783,42.2425],[21.680333,42.242308],[21.681035,42.242192],[21.681738,42.242165],[21.682268,42.242107],[21.682821,42.242123],[21.683408,42.242053],[21.683891,42.242027],[21.684548,42.241827],[21.685096,42.241398],[21.685528,42.240876],[21.685915,42.240466],[21.686293,42.240276],[21.686858,42.240265],[21.687399,42.240166],[21.687881,42.240078],[21.688364,42.239956],[21.688801,42.239853],[21.689215,42.239746],[21.689629,42.239613],[21.690027,42.239304],[21.690453,42.23914],[21.690935,42.23893],[21.6913,42.238571],[21.691525,42.238037],[21.691669,42.237616],[21.691989,42.23728],[21.692434,42.236807],[21.692612,42.236347],[21.692872,42.235904],[21.693212,42.235344],[21.693609,42.234837],[21.693871,42.234432],[21.694096,42.234001],[21.694275,42.233505],[21.694471,42.233178],[21.695216,42.233074],[21.695837,42.232929],[21.696295,42.232792],[21.696743,42.232602],[21.697319,42.232615],[21.697792,42.232613],[21.698181,42.232475],[21.698526,42.232315],[21.698788,42.232142],[21.699005,42.231796],[21.699264,42.231602],[21.69957,42.232429],[21.699688,42.233181],[21.699632,42.233701],[21.700064,42.233864],[21.700548,42.233894],[21.701126,42.233959],[21.701656,42.234043],[21.702095,42.234116],[21.702283,42.234503],[21.701942,42.235348],[21.701884,42.235892],[21.702201,42.23659],[21.702622,42.236855],[21.703094,42.236826],[21.703671,42.236899],[21.704235,42.236912],[21.704697,42.236946],[21.705411,42.236925],[21.705921,42.237059],[21.706223,42.237297],[21.706535,42.237612],[21.706794,42.237961],[21.707085,42.238266],[21.70725,42.238549],[21.707553,42.238863],[21.707992,42.238979],[21.708592,42.239071],[21.709228,42.239195],[21.709714,42.239439],[21.710285,42.239848],[21.71068,42.240215],[21.711052,42.240519],[21.71154,42.240818],[21.711842,42.241013],[21.712076,42.241362],[21.712219,42.241755],[21.712431,42.242147],[21.712814,42.242489],[21.713064,42.242807],[21.713538,42.243124],[21.713947,42.243775],[21.714381,42.244368],[21.714825,42.244907],[21.715128,42.245194],[21.715477,42.245486],[21.715732,42.245792],[21.715992,42.246169],[21.716551,42.246718],[21.716661,42.24725],[21.716423,42.24757],[21.716115,42.247956],[21.715773,42.248322],[21.715661,42.248637],[21.715768,42.249208],[21.715681,42.249752],[21.715286,42.250069],[21.715023,42.250294],[21.714808,42.250664],[21.714699,42.251064],[21.714726,42.251536],[21.714731,42.251973],[21.715058,42.252279],[21.715269,42.252602],[21.71548,42.252938],[21.715782,42.253128],[21.716196,42.253162],[21.716612,42.253197],[21.717096,42.253174],[21.717615,42.253094],[21.71829,42.253299],[21.718846,42.253918],[21.719278,42.254403],[21.71979,42.254826],[21.720205,42.255301],[21.720181,42.255684],[21.720335,42.256161],[21.72078,42.25642],[21.72114,42.256951],[21.721489,42.257172],[21.722098,42.257129],[21.722595,42.257244],[21.723044,42.257214],[21.723462,42.257376],[21.723756,42.257902],[21.724016,42.258499],[21.724218,42.25897],[21.724304,42.259457],[21.724424,42.259903],[21.724499,42.260311],[21.724514,42.261784],[21.724474,42.262199],[21.724493,42.262924],[21.724419,42.263464],[21.724207,42.264004],[21.723995,42.264633],[21.723795,42.265328],[21.724176,42.265476],[21.72459,42.265408],[21.725052,42.265423],[21.725513,42.265419],[21.726055,42.265315],[21.726662,42.265083],[21.727098,42.264877],[21.727696,42.264584],[21.728222,42.264275],[21.728679,42.263996],[21.729275,42.263668],[21.729848,42.263371],[21.730604,42.263004],[21.731705,42.262363],[21.732231,42.262074],[21.73262,42.261864],[21.733032,42.261536],[21.733513,42.261191],[21.734039,42.260857],[21.734533,42.260712],[21.735224,42.260658],[21.735731,42.260685],[21.736284,42.260651],[21.736931,42.260658],[21.737484,42.260605],[21.738012,42.260605],[21.73859,42.260616],[21.739075,42.260612],[21.73951,42.26049],[21.740064,42.260479],[21.740778,42.260433],[21.741238,42.260326],[21.741862,42.260424],[21.742624,42.26059],[21.743065,42.260761],[21.743551,42.260851],[21.744163,42.260982],[21.744556,42.261122],[21.745088,42.261164],[21.745529,42.261234],[21.746075,42.26119],[21.746674,42.261074],[21.747122,42.260969],[21.747795,42.260926],[21.74847,42.260933],[21.748942,42.260969],[21.749418,42.261069],[21.749821,42.261215],[21.75015,42.261257],[21.750479,42.261246],[21.750877,42.261181],[21.751181,42.261027],[21.751457,42.260681],[21.751838,42.260279],[21.752306,42.25984],[21.752678,42.259466],[21.75318,42.259155],[21.753546,42.258961],[21.753967,42.258681],[21.754564,42.258308],[21.755026,42.258041],[21.755618,42.257712],[21.756174,42.257435],[21.756649,42.257181],[21.757053,42.257183],[21.757456,42.257267],[21.757811,42.257427],[21.758342,42.257578],[21.75885,42.25783],[21.759182,42.258182],[21.75947,42.258411],[21.759856,42.258227],[21.760347,42.258288],[21.760884,42.258347],[21.761412,42.258169],[21.761885,42.258108],[21.762424,42.258331],[21.76299,42.258658],[21.763441,42.258833],[21.763716,42.258976],[21.764136,42.259201],[21.764988,42.259654],[21.765169,42.26025],[21.765001,42.260548],[21.765072,42.260816],[21.765463,42.26097],[21.765514,42.261807],[21.765531,42.262493],[21.7657,42.262982],[21.766317,42.263245],[21.766623,42.263357],[21.766994,42.263417],[21.767294,42.263587],[21.767607,42.263744],[21.767962,42.263956],[21.768256,42.264326],[21.768356,42.264717],[21.768462,42.265185],[21.768984,42.265385],[21.769462,42.265303],[21.770105,42.265294],[21.770609,42.265392],[21.770948,42.265428],[21.771492,42.265324],[21.771845,42.26532],[21.772262,42.265301],[21.772581,42.265186],[21.773094,42.265173],[21.773671,42.265189],[21.774002,42.265534],[21.773874,42.266073],[21.7736,42.266495],[21.773323,42.266856],[21.773199,42.267185],[21.772962,42.26746],[21.772598,42.26783],[21.772496,42.268255],[21.773151,42.268216],[21.773803,42.268064],[21.774088,42.267868],[21.774337,42.267588],[21.774584,42.267207],[21.774999,42.266951],[21.775428,42.266783],[21.775864,42.266535],[21.776234,42.26689],[21.776731,42.267369],[21.777201,42.267757],[21.777533,42.268065],[21.777931,42.268517],[21.778302,42.268984],[21.777797,42.269369],[21.777153,42.269797],[21.776669,42.270168],[21.776232,42.270613],[21.775755,42.270985],[21.775383,42.271343],[21.7752,42.271558],[21.775491,42.271607],[21.775957,42.2717],[21.776622,42.271626],[21.77721,42.271565],[21.777709,42.271977],[21.778057,42.272327],[21.778407,42.272665],[21.778927,42.273253],[21.779458,42.273897],[21.779773,42.274378],[21.780086,42.274817],[21.780328,42.275113],[21.780605,42.275537],[21.780909,42.275853],[21.781275,42.276219],[21.781576,42.276611],[21.781837,42.277039],[21.782131,42.277405],[21.782371,42.277782],[21.782654,42.278097],[21.783003,42.278525],[21.783301,42.278914],[21.783771,42.279076],[21.784135,42.279219],[21.784633,42.279476],[21.785064,42.279677],[21.785555,42.279862],[21.785953,42.280203],[21.786196,42.280514],[21.78641,42.280848],[21.786686,42.281193],[21.786876,42.281553],[21.786994,42.282029],[21.787113,42.282518],[21.787033,42.282941],[21.786491,42.282818],[21.785977,42.282719],[21.785988,42.283133],[21.786138,42.283539],[21.786272,42.283993],[21.786478,42.284474],[21.786787,42.284793],[21.787117,42.284828],[21.787446,42.284842],[21.787661,42.28509],[21.787955,42.285154],[21.788395,42.285012],[21.788881,42.284747],[21.789312,42.28455],[21.789655,42.2846],[21.789762,42.28498],[21.789906,42.285512],[21.790212,42.286106],[21.79044,42.28657],[21.790707,42.287018],[21.790976,42.287438],[21.791215,42.287955],[21.79143,42.288399],[21.791668,42.288832],[21.791889,42.289211],[21.792087,42.289639],[21.792286,42.290139],[21.792421,42.290681],[21.792589,42.291296],[21.792744,42.291779],[21.792986,42.292229],[21.793393,42.29266],[21.793676,42.293063],[21.793813,42.293526],[21.793792,42.294113],[21.793689,42.294804],[21.793646,42.295546],[21.793655,42.296246],[21.793811,42.296589],[21.794113,42.296992],[21.794175,42.297443],[21.794444,42.297771],[21.79477,42.298048],[21.795085,42.29835],[21.795422,42.298309],[21.795725,42.298229],[21.7961,42.297974],[21.796528,42.29777],[21.797023,42.297706],[21.797392,42.297327],[21.797789,42.297105],[21.798342,42.297014],[21.798664,42.29667],[21.799193,42.296505],[21.799521,42.296341],[21.799937,42.296132],[21.80035,42.295889],[21.800619,42.29565],[21.801034,42.295447],[21.801575,42.295097],[21.802092,42.294649],[21.80248,42.294298],[21.802767,42.294086],[21.803078,42.293953],[21.803493,42.293896],[21.803854,42.293827],[21.804263,42.293818],[21.80472,42.29369],[21.80526,42.293615],[21.805889,42.293469],[21.806358,42.293511],[21.80677,42.293518],[21.807245,42.293499],[21.807749,42.293461],[21.80822,42.293475],[21.80868,42.293415],[21.808916,42.293133],[21.809155,42.292971],[21.80974,42.292943],[21.810256,42.293037],[21.810768,42.29295],[21.811163,42.29311],[21.811551,42.293303],[21.812011,42.293507],[21.812599,42.293718],[21.813,42.293739],[21.813426,42.293753],[21.814048,42.293796],[21.814713,42.293923],[21.815204,42.294068],[21.815632,42.294334],[21.816078,42.294661],[21.816467,42.295014],[21.816929,42.295351],[21.817366,42.295626],[21.818004,42.295994],[21.818224,42.29624],[21.818524,42.296541],[21.818817,42.296753],[21.819212,42.29693],[21.819809,42.29715],[21.820534,42.297341],[21.821049,42.297524],[21.821559,42.297753],[21.822003,42.297999],[21.822367,42.298214],[21.822714,42.298447],[21.823078,42.298615],[21.823362,42.298836],[21.823904,42.29921],[21.824228,42.299461],[21.824593,42.299704],[21.824877,42.300017],[21.825044,42.300402],[21.825282,42.300858],[21.825645,42.30126],[21.825396,42.301581],[21.824981,42.301829],[21.824616,42.302117],[21.824217,42.302357],[21.823811,42.302555],[21.823445,42.302949],[21.82376,42.303337],[21.824305,42.303471],[21.824717,42.303652],[21.825041,42.303977],[21.825381,42.304445],[21.825791,42.305145],[21.826283,42.305546],[21.826728,42.305665],[21.827271,42.305915],[21.827622,42.30616],[21.827937,42.306246],[21.828217,42.306554],[21.828739,42.306866],[21.829194,42.307259],[21.829459,42.307698],[21.829934,42.308081],[21.830303,42.308306],[21.830424,42.308619],[21.830898,42.308754],[21.831367,42.308935],[21.83185,42.309128],[21.832302,42.309321],[21.832796,42.309538],[21.833152,42.309809],[21.833583,42.310194],[21.834004,42.310555],[21.834396,42.310848],[21.834872,42.311169],[21.835452,42.311379],[21.835865,42.311643],[21.835533,42.312092],[21.835239,42.312638],[21.834899,42.313225],[21.83482,42.313572],[21.834613,42.314078],[21.83441,42.314465],[21.834212,42.314871],[21.834148,42.31535],[21.834153,42.315771],[21.834224,42.316229],[21.834325,42.31687],[21.834528,42.317387],[21.834581,42.317704],[21.834616,42.318043],[21.834406,42.318461],[21.834053,42.319094],[21.833702,42.319655],[21.833592,42.32009],[21.833847,42.320469],[21.834082,42.320882],[21.83413,42.321289],[21.834306,42.321603],[21.834626,42.321787],[21.835021,42.321885],[21.83546,42.321938],[21.836052,42.322181],[21.836585,42.322403],[21.837088,42.322745],[21.837623,42.323092],[21.838157,42.323445],[21.838705,42.323693],[21.83914,42.323769],[21.839728,42.323983],[21.840413,42.324125],[21.840896,42.324231],[21.841331,42.324322],[21.841735,42.32445],[21.842154,42.324554],[21.842524,42.324621],[21.843012,42.324805],[21.843413,42.325092],[21.843695,42.325423],[21.844073,42.325689],[21.844647,42.325716],[21.845272,42.325549],[21.845754,42.325516],[21.846291,42.325447],[21.846942,42.325464],[21.847321,42.325583],[21.847701,42.325618],[21.848082,42.32547],[21.848459,42.325443],[21.848972,42.32543],[21.849446,42.325462],[21.850048,42.325464],[21.850668,42.325546],[21.851046,42.325546],[21.851421,42.325601],[21.851883,42.32531],[21.852284,42.324869],[21.852379,42.324456],[21.852875,42.324295],[21.853468,42.324277],[21.854085,42.323968],[21.854457,42.323819],[21.854848,42.323635],[21.855257,42.323624],[21.855711,42.323687],[21.856427,42.323466],[21.856955,42.323284],[21.857385,42.323063],[21.85783,42.322762],[21.858149,42.322504],[21.858408,42.322133],[21.858302,42.321635],[21.858259,42.321224],[21.858366,42.320816],[21.858791,42.320603],[21.859268,42.320381],[21.859867,42.31977],[21.860097,42.31943],[21.860416,42.319246],[21.86067,42.319073],[21.860982,42.318949],[21.861294,42.318924],[21.861608,42.318917],[21.862178,42.31894],[21.862722,42.31885],[21.863026,42.318718],[21.8636,42.318478],[21.863998,42.318314],[21.864318,42.31811],[21.864658,42.317797],[21.865193,42.317553],[21.865591,42.317371],[21.865965,42.317091],[21.866341,42.316585],[21.866384,42.316032],[21.866147,42.3155],[21.866747,42.314937],[21.867174,42.31456],[21.867268,42.314262],[21.867466,42.313826],[21.867391,42.313093],[21.86743,42.312463],[21.867787,42.311969],[21.867774,42.311437],[21.867992,42.311024],[21.868308,42.310595],[21.868666,42.310099],[21.868917,42.309628],[21.869321,42.309514],[21.869709,42.309575],[21.870143,42.309743],[21.870656,42.309715],[21.871086,42.309414],[21.871336,42.309017],[21.871604,42.308615],[21.87197,42.308407],[21.872305,42.308334],[21.872763,42.308314],[21.873253,42.308375],[21.873507,42.308749],[21.873315,42.309318],[21.873271,42.30967],[21.873334,42.310137],[21.873606,42.310641],[21.874008,42.311011],[21.874562,42.310943],[21.874759,42.310477],[21.875108,42.310133],[21.875582,42.30998],[21.876084,42.309855],[21.876582,42.309962],[21.876925,42.310328],[21.876993,42.310658],[21.876949,42.310967],[21.877057,42.311483],[21.877396,42.311886],[21.877773,42.312057],[21.878233,42.312073],[21.878595,42.312105],[21.879148,42.312103],[21.879581,42.312141],[21.880008,42.312157],[21.880516,42.312302],[21.88088,42.312586],[21.88127,42.31292],[21.881589,42.313291],[21.881936,42.313467],[21.882384,42.313412],[21.882888,42.313305],[21.883194,42.313267],[21.883673,42.31312],[21.884128,42.312937],[21.88462,42.312702],[21.885069,42.312333],[21.885266,42.311892],[21.885294,42.311404],[21.885409,42.310999],[21.885803,42.3105],[21.886208,42.31008],[21.886432,42.309618],[21.886547,42.308989],[21.886637,42.308525],[21.886716,42.308047],[21.886872,42.307697],[21.887214,42.307342],[21.887793,42.307035],[21.888461,42.306851],[21.888604,42.3065],[21.888682,42.306019],[21.888928,42.305512],[21.8892,42.304921],[21.889594,42.304364],[21.889935,42.304073],[21.890268,42.303905],[21.89066,42.30369],[21.891016,42.303398],[21.891358,42.303099],[21.891678,42.302529],[21.891923,42.302032],[21.892043,42.301682],[21.892146,42.301223],[21.892535,42.300682],[21.892819,42.300358],[21.893059,42.300101],[21.893454,42.300227],[21.893846,42.300322],[21.894233,42.30045],[21.894622,42.300698],[21.895099,42.300912],[21.895645,42.301035],[21.89628,42.301113],[21.896804,42.301174],[21.897269,42.301215],[21.897775,42.301255],[21.898209,42.301262],[21.898578,42.301274],[21.899059,42.3013],[21.899389,42.301315],[21.899752,42.30146],[21.900151,42.301633],[21.900674,42.301919],[21.900965,42.302048],[21.901303,42.302145],[21.901754,42.302254],[21.902246,42.302376],[21.902719,42.302509],[21.903229,42.302637],[21.903687,42.30275],[21.904153,42.302821],[21.904604,42.302887],[21.904935,42.303011],[21.905338,42.30308],[21.905759,42.303242],[21.906282,42.303495],[21.906635,42.303627],[21.907088,42.303782],[21.907707,42.303864],[21.908431,42.303938],[21.909235,42.304073],[21.909974,42.304096],[21.910393,42.304184],[21.911812,42.304192],[21.912199,42.30426],[21.91265,42.304344],[21.912987,42.304325],[21.913372,42.304325],[21.913943,42.304341],[21.914559,42.304364],[21.91518,42.304469],[21.915784,42.304608],[21.916204,42.304768],[21.917479,42.305248],[21.918012,42.30551],[21.918626,42.305807],[21.919142,42.30603],[21.919513,42.30617],[21.919962,42.306179],[21.920382,42.306175],[21.921022,42.30616],[21.921472,42.306168],[21.922097,42.306143],[21.922628,42.306175],[21.923023,42.306258],[21.923521,42.306424],[21.924008,42.306725],[21.924557,42.306971],[21.925028,42.307295],[21.92536,42.307556],[21.925766,42.30788],[21.926107,42.308174],[21.926416,42.308445],[21.926775,42.308727],[21.927114,42.309025],[21.927488,42.309292],[21.92807,42.309593],[21.928573,42.309887],[21.928788,42.310328],[21.928901,42.310915],[21.929023,42.311581],[21.929224,42.31214],[21.929392,42.31267],[21.929456,42.31321],[21.929514,42.313877],[21.929572,42.314574],[21.929677,42.315164],[21.929767,42.315697],[21.929873,42.316425],[21.930073,42.316898],[21.930047,42.317352],[21.930023,42.317913],[21.930022,42.318329],[21.930174,42.318846],[21.930445,42.319263],[21.930691,42.319678],[21.93107,42.320312],[21.93122,42.32069],[21.931502,42.321273],[21.931766,42.321787],[21.931459,42.322159],[21.931155,42.32259],[21.931086,42.323086],[21.930862,42.323616],[21.930643,42.323963],[21.930478,42.324253],[21.930381,42.324781],[21.930712,42.325424],[21.931041,42.325942],[21.931338,42.326409],[21.931599,42.327039],[21.931981,42.327601],[21.932189,42.32814],[21.932399,42.32874],[21.932592,42.329304],[21.932926,42.329632],[21.933365,42.330022],[21.933451,42.330414],[21.933303,42.330697],[21.933132,42.331116],[21.932986,42.331776],[21.933177,42.332546],[21.933378,42.333035],[21.933575,42.333371],[21.933756,42.333698],[21.933789,42.334098],[21.933516,42.334581],[21.93363,42.33495],[21.933804,42.335447],[21.934266,42.335597],[21.93471,42.335955],[21.934614,42.336308],[21.934303,42.33638],[21.934028,42.336548],[21.93403,42.337019],[21.933522,42.337375],[21.933006,42.337574],[21.932679,42.337968],[21.93254,42.338301],[21.932619,42.338656],[21.933142,42.338866],[21.933723,42.339062],[21.934381,42.339045],[21.934682,42.339244],[21.934839,42.339587],[21.934539,42.339905],[21.934126,42.340181],[21.933557,42.340528],[21.933781,42.340752],[21.934147,42.340777],[21.934573,42.340736],[21.935002,42.340504],[21.93539,42.340511],[21.93576,42.340705],[21.936015,42.340929],[21.936376,42.341134],[21.936719,42.341322],[21.937089,42.341433],[21.937391,42.341627],[21.937805,42.341903],[21.938174,42.341889],[21.93878,42.341817],[21.939373,42.342101],[21.939826,42.342297],[21.940197,42.342388],[21.940575,42.342423],[21.941027,42.34244],[21.941442,42.342641],[21.941834,42.342799],[21.942339,42.34285],[21.942791,42.342899],[21.943239,42.342919],[21.943706,42.342987],[21.944086,42.343125],[21.944515,42.3433],[21.944806,42.343483],[21.945099,42.343662],[21.94539,42.343889],[21.945604,42.344208],[21.945959,42.34465],[21.946413,42.344546],[21.946702,42.344273],[21.947249,42.344154],[21.947594,42.344101],[21.948014,42.343928],[21.948229,42.343581],[21.948255,42.343243],[21.948223,42.342746],[21.948613,42.34247],[21.949023,42.342467],[21.949433,42.342258],[21.949648,42.341836],[21.949867,42.341522],[21.950145,42.341284],[21.950655,42.34123],[21.951171,42.34147],[21.951649,42.341418],[21.952082,42.340932],[21.952613,42.340745],[21.953089,42.34053],[21.953508,42.340426],[21.95398,42.340441],[21.954458,42.340581],[21.954992,42.340559],[21.955358,42.340307],[21.955741,42.340099],[21.95614,42.340061],[21.956447,42.340086],[21.957014,42.340064],[21.957382,42.339659],[21.957622,42.339248],[21.957959,42.338882],[21.958148,42.338476],[21.958668,42.338084],[21.959288,42.33791],[21.959721,42.337807],[21.960024,42.337698],[21.960312,42.337563],[21.96059,42.337403],[21.960858,42.337078],[21.961078,42.336539],[21.961387,42.335995],[21.961703,42.335682],[21.962067,42.335335],[21.962569,42.335072],[21.963128,42.335129],[21.963521,42.335337],[21.963945,42.335424],[21.964654,42.335387],[21.965204,42.335171],[21.96566,42.33479],[21.96591,42.334359],[21.966187,42.333987],[21.966601,42.33355],[21.967123,42.333105],[21.967594,42.332838],[21.968,42.33264],[21.968349,42.332373],[21.96869,42.33211],[21.968954,42.331879],[21.96963,42.331642],[21.970273,42.331471],[21.970614,42.330841],[21.97094,42.330498],[21.97141,42.330431],[21.971964,42.330429],[21.97249,42.330366],[21.972898,42.330115],[21.973183,42.329773],[21.97348,42.329285],[21.973729,42.32873],[21.97413,42.328292],[21.974621,42.328287],[21.975129,42.328424],[21.97573,42.328364],[21.976194,42.328215],[21.976642,42.327978],[21.976684,42.327444],[21.977039,42.327162],[21.977406,42.327238],[21.977763,42.327292],[21.978092,42.327068],[21.978295,42.326574],[21.978727,42.326304],[21.979175,42.326294],[21.979524,42.326381],[21.979962,42.326402],[21.980189,42.325986],[21.980366,42.325492],[21.980668,42.325301],[21.981087,42.325272],[21.981571,42.325421],[21.982089,42.325551],[21.9825,42.325443],[21.983005,42.325134],[21.983672,42.324964],[21.98421,42.324961],[21.984685,42.324991],[21.985088,42.325081],[21.985426,42.325165],[21.985876,42.325181],[21.986371,42.325051],[21.986676,42.324459],[21.986887,42.324059],[21.987065,42.323812],[21.987329,42.323696],[21.987641,42.323632],[21.988123,42.323605],[21.988499,42.323585],[21.988853,42.323521],[21.98941,42.323297],[21.989869,42.322872],[21.990179,42.322651],[21.990522,42.322552],[21.991121,42.322579],[21.991617,42.322716],[21.992003,42.322741],[21.992445,42.322762],[21.992875,42.322727],[21.993348,42.322511],[21.99372,42.322197],[21.994124,42.321829],[21.994544,42.321558],[21.994914,42.321417],[21.995415,42.321242],[21.995764,42.320998],[21.995996,42.320657],[21.996386,42.320698],[21.996805,42.320797],[21.997188,42.320692],[21.997376,42.320378],[21.997353,42.319959],[21.997285,42.319472],[21.997564,42.319141],[21.997888,42.318916],[21.998283,42.318797],[21.99869,42.318668],[21.999194,42.318556],[21.999789,42.318353],[22.000396,42.317955],[22.000793,42.317644],[22.0011,42.317352],[22.00145,42.317053],[22.001797,42.316711],[22.002219,42.316444],[22.002646,42.316267],[22.003031,42.316061],[22.003478,42.315916],[22.00391,42.315806],[22.004206,42.315693],[22.004523,42.315592],[22.004919,42.315534],[22.00527,42.315442],[22.005677,42.315331],[22.006092,42.315308],[22.006489,42.315252],[22.006844,42.31505],[22.007041,42.314737],[22.0072,42.314288],[22.007525,42.31394],[22.007702,42.313596],[22.007546,42.312976],[22.007599,42.312357],[22.007963,42.31211],[22.008289,42.311699],[22.008404,42.311316],[22.008587,42.310915],[22.009133,42.310646],[22.009731,42.31044],[22.010363,42.31028],[22.011049,42.310045],[22.011525,42.30971],[22.012003,42.309491],[22.012582,42.309286],[22.013201,42.309082],[22.013671,42.308848],[22.014213,42.308649],[22.014925,42.308489],[22.015326,42.308392],[22.015693,42.308327],[22.01622,42.308155],[22.016636,42.308128],[22.017063,42.308182],[22.017493,42.308139],[22.017776,42.307861],[22.017997,42.307521],[22.018545,42.307288],[22.018928,42.306895],[22.018919,42.306336],[22.018946,42.305912],[22.018972,42.305602],[22.019208,42.305066],[22.019656,42.304694],[22.01999,42.304572],[22.020324,42.304199],[22.020619,42.303905],[22.020981,42.303768],[22.021301,42.303729],[22.021644,42.303487],[22.021869,42.303109],[22.021918,42.302702],[22.021934,42.302204],[22.022097,42.301842],[22.022618,42.301788],[22.022959,42.301718],[22.023222,42.301434],[22.023378,42.301163],[22.023523,42.300865],[22.023859,42.300622],[22.024396,42.300567],[22.024906,42.3004],[22.025449,42.299973],[22.026037,42.299816],[22.026525,42.29979],[22.02699,42.299877],[22.027469,42.300072],[22.028035,42.299853],[22.02869,42.299436],[22.029347,42.299113],[22.029869,42.29897],[22.030596,42.299157],[22.031142,42.2992],[22.031508,42.298757],[22.031765,42.298345],[22.032092,42.298192],[22.032512,42.298353],[22.032949,42.29858],[22.033362,42.298746],[22.033739,42.298828],[22.034053,42.298899],[22.034353,42.299004],[22.034659,42.299149],[22.035114,42.299396],[22.035503,42.299667],[22.03585,42.299962],[22.036497,42.300322],[22.037123,42.300617],[22.03757,42.300921],[22.038056,42.301257],[22.038456,42.301619],[22.038844,42.302129],[22.039111,42.302452],[22.039311,42.302876],[22.039558,42.303318],[22.039839,42.303732],[22.040126,42.304359],[22.04057,42.304993],[22.040863,42.305472],[22.041163,42.305923],[22.041595,42.306128],[22.042111,42.306256],[22.042387,42.3064],[22.042686,42.306584],[22.043244,42.306764],[22.043832,42.306946],[22.044334,42.307158],[22.044777,42.307301],[22.045305,42.307406],[22.045926,42.307373],[22.046556,42.307347],[22.047234,42.307327],[22.047682,42.30731],[22.048179,42.307308],[22.048615,42.307351],[22.049121,42.307429],[22.049404,42.307571],[22.049727,42.30768],[22.050081,42.307716],[22.050515,42.307698],[22.050882,42.307686],[22.051272,42.307573],[22.051696,42.307318],[22.052081,42.307029],[22.052425,42.306782],[22.053117,42.306243],[22.053398,42.305943],[22.053641,42.305588],[22.053819,42.305214],[22.054091,42.304655],[22.054482,42.304019],[22.05512,42.303795],[22.055682,42.303792],[22.056045,42.303917],[22.05661,42.303912],[22.057163,42.303854],[22.057777,42.303806],[22.058407,42.303843],[22.059067,42.303949],[22.059624,42.304008],[22.060144,42.303837],[22.060576,42.303751],[22.061029,42.30365],[22.061451,42.303325],[22.061863,42.302963],[22.062344,42.302479],[22.062719,42.3019],[22.062929,42.301444],[22.06301,42.301056],[22.063277,42.3007],[22.063726,42.30019],[22.064092,42.299693],[22.064466,42.299369],[22.064972,42.299196],[22.065259,42.298794],[22.06552,42.29851],[22.0659,42.298501],[22.066476,42.298638],[22.066815,42.298756],[22.0671,42.298924],[22.067495,42.299057],[22.067923,42.299233],[22.068304,42.299461],[22.068644,42.299629],[22.069017,42.299816],[22.069469,42.299999],[22.069966,42.300208],[22.070417,42.30004],[22.070815,42.299877],[22.071332,42.299847],[22.071807,42.300185],[22.072125,42.300476],[22.072365,42.300831],[22.072859,42.300982],[22.073526,42.301244],[22.073767,42.301697],[22.073868,42.30205],[22.073997,42.302546],[22.074141,42.302969],[22.074474,42.303176],[22.075071,42.302954],[22.075477,42.302903],[22.076201,42.302856],[22.076785,42.302769],[22.07726,42.30255],[22.077577,42.302161],[22.078178,42.302008],[22.078811,42.302002],[22.079346,42.301957],[22.079992,42.301857],[22.080622,42.301836],[22.081128,42.301859],[22.081585,42.301826],[22.081955,42.301842],[22.082437,42.301901],[22.082872,42.302012],[22.083331,42.302076],[22.083836,42.302084],[22.084451,42.302174],[22.085062,42.302426],[22.085402,42.302624],[22.085711,42.302835],[22.086021,42.303143],[22.08634,42.303473],[22.086733,42.303709],[22.087399,42.303733],[22.088024,42.303898],[22.088565,42.304108],[22.08893,42.304276],[22.08943,42.304449],[22.089947,42.304619],[22.090572,42.304545],[22.091226,42.304344],[22.09172,42.304173],[22.092181,42.304373],[22.092596,42.304619],[22.093016,42.304844],[22.09347,42.305096],[22.093957,42.305375],[22.09457,42.305605],[22.095126,42.305643],[22.095654,42.305689],[22.096311,42.305822],[22.096824,42.306053],[22.097125,42.306219],[22.097441,42.306404],[22.097748,42.306546],[22.098002,42.306717],[22.09838,42.306456],[22.09884,42.306273],[22.099331,42.305832],[22.099674,42.305311],[22.10018,42.305153],[22.100684,42.305117],[22.101109,42.30528],[22.101486,42.305477],[22.101801,42.305626],[22.102224,42.305895],[22.102692,42.306334],[22.103069,42.306947],[22.103205,42.3074],[22.103403,42.30772],[22.103746,42.308008],[22.104054,42.308466],[22.10454,42.308823],[22.105034,42.30917],[22.105563,42.309528],[22.106314,42.309418],[22.106945,42.309227],[22.107535,42.30904],[22.108078,42.308856],[22.108685,42.308727],[22.109319,42.308727],[22.110038,42.30924],[22.110642,42.309513],[22.111216,42.309769],[22.11166,42.309956],[22.112018,42.310204],[22.112416,42.310442],[22.112667,42.31065],[22.112978,42.310955],[22.113393,42.311268],[22.113794,42.311658],[22.11407,42.312067],[22.114459,42.312105],[22.114883,42.31229],[22.11542,42.312562],[22.115897,42.312864],[22.116187,42.313158],[22.116454,42.313515],[22.11679,42.314049],[22.117255,42.314378],[22.11764,42.314664],[22.118054,42.314783],[22.118406,42.314722],[22.118725,42.314575],[22.119122,42.314344],[22.119612,42.314194],[22.119953,42.314148],[22.120353,42.31403],[22.120907,42.313831],[22.121486,42.313433],[22.121794,42.312973],[22.122005,42.312502],[22.122122,42.311951],[22.122152,42.311416],[22.122691,42.311044],[22.12329,42.311006],[22.123917,42.310895],[22.124352,42.310517],[22.124636,42.310217],[22.124926,42.309895],[22.125202,42.309608],[22.125447,42.309393],[22.125709,42.309212],[22.126082,42.308955],[22.126568,42.308739],[22.126973,42.308562],[22.127331,42.308388],[22.127778,42.308231],[22.128328,42.308119],[22.129052,42.308117],[22.129654,42.308117],[22.130247,42.308094],[22.130728,42.308048],[22.13116,42.307965],[22.131559,42.307838],[22.131901,42.307673],[22.132209,42.307388],[22.132531,42.307172],[22.132992,42.307224],[22.133351,42.307536],[22.13374,42.307739],[22.134087,42.307829],[22.134526,42.307956],[22.134841,42.308228],[22.13509,42.308716],[22.135483,42.3092],[22.135737,42.309633],[22.135971,42.309967],[22.136313,42.310229],[22.136704,42.310503],[22.137156,42.310702],[22.137522,42.310955],[22.137805,42.311121],[22.138252,42.311405],[22.138578,42.311674],[22.139015,42.311914],[22.139372,42.312084],[22.139753,42.312302],[22.14013,42.312567],[22.140333,42.312891],[22.140261,42.313305],[22.139839,42.313721],[22.139666,42.314119],[22.139858,42.314518],[22.140638,42.314629],[22.140792,42.315157],[22.14084,42.315618],[22.141244,42.315989],[22.141649,42.31638],[22.142146,42.316856],[22.142627,42.317331],[22.142958,42.317749],[22.143318,42.318121],[22.143744,42.318573],[22.144072,42.318905],[22.144494,42.319284],[22.144743,42.319664],[22.145004,42.319981],[22.145212,42.320324],[22.145421,42.320811],[22.145666,42.321356],[22.146143,42.321226],[22.146591,42.321161],[22.147167,42.321023],[22.147827,42.320651],[22.14831,42.320322],[22.148886,42.320179],[22.149509,42.320031],[22.150012,42.319885],[22.150396,42.31979],[22.150713,42.319545],[22.151205,42.31927],[22.151694,42.31917],[22.152028,42.319016],[22.152355,42.318943],[22.152805,42.318953],[22.153487,42.318924],[22.154249,42.318863],[22.154857,42.318823],[22.155195,42.318901],[22.155694,42.318925],[22.156096,42.31868],[22.156525,42.318455],[22.157067,42.318049],[22.157442,42.317913],[22.157694,42.317652],[22.158053,42.317535],[22.15841,42.317614],[22.158777,42.317763],[22.159101,42.317599],[22.159163,42.317075],[22.159206,42.316386],[22.159482,42.315827],[22.159792,42.315609],[22.160206,42.315457],[22.160847,42.315426],[22.161399,42.315436],[22.161862,42.315072],[22.161938,42.31449],[22.162009,42.314011],[22.162325,42.31377],[22.162602,42.313568],[22.163168,42.313338],[22.163855,42.313175],[22.164377,42.31308],[22.164911,42.312938],[22.165334,42.312785],[22.165714,42.312506],[22.1664,42.312289],[22.166679,42.312605],[22.166918,42.312947],[22.167213,42.31333],[22.167557,42.313685],[22.167908,42.314026],[22.168194,42.314259],[22.168617,42.314575],[22.169048,42.314854],[22.169445,42.315117],[22.169947,42.315302],[22.170482,42.31556],[22.170849,42.315909],[22.171037,42.316466],[22.171218,42.31716],[22.171333,42.317707],[22.171492,42.318066],[22.171706,42.318409],[22.1721,42.31884],[22.172419,42.319138],[22.172751,42.319347],[22.173098,42.319561],[22.173505,42.31971],[22.173773,42.319893],[22.174026,42.320071],[22.174217,42.320477],[22.174111,42.321015],[22.173735,42.321441],[22.17415,42.321646],[22.174595,42.321793],[22.175148,42.321913],[22.175596,42.32208],[22.175854,42.322353],[22.176285,42.322274],[22.17651,42.322712],[22.176854,42.322899],[22.178051,42.322937],[22.178534,42.322952],[22.178977,42.323352],[22.179113,42.323944],[22.179125,42.324524],[22.180073,42.324528],[22.180489,42.32444],[22.180979,42.324947],[22.181256,42.325171],[22.181679,42.325489],[22.18142,42.32626],[22.181139,42.326615],[22.181272,42.327261],[22.181436,42.327866],[22.181555,42.328213],[22.182264,42.328476],[22.182285,42.329123],[22.182253,42.329575],[22.182296,42.330105],[22.182163,42.330719],[22.181915,42.331245],[22.18178,42.33168],[22.181453,42.332253],[22.181869,42.333002],[22.182434,42.333176],[22.182877,42.333294],[22.183859,42.333382],[22.184366,42.333454],[22.18501,42.333515],[22.186255,42.333969],[22.186949,42.334168],[22.187608,42.334665],[22.188223,42.335278],[22.188736,42.335616],[22.189226,42.335758],[22.189846,42.33581],[22.190599,42.33617],[22.190813,42.336409],[22.191345,42.33651],[22.191803,42.336983],[22.192455,42.337452],[22.192873,42.337517],[22.193843,42.33828],[22.194115,42.338703],[22.194231,42.339251],[22.19438,42.339905],[22.194973,42.339901],[22.196007,42.340172],[22.19709,42.340588],[22.199746,42.3405],[22.200329,42.340359],[22.200956,42.340321],[22.201389,42.340336],[22.201882,42.340456],[22.202422,42.340143],[22.202915,42.33985],[22.203541,42.339459],[22.204121,42.338722],[22.2045,42.338371],[22.204845,42.338013],[22.20532,42.337605],[22.205651,42.337279],[22.20616,42.336589],[22.206491,42.336704],[22.207033,42.337043],[22.20775,42.337025],[22.208155,42.337185],[22.208466,42.337456],[22.209381,42.337464],[22.210953,42.33741],[22.212028,42.337387],[22.213008,42.337363],[22.213587,42.337406],[22.214294,42.337486],[22.214955,42.337536],[22.215544,42.337706],[22.216557,42.338142],[22.217898,42.338581],[22.218541,42.338713],[22.218881,42.338825],[22.219198,42.338642],[22.219677,42.338432],[22.220427,42.338188],[22.220983,42.337883],[22.221508,42.337654],[22.222009,42.337343],[22.222375,42.336997],[22.221781,42.336533],[22.221895,42.336051],[22.221656,42.335711],[22.221626,42.3354],[22.221837,42.335159],[22.222363,42.335146],[22.223077,42.335284],[22.223592,42.335366],[22.223926,42.335594],[22.224486,42.335533],[22.225048,42.335982],[22.22541,42.336006],[22.225728,42.33585],[22.226097,42.335819],[22.226439,42.336033],[22.227026,42.335646],[22.227805,42.335678],[22.228347,42.335629],[22.228839,42.335573],[22.229244,42.335739],[22.229662,42.335821],[22.23014,42.336007],[22.230551,42.336519],[22.230726,42.336864],[22.231147,42.337401],[22.231363,42.337773],[22.231761,42.338038],[22.232182,42.338131],[22.23297,42.338309],[22.233585,42.338486],[22.233988,42.338604],[22.234285,42.338984],[22.234461,42.339312],[22.234797,42.33969],[22.235332,42.339959],[22.235786,42.340187],[22.236287,42.340365],[22.236759,42.340649],[22.237197,42.340882],[22.2376,42.341045],[22.23804,42.341306],[22.238616,42.34158],[22.239315,42.341967],[22.239844,42.342385],[22.240136,42.342951],[22.240279,42.343678],[22.240386,42.344196],[22.24071,42.344559],[22.241255,42.344685],[22.241868,42.344872],[22.242504,42.345375],[22.243157,42.345818],[22.243593,42.346043],[22.244089,42.346235],[22.24356,42.346356],[22.242711,42.346459],[22.242011,42.346844],[22.241507,42.347694],[22.241087,42.348003],[22.240488,42.348198],[22.23986,42.348141],[22.239378,42.348103],[22.238655,42.348072],[22.238142,42.348114],[22.2372,42.348418],[22.236778,42.348799],[22.236349,42.349262],[22.236279,42.349738],[22.236856,42.35013],[22.23768,42.350353],[22.238157,42.350597],[22.23863,42.350901],[22.239037,42.351135],[22.239553,42.351296],[22.240451,42.351219],[22.240871,42.351318],[22.241698,42.351273],[22.242418,42.351223],[22.243001,42.35104],[22.243238,42.350842],[22.243601,42.350452],[22.243979,42.350033],[22.244559,42.349684],[22.244881,42.349461],[22.245282,42.349352],[22.24615,42.349432],[22.246942,42.349686],[22.247715,42.349751],[22.248213,42.349743],[22.248856,42.349785],[22.249786,42.349781],[22.250214,42.349848],[22.250857,42.349882],[22.251787,42.350224],[22.252324,42.350491],[22.252558,42.350945],[22.252449,42.351532],[22.252308,42.352135],[22.252609,42.352711],[22.253205,42.353653],[22.253101,42.35405],[22.253271,42.354561],[22.25333,42.355885],[22.252514,42.356857],[22.252316,42.357445],[22.251776,42.358536],[22.251625,42.359039],[22.251524,42.359615],[22.251649,42.360644],[22.252124,42.361109],[22.253702,42.361714],[22.254778,42.362473],[22.255249,42.362778],[22.255653,42.362919],[22.256029,42.363174],[22.25667,42.363526],[22.257291,42.364039],[22.257666,42.364325],[22.258726,42.364415],[22.259167,42.365051],[22.259417,42.365517],[22.259714,42.365891],[22.260071,42.366127],[22.260479,42.36636],[22.261383,42.366604],[22.262316,42.36665],[22.263119,42.366684],[22.263857,42.366623],[22.264509,42.366299],[22.26505,42.365999],[22.26564,42.365787],[22.266117,42.365562],[22.266449,42.365265],[22.266729,42.364845],[22.267057,42.364323],[22.267689,42.363857],[22.268082,42.363361],[22.268299,42.362949],[22.268641,42.362434],[22.269117,42.362133],[22.269527,42.361771],[22.27018,42.361511],[22.270578,42.36129],[22.272117,42.361195],[22.273066,42.361161],[22.273487,42.361366],[22.273945,42.361805],[22.274338,42.362141],[22.274938,42.362453],[22.275528,42.362926],[22.276266,42.363677],[22.276848,42.363917],[22.27729,42.364273],[22.277569,42.364655],[22.277874,42.365406],[22.278564,42.366127],[22.279208,42.366638],[22.27995,42.366743],[22.280433,42.367249],[22.280558,42.367794],[22.280602,42.368367],[22.280901,42.368877],[22.281906,42.369293],[22.282345,42.369587],[22.283316,42.36993],[22.284256,42.370255],[22.284647,42.370514],[22.285033,42.370611],[22.285297,42.370934],[22.285734,42.37112],[22.286804,42.371544],[22.287548,42.371845],[22.288536,42.372131],[22.289373,42.372265],[22.290114,42.372341],[22.290791,42.37244],[22.291452,42.372578],[22.292177,42.372681],[22.292759,42.372847],[22.293387,42.373287],[22.293797,42.37363],[22.294123,42.373543],[22.295296,42.372704],[22.295643,42.372482],[22.296295,42.372108],[22.297215,42.371498],[22.297699,42.370857],[22.297586,42.370075],[22.297536,42.369559],[22.297852,42.368858],[22.298216,42.368118],[22.298002,42.367653],[22.298172,42.367256],[22.29834,42.366882],[22.298637,42.366501],[22.29894,42.365969],[22.299064,42.364983],[22.298714,42.364681],[22.297897,42.364147],[22.297134,42.363735],[22.295535,42.362824],[22.295262,42.362461],[22.294947,42.361679],[22.294917,42.360556],[22.29479,42.359909],[22.29476,42.359169],[22.294655,42.35873],[22.294516,42.358246],[22.294149,42.357594],[22.293884,42.357227],[22.293797,42.356815],[22.293593,42.356342],[22.29328,42.355892],[22.293077,42.355457],[22.292681,42.354889],[22.292364,42.35432],[22.29203,42.35376],[22.291423,42.353123],[22.290811,42.352637],[22.291006,42.352367],[22.29096,42.352051],[22.291233,42.351646],[22.291474,42.351254],[22.291563,42.350491],[22.29175,42.350243],[22.292158,42.349834],[22.292693,42.349243],[22.293102,42.348846],[22.293633,42.348459],[22.294286,42.348204],[22.294674,42.347912],[22.294987,42.347527],[22.295341,42.347159],[22.296228,42.346583],[22.296831,42.346251],[22.297222,42.346115],[22.29756,42.346127],[22.298093,42.345875],[22.29854,42.345406],[22.299011,42.344484],[22.299593,42.344227],[22.30026,42.343903],[22.300882,42.343666],[22.301334,42.343392],[22.301869,42.343258],[22.302423,42.34288],[22.303694,42.342209],[22.303938,42.341961],[22.304359,42.341751],[22.304737,42.3414],[22.305567,42.341145],[22.306025,42.340765],[22.306171,42.34001],[22.306796,42.339985],[22.307032,42.339722],[22.307234,42.339043],[22.307795,42.339321],[22.308277,42.339401],[22.308717,42.339308],[22.30904,42.338997],[22.309158,42.338474],[22.309387,42.337921],[22.309786,42.336998],[22.310204,42.336254],[22.310514,42.3358],[22.311127,42.335114],[22.312036,42.334862],[22.312801,42.333767],[22.313982,42.333002],[22.316462,42.331772],[22.317175,42.332152],[22.317875,42.332165],[22.318888,42.333027],[22.319923,42.333374],[22.320421,42.333408],[22.320779,42.333127],[22.321016,42.333488],[22.321806,42.333549],[22.322697,42.333954],[22.323138,42.333563],[22.32369,42.333046],[22.32378,42.332371],[22.324094,42.331659],[22.324484,42.331118],[22.325474,42.330071],[22.32531,42.329564],[22.325478,42.329123],[22.326644,42.328188],[22.327279,42.328357],[22.327992,42.327637],[22.328367,42.327132],[22.329344,42.327049],[22.329908,42.32639],[22.330204,42.325958],[22.330353,42.325428],[22.330985,42.324534],[22.331422,42.323941],[22.330974,42.323637],[22.330516,42.323478],[22.330625,42.32306],[22.331301,42.322392],[22.33198,42.321884],[22.332877,42.32137],[22.33353,42.321313],[22.333872,42.320976],[22.334524,42.320645],[22.335177,42.320423],[22.335682,42.320071],[22.33616,42.319889],[22.336348,42.319622],[22.336769,42.31946],[22.33727,42.319575],[22.337553,42.320054],[22.338054,42.320223],[22.338591,42.320145],[22.339049,42.319767],[22.339666,42.31942],[22.34071,42.319435],[22.34129,42.319485],[22.341722,42.319431],[22.342167,42.319225],[22.342934,42.319004],[22.343746,42.318802],[22.345137,42.318428],[22.345905,42.318363],[22.34645,42.318345],[22.346809,42.317862],[22.347462,42.317806],[22.348255,42.317854],[22.348819,42.317997],[22.349448,42.318097],[22.350502,42.317833],[22.350584,42.317192],[22.351485,42.316912],[22.3521,42.316797],[22.352789,42.316746],[22.353006,42.316395],[22.353188,42.315807],[22.353207,42.315285],[22.353458,42.314587],[22.354034,42.314175],[22.354252,42.313805],[22.354668,42.313717],[22.355153,42.313196],[22.355362,42.312815],[22.356033,42.312328],[22.356494,42.311796],[22.356968,42.311764],[22.357487,42.311962],[22.358399,42.311825],[22.358959,42.311741],[22.35947,42.311653],[22.359837,42.311481],[22.360639,42.311392],[22.361307,42.311265],[22.361713,42.311005],[22.362316,42.310707],[22.362972,42.310369],[22.363471,42.310148],[22.363887,42.309976],[22.364636,42.309779],[22.365135,42.309645],[22.365572,42.30952],[22.366092,42.309362],[22.366592,42.309158],[22.367029,42.308953],[22.367622,42.308678],[22.368324,42.308557],[22.36885,42.308647],[22.36938,42.308742],[22.369817,42.308828],[22.370233,42.308938],[22.370961,42.308946],[22.371565,42.308773],[22.371898,42.308529],[22.37222,42.308262],[22.372616,42.307979],[22.373136,42.307719],[22.373719,42.307641],[22.374103,42.307696],[22.374519,42.30779],[22.375081,42.307986],[22.375684,42.308262],[22.376121,42.308482],[22.376537,42.308686],[22.376995,42.308883],[22.377703,42.309056],[22.378202,42.309025],[22.378816,42.308851],[22.379388,42.308537],[22.379721,42.308105],[22.380148,42.307648],[22.380668,42.307161],[22.381052,42.306909],[22.381365,42.306501],[22.381573,42.305833],[22.381697,42.305353],[22.381864,42.304889],[22.382311,42.304433],[22.382832,42.304166],[22.383477,42.303969],[22.38407,42.303631],[22.384548,42.303199],[22.384902,42.30279],[22.385235,42.302397],[22.385453,42.301996],[22.385661,42.301539],[22.386025,42.301029],[22.386379,42.300683],[22.386753,42.300345],[22.387326,42.299991],[22.3877,42.29948],[22.388116,42.298835],[22.388397,42.298261],[22.388543,42.297868],[22.38872,42.29724],[22.388741,42.29632],[22.388709,42.295871],[22.388741,42.2954],[22.388917,42.294944],[22.389542,42.294621],[22.390041,42.294378],[22.390457,42.294252],[22.391206,42.29404],[22.391955,42.293859],[22.392392,42.293811],[22.392871,42.293796],[22.393557,42.293639],[22.39414,42.29345],[22.394535,42.293308],[22.395055,42.29312],[22.395586,42.292915],[22.396096,42.292727],[22.396678,42.292506],[22.397365,42.292255],[22.397781,42.292145],[22.398218,42.291972],[22.398696,42.291815],[22.399175,42.29161],[22.39957,42.291374],[22.400163,42.291162],[22.400944,42.290793],[22.401485,42.290408],[22.401838,42.290132],[22.401942,42.289826],[22.40163,42.289346],[22.401152,42.289016],[22.400808,42.288505],[22.400517,42.287829],[22.400319,42.287318],[22.400101,42.286909],[22.399882,42.286343],[22.399675,42.285942],[22.399508,42.285517],[22.399445,42.285132],[22.399498,42.2847],[22.399654,42.284189],[22.400039,42.283749],[22.4006,42.283466],[22.40111,42.283277],[22.401443,42.283002],[22.401776,42.282726],[22.401963,42.282333],[22.402109,42.281995],[22.402192,42.281626],[22.402255,42.281225],[22.402483,42.280769],[22.402952,42.280438],[22.403482,42.280116],[22.404002,42.279676],[22.404315,42.279157],[22.404523,42.27856],[22.404668,42.278143],[22.404939,42.277742],[22.405365,42.277309],[22.405833,42.276971],[22.406208,42.276735],[22.406655,42.276476],[22.407186,42.276201],[22.407748,42.275997],[22.408403,42.275761],[22.408912,42.275572],[22.409365,42.275305],[22.409683,42.274794],[22.409766,42.274314],[22.409849,42.273882],[22.410026,42.273347],[22.410265,42.272836],[22.410723,42.272443],[22.411222,42.272144],[22.411701,42.27194],[22.412252,42.271704],[22.41272,42.271484],[22.413136,42.271209],[22.41349,42.270855],[22.413684,42.270357],[22.413761,42.269865],[22.413823,42.269409],[22.41399,42.268772],[22.414281,42.268088],[22.414676,42.267663],[22.415071,42.267286],[22.415467,42.267034],[22.415925,42.266775],[22.416725,42.266256],[22.417287,42.265832],[22.418005,42.265399],[22.41864,42.265108],[22.419337,42.264825],[22.419972,42.264424],[22.420502,42.264083],[22.420949,42.264258],[22.421334,42.264487],[22.421813,42.26455],[22.422395,42.264612],[22.422915,42.264628],[22.423394,42.264597],[22.42407,42.2644],[22.424341,42.263787],[22.424226,42.263221],[22.424102,42.262608],[22.424184,42.262018],[22.424414,42.261484],[22.424621,42.260996],[22.424663,42.260595],[22.424767,42.260068],[22.424663,42.259542],[22.424517,42.258866],[22.42433,42.258339],[22.424403,42.257922],[22.424538,42.257388],[22.42457,42.256916],[22.424632,42.256342],[22.425048,42.256122],[22.425579,42.256248],[22.426328,42.256389],[22.42691,42.256452],[22.42741,42.256468],[22.42793,42.256452],[22.42843,42.256436],[22.428991,42.25664],[22.429469,42.256798],[22.429906,42.256892],[22.430468,42.256971],[22.430863,42.257081],[22.431654,42.257278],[22.432299,42.257521],[22.432819,42.25771],[22.433277,42.257835],[22.433735,42.257977],[22.434203,42.258079],[22.434692,42.257977],[22.434942,42.257474],[22.435067,42.256743],[22.43515,42.2562],[22.435285,42.255752],[22.435607,42.255351],[22.43594,42.255005],[22.436294,42.254691],[22.436627,42.254392],[22.436981,42.254093],[22.437314,42.253779],[22.437792,42.253347],[22.438375,42.253024],[22.438958,42.252718],[22.439186,42.252128],[22.439197,42.251633],[22.439145,42.251043],[22.439103,42.250555],[22.439072,42.250186],[22.43904,42.249816],[22.43903,42.249479],[22.43901,42.248984],[22.438999,42.248543],[22.43903,42.248166],[22.439325,42.247793],[22.43979,42.247678],[22.440268,42.247513],[22.440685,42.247183],[22.440747,42.24684],[22.440857,42.246404],[22.441381,42.246114],[22.441808,42.24598],[22.442182,42.24587],[22.44264,42.245626],[22.443108,42.245328],[22.443608,42.245021],[22.444076,42.244816],[22.444617,42.244691],[22.44547,42.244588],[22.446115,42.244541],[22.446531,42.244345],[22.446916,42.24407],[22.447332,42.243779],[22.447779,42.243535],[22.448091,42.243338],[22.448518,42.243102],[22.448861,42.242961],[22.449163,42.242851],[22.449538,42.242678],[22.44986,42.242356],[22.45013,42.242033],[22.450297,42.241664],[22.450443,42.241278],[22.450443,42.240776],[22.450318,42.240261],[22.450141,42.239872],[22.449912,42.239526],[22.449621,42.239077],[22.449267,42.238558],[22.448965,42.238086],[22.448716,42.237725],[22.448497,42.237355],[22.44831,42.236868],[22.448362,42.236428],[22.448736,42.236011],[22.449049,42.235657],[22.449392,42.235311],[22.449797,42.235013],[22.450287,42.234856],[22.450672,42.234659],[22.450942,42.234407],[22.45114,42.234109],[22.451296,42.233668],[22.451441,42.233065],[22.451618,42.23256],[22.451982,42.23212],[22.452451,42.231679],[22.45296,42.231294],[22.453387,42.231003],[22.453741,42.23076],[22.454125,42.230508],[22.45449,42.230146],[22.454874,42.229816],[22.455114,42.229431],[22.455447,42.228959],[22.455686,42.228636],[22.455883,42.228212],[22.456112,42.227741],[22.456289,42.227394],[22.456477,42.226907],[22.45656,42.226482],[22.456612,42.226121],[22.456622,42.225594],[22.456664,42.225036],[22.456685,42.224423],[22.456768,42.223982],[22.456903,42.223613],[22.457059,42.223094],[22.457205,42.222693],[22.457392,42.22217],[22.457975,42.221938],[22.458412,42.22182],[22.459046,42.221687],[22.459639,42.221529],[22.459764,42.221152],[22.459701,42.220822],[22.459556,42.220468],[22.459514,42.220083],[22.459421,42.219572],[22.459327,42.219124],[22.459359,42.218487],[22.459493,42.218039],[22.459858,42.217756],[22.460503,42.217245],[22.460867,42.216859],[22.461075,42.216631],[22.461512,42.21649],[22.462108,42.216188],[22.462053,42.215727],[22.461845,42.215268],[22.462126,42.214721],[22.46251,42.214469],[22.462822,42.214296],[22.463124,42.214108],[22.463426,42.213919],[22.463614,42.21366],[22.463936,42.213282],[22.464362,42.212897],[22.464831,42.212465],[22.465257,42.212127],[22.465663,42.211773],[22.466131,42.211396],[22.46663,42.211057],[22.466984,42.210837],[22.4674,42.210405],[22.467681,42.209815],[22.467733,42.209501],[22.467816,42.209195],[22.467899,42.208785],[22.468045,42.208348],[22.468149,42.207905],[22.468281,42.207472],[22.468461,42.207032],[22.468659,42.206623],[22.468857,42.206152],[22.469044,42.205664],[22.46921,42.205098],[22.469345,42.204619],[22.469606,42.204006],[22.469723,42.203379],[22.469553,42.202693],[22.469293,42.202221],[22.469179,42.201781],[22.469023,42.201178],[22.469439,42.20123],[22.469876,42.201356],[22.470313,42.201466],[22.470895,42.201497],[22.471478,42.201497],[22.471957,42.20145],[22.47256,42.201387],[22.472976,42.201324],[22.47358,42.201144],[22.474183,42.200963],[22.474911,42.200915],[22.475452,42.200963],[22.47591,42.200978],[22.476409,42.200963],[22.476909,42.200931],[22.477533,42.200884],[22.478095,42.200743],[22.478656,42.200837],[22.479093,42.200915],[22.47978,42.200963],[22.480571,42.2009],[22.481049,42.200853],[22.481715,42.200853],[22.482079,42.201034],[22.482485,42.201222],[22.483078,42.20123],[22.483608,42.201199],[22.484087,42.201144],[22.484586,42.20123],[22.485023,42.201324],[22.485491,42.20138],[22.486137,42.201253],[22.486792,42.200963],[22.48726,42.200759],[22.487687,42.200617],[22.488883,42.2002],[22.489434,42.200019],[22.489913,42.199776],[22.490464,42.199406],[22.490849,42.199202],[22.491223,42.199029],[22.491619,42.198919],[22.491993,42.19873],[22.492389,42.198604],[22.492846,42.198415],[22.493513,42.198282],[22.494199,42.198148],[22.494834,42.198085],[22.495447,42.197818],[22.495905,42.197645],[22.496457,42.197433],[22.497081,42.197118],[22.497809,42.196843],[22.498579,42.19671],[22.49913,42.196584],[22.499671,42.196497],[22.500087,42.196434],[22.500729,42.196348],[22.501408,42.19594],[22.50197,42.195515],[22.502204,42.195161],[22.502626,42.194595],[22.503047,42.194099],[22.503422,42.193639],[22.503609,42.193179],[22.503867,42.192595],[22.504171,42.19194],[22.504078,42.191515],[22.504171,42.190984],[22.503984,42.190524],[22.503422,42.189957],[22.503094,42.189639],[22.502579,42.189214],[22.502204,42.188895],[22.5019,42.188276],[22.501689,42.187833],[22.501479,42.18732],[22.501502,42.186648],[22.501642,42.186028],[22.501666,42.185409],[22.501689,42.184647],[22.501994,42.183497],[22.502157,42.183054],[22.502368,42.182559],[22.502649,42.181992],[22.503023,42.181284],[22.503492,42.180629],[22.504031,42.180081],[22.504405,42.179797],[22.504663,42.17932],[22.504851,42.178665],[22.505038,42.177957],[22.505179,42.177231],[22.505202,42.176718],[22.505272,42.176134],[22.505342,42.175638],[22.505342,42.175231],[22.505295,42.17477],[22.505342,42.174275],[22.505249,42.173708],[22.505108,42.173018],[22.505202,42.172292],[22.505108,42.171584],[22.505342,42.171053],[22.505413,42.170523],[22.50567,42.169814],[22.505811,42.169177],[22.506092,42.168682],[22.506513,42.168186],[22.506935,42.167726],[22.507544,42.167018],[22.507871,42.166557],[22.508293,42.166062],[22.508668,42.165637],[22.509183,42.165354],[22.509792,42.165035],[22.510448,42.164504],[22.510869,42.163832],[22.511337,42.163194],[22.511993,42.16238],[22.512321,42.162132],[22.512789,42.161778],[22.513352,42.160964],[22.514241,42.160221],[22.514803,42.159619],[22.515412,42.159088],[22.516021,42.158592],[22.516771,42.158061],[22.515506,42.157778],[22.514991,42.15753],[22.514148,42.157247],[22.513211,42.156787],[22.512649,42.156362],[22.511806,42.156008],[22.511056,42.155406],[22.510588,42.154309],[22.511384,42.15353],[22.51204,42.152928],[22.513117,42.152291],[22.513867,42.152008],[22.514616,42.151654],[22.514991,42.151477],[22.515553,42.150981],[22.516162,42.150627],[22.516864,42.150273],[22.51752,42.150061],[22.518129,42.149742],[22.518878,42.149423],[22.519721,42.148963],[22.520284,42.148715],[22.520986,42.148432],[22.521548,42.148184],[22.522204,42.147972],[22.522672,42.147724],[22.523328,42.147299],[22.52389,42.147052],[22.524218,42.146804],[22.524546,42.146414],[22.524757,42.145689],[22.524967,42.144998],[22.525295,42.144432],[22.525576,42.143901],[22.525717,42.143441],[22.526138,42.142733],[22.526513,42.142166],[22.526935,42.141671],[22.52745,42.141033],[22.527778,42.140467],[22.52834,42.139901],[22.529698,42.139228],[22.530869,42.138909],[22.531946,42.138662],[22.532836,42.138308],[22.533867,42.138024],[22.534663,42.137599],[22.535787,42.137316],[22.53663,42.137033],[22.537895,42.136626],[22.53855,42.13636],[22.539066,42.136183],[22.539487,42.136042],[22.540002,42.135936],[22.540471,42.135829],[22.541407,42.135652],[22.541969,42.135546],[22.542672,42.135475],[22.543515,42.13544],[22.544077,42.135298],[22.544827,42.135298],[22.545389,42.135298],[22.546513,42.135051],[22.547356,42.13498],[22.548012,42.134767],[22.54862,42.134449],[22.549323,42.133918],[22.549932,42.133351],[22.55026,42.132785],[22.550681,42.132219],[22.551243,42.131546],[22.551712,42.131121],[22.552227,42.130555],[22.552649,42.130094],[22.553304,42.129386],[22.554007,42.128855],[22.554756,42.128572],[22.555412,42.12836],[22.555974,42.128324],[22.55677,42.128183],[22.557286,42.127793],[22.557473,42.127192],[22.557707,42.126767],[22.558082,42.1262],[22.55855,42.125669],[22.558925,42.125315],[22.559393,42.125103],[22.559955,42.124961],[22.560752,42.124678],[22.56122,42.124572],[22.561922,42.124395],[22.562438,42.124218],[22.562766,42.123899],[22.563117,42.123262],[22.563421,42.122377],[22.563609,42.121881],[22.563796,42.121457],[22.564124,42.120784],[22.564499,42.120147],[22.564733,42.119722],[22.565107,42.119262],[22.565201,42.11866],[22.565857,42.118235],[22.566653,42.11781],[22.567871,42.117456],[22.568948,42.116925],[22.569932,42.116465],[22.570962,42.116111],[22.572039,42.115616],[22.572508,42.11512],[22.573117,42.114553],[22.574288,42.113668],[22.57499,42.113279],[22.575412,42.11289],[22.575927,42.112571],[22.576489,42.112252],[22.577051,42.11204],[22.577473,42.111721],[22.577988,42.111509],[22.578409,42.111226],[22.579346,42.110801],[22.580236,42.110412],[22.581126,42.109916],[22.582016,42.109597],[22.582859,42.109314],[22.583608,42.109031],[22.584545,42.108889],[22.585435,42.108996],[22.586419,42.109314],[22.587309,42.109562],[22.588339,42.109881],[22.589416,42.109987],[22.590259,42.109987],[22.590681,42.109987],[22.591243,42.10942],[22.591899,42.108854],[22.592461,42.108465],[22.593023,42.107934],[22.593491,42.107048],[22.5941,42.106128],[22.594615,42.105526],[22.595412,42.10496],[22.595646,42.104535],[22.595786,42.103969],[22.595786,42.10319],[22.595927,42.10273],[22.596583,42.102269],[22.597238,42.101809],[22.597894,42.101207],[22.598643,42.100676],[22.599159,42.10011],[22.599486,42.099685],[22.599955,42.098977],[22.60033,42.09834],[22.600611,42.09795],[22.601219,42.09788],[22.602437,42.097809],[22.603561,42.09788],[22.604451,42.097915],[22.605622,42.097915],[22.606372,42.097773],[22.606981,42.097384],[22.607683,42.096995],[22.608339,42.096818],[22.608807,42.096605],[22.609557,42.096357],[22.610212,42.096039],[22.61054,42.095685],[22.611055,42.095154],[22.612226,42.094481],[22.613257,42.094871],[22.614194,42.095225],[22.615037,42.095508],[22.616067,42.096039],[22.616957,42.096428],[22.617566,42.096747],[22.618034,42.096818],[22.619439,42.096322],[22.620704,42.096003],[22.622016,42.095508],[22.623514,42.095154],[22.624685,42.094871],[22.62609,42.094517],[22.62773,42.094198],[22.629041,42.09395],[22.630072,42.093809],[22.630727,42.093596],[22.63129,42.092906],[22.631711,42.09218],[22.632367,42.091472],[22.63314,42.090818],[22.633819,42.090445],[22.634147,42.090021],[22.634568,42.089596],[22.634896,42.089348],[22.635692,42.089065],[22.636582,42.088817],[22.637378,42.088817],[22.638081,42.088817],[22.638643,42.088428],[22.639533,42.087578],[22.640423,42.08687],[22.641125,42.086516],[22.641687,42.085702],[22.642203,42.085419],[22.642999,42.085242],[22.643748,42.085029],[22.64431,42.084746],[22.644779,42.084215],[22.6452,42.083755],[22.645716,42.082905],[22.646231,42.082162],[22.646746,42.081489],[22.647449,42.080852],[22.648479,42.080462],[22.649509,42.080427],[22.650353,42.080356],[22.650774,42.080179],[22.651102,42.079719],[22.651196,42.079259],[22.651055,42.078834],[22.650961,42.078409],[22.650727,42.077737],[22.650727,42.077206],[22.650961,42.07671],[22.651758,42.076214],[22.653022,42.075896],[22.654146,42.075435],[22.655083,42.075365],[22.656114,42.075188],[22.657612,42.074161],[22.658502,42.073772],[22.659158,42.073488],[22.660188,42.073241],[22.660704,42.073099],[22.6615,42.07278],[22.662109,42.072462],[22.662811,42.072108],[22.663561,42.071577],[22.664123,42.071187],[22.664732,42.070692],[22.665341,42.070302],[22.666465,42.069984],[22.667261,42.069984],[22.668151,42.070196],[22.668853,42.070409],[22.669509,42.070444],[22.670165,42.070161],[22.670821,42.069665],[22.671617,42.068992],[22.672554,42.06832],[22.673256,42.06747],[22.673397,42.066727],[22.673444,42.066302],[22.673912,42.065842],[22.674334,42.065452],[22.674755,42.065028],[22.675177,42.06478],[22.676113,42.064497],[22.67705,42.064178],[22.678268,42.064355],[22.678736,42.064497],[22.679205,42.064178],[22.679345,42.063753],[22.680001,42.06347],[22.681172,42.063293],[22.681921,42.063258],[22.682764,42.063293],[22.683467,42.063576],[22.684029,42.064143],[22.684685,42.064603],[22.685715,42.064072],[22.686511,42.063222],[22.687542,42.064213],[22.688244,42.064709],[22.688806,42.064709],[22.689837,42.064497],[22.690258,42.064355],[22.691055,42.064001],[22.692366,42.063612],[22.69349,42.063399],[22.694802,42.063541],[22.695785,42.063647],[22.696628,42.063576],[22.697425,42.063399],[22.698642,42.06347],[22.699486,42.063966],[22.700048,42.064532],[22.700891,42.064709],[22.701546,42.06478],[22.702343,42.065063],[22.703233,42.065205],[22.703982,42.065311],[22.704731,42.065417],[22.705481,42.0657],[22.706511,42.065877],[22.707542,42.065983],[22.708713,42.066337],[22.709603,42.066762],[22.710352,42.066975],[22.711336,42.06747],[22.712179,42.067647],[22.71335,42.067576],[22.714708,42.067399],[22.715738,42.067753],[22.716675,42.068178],[22.717331,42.068851],[22.717752,42.069382],[22.718876,42.070019],[22.718268,42.068638],[22.717752,42.068107],[22.717612,42.067222],[22.717659,42.066444],[22.717752,42.065452],[22.718033,42.064851],[22.71808,42.063859],[22.719111,42.063258],[22.719673,42.062797],[22.720328,42.06262],[22.721218,42.062337],[22.721921,42.061877],[22.722577,42.06131],[22.722998,42.060779],[22.723513,42.060036],[22.724544,42.058939],[22.725434,42.058868],[22.726277,42.058832],[22.727354,42.058868],[22.727916,42.058549],[22.728525,42.057947],[22.728525,42.057346],[22.728338,42.056602],[22.728244,42.055823],[22.728338,42.055292],[22.728619,42.054903],[22.72904,42.05462],[22.729555,42.054336],[22.730071,42.053805],[22.730726,42.05285],[22.730773,42.052106],[22.731242,42.051009],[22.73171,42.050372],[22.732272,42.049593],[22.73274,42.049062],[22.733021,42.04846],[22.73363,42.047787],[22.734567,42.047115],[22.735785,42.04669],[22.736769,42.046513],[22.73808,42.04623],[22.739064,42.045557],[22.740188,42.045061],[22.741499,42.044743],[22.742436,42.044601],[22.74342,42.044672],[22.744403,42.045097],[22.745153,42.045663],[22.746277,42.046336],[22.74726,42.046654],[22.748103,42.0463],[22.748759,42.046017],[22.749508,42.046123],[22.74993,42.0463],[22.750727,42.046531],[22.751195,42.046088],[22.751944,42.045274],[22.752834,42.044601],[22.754005,42.043929],[22.755129,42.043575],[22.756206,42.043362],[22.757518,42.043327],[22.758736,42.043504],[22.760141,42.043575],[22.761171,42.043327],[22.762155,42.04315],[22.762764,42.042973],[22.7637,42.042796],[22.764403,42.042513],[22.765387,42.042194],[22.766698,42.041734],[22.768056,42.041344],[22.769602,42.041026],[22.77082,42.040743],[22.771382,42.040566],[22.77171,42.040105],[22.771663,42.039326],[22.772881,42.03876],[22.774286,42.038548],[22.775691,42.038477],[22.77644,42.038406],[22.777283,42.038264],[22.777939,42.038158],[22.778829,42.038123],[22.778782,42.037167],[22.779532,42.036707],[22.780281,42.036601],[22.781592,42.036671],[22.78267,42.037061],[22.783934,42.037592],[22.784543,42.037946],[22.785293,42.037698],[22.786042,42.037273],[22.787447,42.037273],[22.788384,42.037344],[22.789742,42.037379],[22.79082,42.037592],[22.791756,42.037804],[22.792646,42.037981],[22.793208,42.038441],[22.79363,42.038902],[22.794098,42.039468],[22.794801,42.040105],[22.795316,42.040495],[22.795878,42.040813],[22.79644,42.04099],[22.797002,42.041097],[22.797377,42.041451],[22.797611,42.041946],[22.797705,42.042725],[22.797939,42.043539],[22.798173,42.044318],[22.798314,42.045132],[22.798641,42.045805],[22.799321,42.046354],[22.799842,42.045452],[22.800488,42.044204],[22.801207,42.043227],[22.802787,42.041436],[22.805803,42.038288],[22.808245,42.035519],[22.811405,42.031937],[22.815356,42.027975],[22.816648,42.026835],[22.818516,42.025261],[22.820168,42.024013],[22.821963,42.022873],[22.823759,42.022113],[22.825339,42.021353],[22.827637,42.020811],[22.829361,42.020539],[22.830725,42.020431],[22.831803,42.020376],[22.83288,42.020159],[22.834891,42.019996],[22.836687,42.019888],[22.837836,42.019834],[22.838769,42.019888],[22.840206,42.019996],[22.841858,42.020051],[22.843222,42.020214],[22.844874,42.020539],[22.84588,42.020756],[22.84667,42.021082],[22.847675,42.021733],[22.848825,42.022385],[22.849758,42.022982],[22.850548,42.023742],[22.851195,42.024176],[22.852344,42.024393],[22.85299,42.024556],[22.853421,42.024556],[22.854211,42.024501],[22.85457,42.02423],[22.855001,42.023362],[22.855791,42.022765],[22.856222,42.022276],[22.85694,42.021679],[22.858018,42.021353],[22.859526,42.021191],[22.860531,42.021191],[22.861465,42.021353],[22.862614,42.02157],[22.863476,42.021896],[22.864338,42.022113],[22.865056,42.022276],[22.865559,42.022276],[22.866062,42.021679],[22.866636,42.020648],[22.866995,42.019019],[22.867355,42.017988],[22.867498,42.01712],[22.86757,42.016414],[22.867498,42.015654],[22.867283,42.014949],[22.866852,42.0137],[22.866565,42.012778],[22.866277,42.011909],[22.865774,42.011149],[22.865487,42.010715],[22.864697,42.009955],[22.863907,42.009195],[22.863045,42.008436],[22.862183,42.007676],[22.861322,42.00697],[22.86046,42.006156],[22.859598,42.00545],[22.859239,42.005016],[22.859095,42.004582],[22.859167,42.003958],[22.859526,42.003279],[22.859957,42.002737],[22.860819,42.002628],[22.861752,42.002248],[22.863189,42.001922],[22.863979,42.001814],[22.864913,42.001542],[22.866277,42.001],[22.867355,42.000511],[22.86836,41.999914],[22.869294,41.999209],[22.869938,41.998809],[22.870717,41.998537],[22.871615,41.998039],[22.872393,41.997813],[22.873411,41.997677],[22.87407,41.997632],[22.874908,41.997542],[22.875327,41.99727],[22.875387,41.996501],[22.875387,41.995867],[22.875268,41.994962],[22.875088,41.994374],[22.874789,41.993876],[22.874369,41.993424],[22.87395,41.992745],[22.87383,41.992157],[22.87419,41.991659],[22.874609,41.991252],[22.874908,41.990799],[22.875148,41.990347],[22.874968,41.989759],[22.875148,41.98899],[22.874968,41.988401],[22.874848,41.987632],[22.874669,41.986863],[22.874609,41.986275],[22.874489,41.985686],[22.87407,41.985189],[22.87389,41.984533],[22.87431,41.983899],[22.874729,41.983288],[22.874489,41.9827],[22.87425,41.982112],[22.87407,41.981478],[22.87383,41.981071],[22.87383,41.980483],[22.87389,41.979804],[22.87395,41.978808],[22.87419,41.97813],[22.874669,41.977722],[22.875268,41.977541],[22.875866,41.977406],[22.876525,41.977179],[22.877184,41.976863],[22.877782,41.976546],[22.878022,41.976048],[22.877842,41.975143],[22.877483,41.974148],[22.877543,41.973424],[22.877303,41.972745],[22.876824,41.971976],[22.876345,41.971252],[22.875986,41.970618],[22.875806,41.97003],[22.876106,41.969397],[22.876405,41.968763],[22.876525,41.968084],[22.876525,41.967451],[22.876345,41.966998],[22.876405,41.96641],[22.876285,41.965596],[22.876285,41.964962],[22.876106,41.964102],[22.875926,41.963062],[22.875866,41.961976],[22.875747,41.961252],[22.875327,41.96012],[22.875148,41.959442],[22.874609,41.958763],[22.87431,41.95831],[22.87413,41.957632],[22.87401,41.956772],[22.873711,41.956003],[22.873411,41.955233],[22.873591,41.954419],[22.87401,41.954057],[22.874429,41.953514],[22.874549,41.952654],[22.874549,41.951795],[22.874549,41.951071],[22.874669,41.950392],[22.874609,41.949623],[22.874789,41.94908],[22.875088,41.948582],[22.875687,41.948265],[22.876046,41.948039],[22.876046,41.947496],[22.875268,41.947043],[22.874789,41.9465],[22.874429,41.946003],[22.8741,41.945324],[22.87431,41.944871],[22.874669,41.944645],[22.875148,41.944328],[22.876106,41.943966],[22.876824,41.94374],[22.877603,41.943514],[22.877782,41.943061],[22.877663,41.942156],[22.877423,41.941523],[22.877243,41.940889],[22.877004,41.940256],[22.876465,41.939713],[22.875806,41.93917],[22.875387,41.938763],[22.874848,41.938174],[22.874369,41.937541],[22.87383,41.937088],[22.873351,41.93641],[22.873531,41.935867],[22.87419,41.935505],[22.874908,41.935052],[22.875567,41.934465],[22.876226,41.933921],[22.876735,41.933627],[22.877184,41.933378],[22.877543,41.932926],[22.877902,41.932156],[22.878082,41.931478],[22.878381,41.930889],[22.878681,41.93012],[22.87886,41.929532],[22.87898,41.928989],[22.87904,41.928084],[22.8791,41.927224],[22.87916,41.926364],[22.879339,41.92564],[22.879878,41.925143],[22.880417,41.924781],[22.881016,41.924283],[22.881375,41.923695],[22.881914,41.923106],[22.882273,41.922563],[22.882812,41.921839],[22.883351,41.921296],[22.88395,41.920934],[22.884848,41.920753],[22.885926,41.920618],[22.886944,41.920482],[22.888201,41.920437],[22.889339,41.920301],[22.890297,41.920075],[22.891195,41.919577],[22.891494,41.918627],[22.891674,41.917812],[22.891913,41.917133],[22.892153,41.916681],[22.892752,41.9165],[22.89335,41.916409],[22.89359,41.915912],[22.894009,41.915097],[22.894249,41.914238],[22.894308,41.913537],[22.894009,41.91288],[22.89371,41.912473],[22.89335,41.911794],[22.89347,41.911251],[22.89353,41.910618],[22.89371,41.910165],[22.894129,41.909848],[22.894608,41.909532],[22.895027,41.90917],[22.895326,41.908717],[22.895506,41.908219],[22.895626,41.907676],[22.895985,41.907043],[22.896344,41.906409],[22.897003,41.905957],[22.897482,41.90564],[22.898081,41.905142],[22.89862,41.90469],[22.898979,41.904056],[22.899218,41.903468],[22.898979,41.902789],[22.89862,41.902246],[22.89838,41.901703],[22.898081,41.90116],[22.897662,41.900346],[22.897183,41.899667],[22.897003,41.899079],[22.896644,41.8984],[22.896943,41.897812],[22.897183,41.897269],[22.897362,41.896726],[22.897362,41.896047],[22.897123,41.895323],[22.897123,41.894871],[22.897602,41.894464],[22.898081,41.894011],[22.898799,41.893649],[22.899398,41.893197],[22.900236,41.892925],[22.900775,41.892473],[22.901314,41.891975],[22.901434,41.891568],[22.901015,41.89107],[22.900236,41.890663],[22.899518,41.890029],[22.899039,41.889305],[22.898859,41.888807],[22.898919,41.888129],[22.898799,41.887405],[22.898979,41.886862],[22.899278,41.886228],[22.899757,41.885866],[22.900057,41.885414],[22.900236,41.884916],[22.900296,41.884192],[22.900356,41.883423],[22.900536,41.883015],[22.900835,41.882699],[22.901254,41.882065],[22.901314,41.881477],[22.901075,41.880753],[22.901015,41.880119],[22.900955,41.87926],[22.901015,41.878355],[22.901374,41.877767],[22.901613,41.877405],[22.901733,41.876907],[22.901913,41.876454],[22.902332,41.876047],[22.902811,41.875957],[22.90341,41.875866],[22.904068,41.875821],[22.904787,41.875776],[22.905625,41.87573],[22.906164,41.875504],[22.906583,41.875459],[22.907182,41.875368],[22.907541,41.875685],[22.90808,41.876319],[22.908499,41.876862],[22.909098,41.877224],[22.909757,41.87745],[22.910655,41.877586],[22.911254,41.877586],[22.911793,41.877495],[22.912511,41.877088],[22.91311,41.876997],[22.913649,41.876907],[22.914397,41.876771],[22.915027,41.876424],[22.915385,41.876002],[22.915625,41.875504],[22.915962,41.875035],[22.916273,41.874653],[22.9167,41.874359],[22.917301,41.874192],[22.91802,41.87392],[22.918439,41.873558],[22.918738,41.873015],[22.918978,41.872518],[22.919217,41.871929],[22.919457,41.871341],[22.919936,41.870662],[22.920475,41.870029],[22.921253,41.869531],[22.921972,41.869033],[22.92251,41.86849],[22.922989,41.867947],[22.923768,41.867585],[22.924247,41.867042],[22.924486,41.866499],[22.924606,41.865775],[22.924786,41.865097],[22.924786,41.864599],[22.925145,41.863965],[22.925564,41.863649],[22.926343,41.863422],[22.927061,41.863151],[22.92754,41.862698],[22.92772,41.862291],[22.92748,41.861929],[22.927121,41.861477],[22.926822,41.860979],[22.926702,41.860481],[22.926762,41.859984],[22.927001,41.859531],[22.927241,41.859124],[22.9276,41.858671],[22.928109,41.858151],[22.928498,41.857585],[22.928738,41.857133],[22.929157,41.856635],[22.929815,41.856409],[22.930294,41.855866],[22.930534,41.855187],[22.930474,41.854418],[22.930354,41.853739],[22.930354,41.853287],[22.930534,41.852608],[22.930774,41.851929],[22.930893,41.851431],[22.931133,41.850888],[22.931312,41.850391],[22.931612,41.850029],[22.932211,41.849712],[22.932989,41.84944],[22.933228,41.848852],[22.933468,41.848354],[22.934007,41.847947],[22.934845,41.847766],[22.935564,41.847495],[22.936761,41.847404],[22.93712,41.847042],[22.936881,41.846544],[22.936402,41.845911],[22.936103,41.845277],[22.935803,41.844825],[22.935624,41.844191],[22.935564,41.843467],[22.935564,41.843015],[22.935744,41.842359],[22.936222,41.84202],[22.936701,41.841658],[22.93712,41.84116],[22.93724,41.840753],[22.937659,41.840052],[22.937779,41.839486],[22.938078,41.839078],[22.938438,41.83849],[22.938917,41.837811],[22.939336,41.837314],[22.939875,41.836703],[22.940054,41.836137],[22.939875,41.835594],[22.939815,41.835142],[22.939815,41.834599],[22.940054,41.834146],[22.940474,41.833784],[22.940833,41.833332],[22.941132,41.832789],[22.941611,41.832291],[22.941971,41.831748],[22.94227,41.831069],[22.942509,41.830617],[22.942749,41.829576],[22.942869,41.828897],[22.942929,41.828264],[22.942929,41.827766],[22.942749,41.827132],[22.942509,41.826544],[22.94227,41.826001],[22.941791,41.825096],[22.941432,41.824508],[22.941192,41.823784],[22.940953,41.823151],[22.940833,41.822562],[22.940713,41.821929],[22.940713,41.82125],[22.940773,41.820707],[22.940713,41.819938],[22.940653,41.81944],[22.940713,41.818942],[22.940593,41.818173],[22.940713,41.817359],[22.940893,41.81668],[22.941192,41.816001],[22.941611,41.815639],[22.94221,41.815141],[22.943048,41.814689],[22.943827,41.814327],[22.944605,41.813693],[22.945084,41.812969],[22.945204,41.812245],[22.945264,41.811069],[22.945563,41.810481],[22.945743,41.809666],[22.945982,41.808987],[22.946342,41.808173],[22.946461,41.807539],[22.946521,41.807132],[22.946761,41.806544],[22.94688,41.806046],[22.94718,41.805594],[22.947599,41.805232],[22.948437,41.804689],[22.949036,41.804417],[22.949635,41.80401],[22.950413,41.803558],[22.951072,41.803105],[22.95191,41.802788],[22.952509,41.802336],[22.952928,41.801883],[22.952928,41.80134],[22.952988,41.800707],[22.952988,41.800119],[22.952928,41.799621],[22.952988,41.799214],[22.953167,41.798625],[22.953467,41.797992],[22.953766,41.797404],[22.954066,41.796861],[22.954365,41.796363],[22.954724,41.795639],[22.955024,41.795005],[22.955563,41.794508],[22.955922,41.794055],[22.956521,41.793467],[22.957239,41.792879],[22.957658,41.792336],[22.958257,41.791747],[22.958856,41.791204],[22.959694,41.790707],[22.960293,41.790254],[22.96094,41.789927],[22.961601,41.789633],[22.962568,41.789304],[22.963406,41.789304],[22.964065,41.789349],[22.964544,41.789394],[22.964784,41.788987],[22.964844,41.788535],[22.964784,41.787992],[22.964724,41.787403],[22.964604,41.786725],[22.964544,41.786001],[22.964544,41.785367],[22.964424,41.784643],[22.964484,41.78401],[22.964664,41.783376],[22.964844,41.782743],[22.964903,41.782019],[22.965083,41.781431],[22.965203,41.780526],[22.965203,41.779802],[22.965143,41.779123],[22.964604,41.778444],[22.963766,41.777992],[22.963107,41.777539],[22.962448,41.777041],[22.962209,41.776408],[22.962508,41.77582],[22.962748,41.775277],[22.963107,41.774869],[22.963616,41.774055],[22.964005,41.773557],[22.964544,41.773286],[22.965263,41.773059],[22.965802,41.772833],[22.96652,41.772471],[22.967298,41.772064],[22.968137,41.771566],[22.969035,41.771068],[22.969694,41.770661],[22.970232,41.770435],[22.97125,41.770661],[22.97161,41.771114],[22.972268,41.771792],[22.972927,41.772109],[22.973945,41.772019],[22.974963,41.771702],[22.975981,41.77134],[22.976939,41.770933],[22.977717,41.770616],[22.979034,41.770344],[22.980052,41.770163],[22.980891,41.769756],[22.981968,41.769575],[22.983166,41.76953],[22.984304,41.769756],[22.984962,41.770073],[22.985741,41.770435],[22.98622,41.770933],[22.987118,41.771249],[22.987956,41.77143],[22.988734,41.771476],[22.989303,41.771408],[22.989513,41.770978],[22.989692,41.770571],[22.989932,41.770073],[22.990112,41.769485],[22.990471,41.768987],[22.99089,41.768444],[22.991309,41.767991],[22.991728,41.767675],[22.992207,41.767358],[22.992626,41.767177],[22.993704,41.767087],[22.994602,41.767177],[22.995321,41.767403],[22.99592,41.767494],[22.996459,41.767946],[22.997117,41.768444],[22.997776,41.768851],[22.998255,41.769168],[22.998734,41.769439],[22.999452,41.769666],[23.000291,41.769801],[23.001428,41.769485],[23.002147,41.769077],[23.003165,41.768715],[23.003858,41.768804],[23.004602,41.768896],[23.00568,41.768942],[23.006458,41.769123],[23.007296,41.769213],[23.008194,41.769168],[23.008434,41.76867],[23.008494,41.768127],[23.008673,41.767584],[23.008913,41.767041],[23.009272,41.766498],[23.009871,41.76582],[23.010111,41.765096],[23.01041,41.764145],[23.010505,41.763281],[23.010583,41.762517],[23.011009,41.761838],[23.011428,41.76134],[23.011847,41.761023],[23.012386,41.760752],[23.012565,41.760163],[23.012685,41.75962],[23.013104,41.759123],[23.013823,41.75867],[23.014541,41.758263],[23.01544,41.757856],[23.015859,41.757403],[23.015919,41.756724],[23.015978,41.756227],[23.015739,41.755593],[23.015679,41.755141],[23.015559,41.754688],[23.015889,41.754236],[23.015679,41.753534],[23.01532,41.752923],[23.01526,41.75238],[23.01508,41.751883],[23.01502,41.751385],[23.01514,41.750887],[23.01544,41.750344],[23.015859,41.750027],[23.016278,41.749801],[23.016757,41.749665],[23.017236,41.749484],[23.017535,41.749168],[23.017962,41.748674],[23.018541,41.748458],[23.019526,41.748373],[23.020453,41.74846],[23.021264,41.748245],[23.021786,41.74738],[23.022192,41.746774],[23.022308,41.746298],[23.022367,41.745692],[23.022599,41.745],[23.022947,41.744265],[23.023179,41.743443],[23.02347,41.742577],[23.023644,41.741798],[23.023877,41.740976],[23.023993,41.740067],[23.02411,41.739418],[23.024342,41.738899],[23.02469,41.73851],[23.025153,41.738034],[23.025849,41.737516],[23.026602,41.737127],[23.02695,41.736651],[23.02724,41.735873],[23.027472,41.735007],[23.027763,41.734142],[23.027995,41.733493],[23.028111,41.732801],[23.028343,41.732281],[23.028749,41.731719],[23.029155,41.731287],[23.029676,41.730768],[23.030256,41.730292],[23.030835,41.72999],[23.031298,41.729558],[23.031299,41.728562],[23.031068,41.727826],[23.031185,41.727134],[23.031301,41.726658],[23.031359,41.725835],[23.031649,41.725143],[23.032113,41.724365],[23.032866,41.723543],[23.033272,41.723024],[23.033678,41.722635],[23.03391,41.722203],[23.033621,41.72151],[23.033042,41.721076],[23.032464,41.720426],[23.032059,41.719906],[23.031422,41.719386],[23.031307,41.718953],[23.031365,41.718218],[23.031308,41.717612],[23.031309,41.717049],[23.031425,41.71653],[23.031657,41.71614],[23.031976,41.715297],[23.03189,41.714366],[23.032122,41.713587],[23.03218,41.712981],[23.032528,41.712203],[23.03305,41.711511],[23.033629,41.710862],[23.034035,41.71017],[23.034093,41.709391],[23.033573,41.708698],[23.032416,41.708134],[23.031606,41.70757],[23.030622,41.70718],[23.029754,41.707049],[23.029002,41.706745],[23.028482,41.705533],[23.028136,41.704537],[23.027847,41.703844],[23.027384,41.703194],[23.027038,41.702761],[23.02669,41.702544],[23.025938,41.702457],[23.024954,41.702629],[23.023854,41.702801],[23.022986,41.702886],[23.022465,41.702756],[23.022119,41.702366],[23.021598,41.701846],[23.020904,41.701196],[23.020268,41.700459],[23.01998,41.69994],[23.019575,41.69916],[23.019229,41.698467],[23.01894,41.697644],[23.018652,41.696908],[23.018189,41.696302],[23.017438,41.695738],[23.017033,41.695132],[23.016397,41.694482],[23.015646,41.693961],[23.014894,41.693181],[23.014547,41.692705],[23.013825,41.691925],[23.013276,41.691275],[23.01293,41.690409],[23.012583,41.689629],[23.012179,41.689023],[23.011427,41.688459],[23.01085,41.687852],[23.010503,41.687159],[23.009578,41.686552],[23.009116,41.686162],[23.008596,41.685556],[23.008423,41.684906],[23.008655,41.684473],[23.008771,41.683998],[23.008483,41.683218],[23.008021,41.682525],[23.007732,41.682092],[23.006864,41.682047],[23.005823,41.682003],[23.005071,41.682002],[23.004261,41.681654],[23.003625,41.681177],[23.003163,41.680398],[23.002586,41.679834],[23.001718,41.679444],[23.001429,41.67914],[23.000967,41.67849],[22.999984,41.678056],[22.999696,41.677753],[22.999291,41.677146],[22.998945,41.67667],[22.99773,41.676452],[22.997153,41.675628],[22.996749,41.674979],[22.996229,41.674545],[22.995419,41.674198],[22.99461,41.67372],[22.99409,41.673243],[22.993802,41.672637],[22.993456,41.671901],[22.993457,41.671295],[22.993168,41.670515],[22.992707,41.669562],[22.992014,41.668523],[22.991611,41.6677],[22.990976,41.666833],[22.990687,41.6664],[22.989936,41.666009],[22.990111,41.664797],[22.990228,41.663845],[22.988841,41.663497],[22.987858,41.663279],[22.987569,41.662543],[22.987571,41.661591],[22.987803,41.660899],[22.9874,41.660162],[22.987053,41.659902],[22.986418,41.659079],[22.985898,41.658558],[22.985494,41.658168],[22.983991,41.658036],[22.982487,41.657904],[22.981679,41.656994],[22.981507,41.655998],[22.981566,41.655176],[22.982088,41.654268],[22.983014,41.65362],[22.983767,41.652885],[22.98452,41.652367],[22.984579,41.651415],[22.98435,41.650246],[22.984351,41.649466],[22.984237,41.648557],[22.98418,41.648038],[22.983949,41.647561],[22.983025,41.647257],[22.982273,41.646996],[22.981695,41.646909],[22.980827,41.647513],[22.980537,41.648119],[22.980016,41.648464],[22.979437,41.64855],[22.978455,41.648332],[22.97753,41.648114],[22.976258,41.647679],[22.975681,41.647332],[22.975276,41.646985],[22.97464,41.646984],[22.974177,41.647243],[22.973656,41.647632],[22.972789,41.647587],[22.971864,41.647326],[22.970476,41.647281],[22.969666,41.647452],[22.968798,41.648187],[22.968046,41.648315],[22.966773,41.648357],[22.965386,41.648224],[22.963825,41.647919],[22.96238,41.647484],[22.961282,41.647135],[22.960531,41.646918],[22.96001,41.64683],[22.959836,41.647393],[22.959546,41.647955],[22.959025,41.648041],[22.958448,41.647304],[22.958276,41.646481],[22.958163,41.645572],[22.957933,41.644792],[22.957587,41.644229],[22.956547,41.643924],[22.955564,41.643749],[22.954755,41.643402],[22.954178,41.643098],[22.953658,41.642621],[22.952964,41.642663],[22.952155,41.642748],[22.951519,41.642574],[22.951115,41.64201],[22.951117,41.641231],[22.95083,41.640105],[22.950775,41.639066],[22.950777,41.638071],[22.950778,41.637378],[22.950896,41.636556],[22.950781,41.635906],[22.949974,41.634823],[22.949108,41.634085],[22.948474,41.633262],[22.948129,41.632569],[22.948073,41.631876],[22.948653,41.631011],[22.949753,41.630234],[22.950679,41.6295],[22.951722,41.628679],[22.952649,41.627469],[22.952882,41.626604],[22.953288,41.625825],[22.953348,41.625003],[22.953003,41.624094],[22.952427,41.62301],[22.952197,41.622317],[22.952835,41.62128],[22.953358,41.620242],[22.95417,41.619031],[22.954171,41.618295],[22.953653,41.617212],[22.953308,41.616389],[22.952905,41.615393],[22.953138,41.614614],[22.953429,41.613576],[22.9532,41.61258],[22.95222,41.61141],[22.951413,41.610586],[22.951067,41.610109],[22.9513,41.609287],[22.951418,41.608248],[22.951015,41.607295],[22.950671,41.606299],[22.951019,41.605391],[22.951484,41.604266],[22.951948,41.603358],[22.951142,41.602275],[22.950451,41.600888],[22.949991,41.599892],[22.949646,41.599026],[22.949994,41.598334],[22.949996,41.597381],[22.949826,41.595866],[22.950175,41.594871],[22.95064,41.593444],[22.950874,41.592102],[22.950935,41.590804],[22.951053,41.589635],[22.951518,41.588381],[22.952098,41.58717],[22.952563,41.586132],[22.953199,41.585527],[22.954586,41.585486],[22.956088,41.585489],[22.957532,41.585578],[22.959035,41.585364],[22.960365,41.584761],[22.96106,41.58342],[22.961062,41.582641],[22.961064,41.581818],[22.962567,41.580955],[22.963666,41.580221],[22.963609,41.579745],[22.964941,41.578492],[22.965809,41.577671],[22.965636,41.577065],[22.965291,41.576415],[22.964715,41.575721],[22.964889,41.575116],[22.96541,41.574424],[22.965932,41.573603],[22.966106,41.572954],[22.965935,41.572131],[22.965763,41.571525],[22.965706,41.570962],[22.965765,41.570226],[22.965998,41.569491],[22.966172,41.568885],[22.966289,41.568322],[22.966752,41.567587],[22.9671,41.566592],[22.967911,41.565468],[22.968779,41.564561],[22.969589,41.563956],[22.970283,41.563481],[22.971207,41.56331],[22.972218,41.563376],[22.972421,41.562792],[22.97248,41.562013],[22.972423,41.561364],[22.972309,41.560887],[22.972714,41.560239],[22.972888,41.559806],[22.9726,41.559373],[22.972082,41.558766],[22.97139,41.558072],[22.970987,41.557336],[22.970584,41.556599],[22.970181,41.556123],[22.969893,41.555516],[22.969779,41.55504],[22.969433,41.554606],[22.968914,41.554238],[22.968916,41.55309],[22.969322,41.552009],[22.969382,41.55084],[22.969442,41.549629],[22.969271,41.548546],[22.969099,41.54807],[22.969504,41.547291],[22.969737,41.546296],[22.969854,41.545863],[22.969856,41.544738],[22.969743,41.543591],[22.969455,41.542963],[22.968763,41.542659],[22.968243,41.542528],[22.967261,41.542743],[22.96576,41.542956],[22.964432,41.542997],[22.963278,41.542692],[22.961893,41.54243],[22.960796,41.542342],[22.959988,41.542081],[22.960111,41.538445],[22.959997,41.537796],[22.959075,41.537145],[22.958904,41.535976],[22.958675,41.535066],[22.958445,41.53433],[22.958909,41.533595],[22.959545,41.53286],[22.959431,41.532167],[22.95978,41.531172],[22.960301,41.530221],[22.960765,41.529097],[22.961692,41.527237],[22.962388,41.525507],[22.962901,41.52459],[22.963835,41.523431],[22.964818,41.522611],[22.96557,41.521616],[22.966091,41.521098],[22.966726,41.520839],[22.967419,41.520667],[22.967824,41.520278],[22.968344,41.51976],[22.968807,41.518982],[22.969501,41.51829],[22.970311,41.517469],[22.970889,41.516778],[22.970718,41.515998],[22.970776,41.515435],[22.971066,41.514917],[22.970894,41.514224],[22.970434,41.513487],[22.970032,41.512188],[22.969977,41.510716],[22.969979,41.50972],[22.970154,41.509028],[22.969578,41.508075],[22.96935,41.506819],[22.969411,41.505261],[22.969413,41.504092],[22.969126,41.503486],[22.967511,41.502704],[22.96659,41.502053],[22.965322,41.501272],[22.963881,41.500663],[22.962267,41.499925],[22.961575,41.499707],[22.96146,41.499101],[22.960822,41.4985],[22.960246,41.497893],[22.959727,41.497198],[22.959497,41.496591],[22.959324,41.496027],[22.958748,41.495462],[22.958114,41.494811],[22.957711,41.494204],[22.957711,41.49377],[22.958289,41.493249],[22.958981,41.492772],[22.959789,41.492381],[22.960482,41.492077],[22.961001,41.49147],[22.961002,41.490862],[22.960541,41.490472],[22.960138,41.489734],[22.95985,41.48904],[22.960139,41.488389],[22.960428,41.487607],[22.960775,41.48674],[22.961122,41.485568],[22.961527,41.484656],[22.961816,41.483571],[22.961759,41.482573],[22.961298,41.481792],[22.961415,41.481011],[22.961588,41.480013],[22.961532,41.479188],[22.961359,41.478364],[22.961302,41.477496],[22.961476,41.476845],[22.962464,41.476275],[22.963784,41.475847],[22.96511,41.475413],[22.966034,41.474805],[22.966899,41.474414],[22.967245,41.474154],[22.967015,41.47346],[22.966785,41.472852],[22.966382,41.472158],[22.966152,41.471203],[22.966037,41.470335],[22.965808,41.468773],[22.965751,41.468295],[22.96506,41.467427],[22.964426,41.466212],[22.964138,41.465865],[22.964139,41.465388],[22.96437,41.464954],[22.964716,41.464042],[22.965467,41.462827],[22.965756,41.461786],[22.96616,41.461004],[22.96668,41.460267],[22.967489,41.459434],[22.968714,41.458484],[22.970091,41.457361],[22.971354,41.45644],[22.972923,41.455375],[22.974377,41.454367],[22.975218,41.45393],[22.97591,41.453192],[22.976635,41.452006],[22.977209,41.450999],[22.977872,41.449981],[22.97832,41.449012],[22.979026,41.448288],[22.97943,41.447507],[22.979373,41.446595],[22.979163,41.4455],[22.978934,41.444607],[22.978338,41.443818],[22.977589,41.442863],[22.977243,41.442169],[22.976552,41.441561],[22.975515,41.441128],[22.974593,41.44065],[22.97412,41.439829],[22.973623,41.439052],[22.973039,41.438177],[22.972521,41.437135],[22.971945,41.43605],[22.970966,41.434965],[22.970218,41.433794],[22.969469,41.432926],[22.969041,41.43197],[22.968354,41.43079],[22.96736,41.430876],[22.966289,41.43102],[22.96518,41.43128],[22.964492,41.431423],[22.963689,41.431308],[22.963116,41.430992],[22.962543,41.430301],[22.961855,41.429811],[22.961435,41.429466],[22.960748,41.428832],[22.959831,41.427998],[22.958986,41.42685],[22.958122,41.425678],[22.957579,41.424744],[22.95651,41.423219],[22.955556,41.421923],[22.954678,41.420714],[22.953762,41.41962],[22.953113,41.418785],[22.95254,41.418256],[22.952599,41.417475],[22.9526,41.416651],[22.952658,41.416087],[22.952947,41.415132],[22.953409,41.41422],[22.954159,41.412962],[22.954343,41.412049],[22.95531,41.411392],[22.956195,41.410921],[22.95734,41.410373],[22.95885,41.409746],[22.960047,41.409158],[22.960847,41.408362],[22.960905,41.407581],[22.960503,41.406583],[22.960504,41.405802],[22.961023,41.404934],[22.961191,41.404103],[22.961613,41.403125],[22.962351,41.402113],[22.962761,41.400678],[22.963563,41.399466],[22.964139,41.398116],[22.96479,41.396878],[22.965409,41.395863],[22.96567,41.395064],[22.966044,41.394388],[22.966092,41.393509],[22.96552,41.392531],[22.965176,41.391869],[22.964528,41.391034],[22.964108,41.390285],[22.963802,41.389614],[22.9634,41.388659],[22.963343,41.387531],[22.962826,41.386012],[22.962597,41.384753],[22.962138,41.383582],[22.962023,41.38267],[22.961909,41.381195],[22.961826,41.379777],[22.96217,41.378568],[22.962745,41.377215],[22.963124,41.376074],[22.963297,41.375162],[22.963414,41.37347],[22.963415,41.371994],[22.963704,41.370822],[22.963302,41.369868],[22.963325,41.368982],[22.963517,41.368176],[22.964129,41.367197],[22.96455,41.366506],[22.964856,41.365815],[22.965091,41.36505],[22.964804,41.364313],[22.964747,41.363358],[22.964806,41.36262],[22.964749,41.361839],[22.96475,41.360884],[22.964808,41.360016],[22.964809,41.359192],[22.964752,41.35828],[22.964638,41.357282],[22.964753,41.356674],[22.964754,41.35585],[22.964582,41.355069],[22.96441,41.354418],[22.964104,41.353502],[22.963376,41.353189],[22.962701,41.352954],[22.961661,41.352836],[22.960726,41.352601],[22.959322,41.352522],[22.958282,41.352483],[22.957139,41.352522],[22.956047,41.352561],[22.954279,41.352482],[22.952824,41.352482],[22.9522,41.352443],[22.951576,41.352561],[22.951004,41.352404],[22.950381,41.352051],[22.949966,41.351384],[22.949239,41.350718],[22.9482,41.349856],[22.94685,41.348797],[22.945896,41.347849],[22.945019,41.346899],[22.944098,41.346327],[22.943059,41.3457],[22.941968,41.344916],[22.940878,41.344092],[22.939943,41.343348],[22.93932,41.342681],[22.938438,41.341936],[22.937659,41.341387],[22.936724,41.340838],[22.935633,41.340564],[22.934385,41.340602],[22.933186,41.340628],[22.932649,41.340708],[22.931458,41.340925],[22.928802,41.341091],[22.927894,41.340346],[22.927568,41.339683],[22.927367,41.339274],[22.926277,41.338965],[22.921499,41.339601],[22.916249,41.340982],[22.914066,41.341167],[22.903375,41.340237],[22.896403,41.338611],[22.889895,41.339773],[22.885248,41.34047],[22.877346,41.34047],[22.871303,41.34047],[22.864098,41.34047],[22.857126,41.338378],[22.852013,41.338611],[22.844576,41.338611],[22.838534,41.337913],[22.833886,41.337216],[22.830167,41.335822],[22.82273,41.334195],[22.815758,41.339075],[22.812504,41.343491],[22.807623,41.34047],[22.805764,41.338378],[22.80193,41.338829],[22.7967,41.33954],[22.796003,41.337216],[22.796235,41.334195],[22.792284,41.330709],[22.788798,41.328152],[22.784771,41.32681],[22.782523,41.326061],[22.780199,41.32699],[22.769044,41.326061],[22.763001,41.32211],[22.75998,41.314673],[22.757423,41.309095],[22.75737,41.307923],[22.757191,41.303982],[22.758121,41.299566],[22.762536,41.296545],[22.76486,41.291897],[22.763001,41.287481],[22.759515,41.282136],[22.756726,41.275628],[22.760445,41.267959],[22.758585,41.260057],[22.758585,41.250761],[22.756494,41.242161],[22.755099,41.231936],[22.755099,41.218456],[22.752775,41.204744],[22.752078,41.193356],[22.748824,41.179644],[22.7465,41.16384],[22.742782,41.15803],[22.735809,41.149431],[22.727443,41.145712],[22.717682,41.143388],[22.713963,41.141529],[22.711872,41.140367],[22.704202,41.143853],[22.698159,41.150128],[22.692117,41.155241],[22.684447,41.161981],[22.67794,41.169418],[22.672361,41.177321],[22.666087,41.18313],[22.656326,41.183362],[22.650283,41.179876],[22.645403,41.174763],[22.642614,41.168256],[22.642149,41.160819],[22.635177,41.152452],[22.622859,41.138973],[22.616817,41.131768],[22.61316,41.129627],[22.607288,41.12619],[22.5959,41.120148],[22.587534,41.117126],[22.577307,41.118056],[22.569173,41.121774],[22.564061,41.126887],[22.561504,41.130606],[22.552208,41.130374],[22.538263,41.129676],[22.525713,41.128282],[22.508747,41.125958],[22.492247,41.122704],[22.47807,41.120612],[22.469935,41.11945],[22.465287,41.117126],[22.457618,41.120148],[22.450413,41.12131],[22.443906,41.118986],[22.436701,41.118986],[22.430891,41.119915],[22.423919,41.119683],[22.416714,41.118753],[22.413228,41.122704],[22.406256,41.126887],[22.401375,41.129211],[22.401608,41.133162],[22.403699,41.136416],[22.398819,41.138508],[22.393706,41.135951],[22.389522,41.132465],[22.382085,41.132233],[22.377669,41.135022],[22.372324,41.13781],[22.368606,41.137578],[22.364887,41.13386],[22.35838,41.133627],[22.352802,41.135486],[22.349316,41.135022],[22.343506,41.131535],[22.336998,41.129211],[22.334442,41.128049],[22.334674,41.122007],[22.331421,41.119683],[22.326772,41.122472],[22.325378,41.128747],[22.325378,41.135951],[22.323286,41.139902],[22.321427,41.144783],[22.323286,41.149663],[22.322589,41.151058],[22.315849,41.148734],[22.312363,41.146642],[22.304926,41.146874],[22.296095,41.151755],[22.288193,41.153382],[22.281453,41.154079],[22.274946,41.155706],[22.272157,41.160354],[22.2696,41.16384],[22.261234,41.164537],[22.249846,41.165932],[22.242408,41.165002],[22.235901,41.163375],[22.230091,41.165002],[22.22521,41.165235],[22.22033,41.166861],[22.216146,41.168721],[22.215615,41.16878],[22.214055,41.168953],[22.210801,41.165467],[22.207315,41.162446],[22.204061,41.160819],[22.197321,41.160819],[22.188258,41.161748],[22.180356,41.158495],[22.172221,41.157798],[22.16827,41.153382],[22.16339,41.146874],[22.158509,41.140135],[22.154791,41.137346],[22.151769,41.133395],[22.148284,41.128747],[22.141544,41.125958],[22.134107,41.125261],[22.130156,41.125028],[22.123416,41.124796],[22.116444,41.129676],[22.108542,41.13386],[22.102267,41.135022],[22.097154,41.136648],[22.092273,41.136648],[22.087393,41.139205],[22.08042,41.143156],[22.078097,41.14641],[22.079491,41.149431],[22.077399,41.152917],[22.073448,41.155241],[22.068568,41.156403],[22.065081,41.159657],[22.061363,41.161284],[22.060666,41.155706],[22.059504,41.150593],[22.054856,41.147572],[22.050672,41.147572],[22.045792,41.145945],[22.041841,41.142459],[22.034172,41.136881],[22.030221,41.134092],[22.023713,41.132233],[22.013255,41.130838],[22.005353,41.129909],[22,41.12712],[21.991176,41.126887],[21.984436,41.127352],[21.978161,41.127817],[21.974443,41.129211],[21.970957,41.125028],[21.964681,41.119683],[21.958871,41.116661],[21.954456,41.115964],[21.950969,41.113175],[21.945159,41.109689],[21.93656,41.107133],[21.929588,41.103647],[21.927817,41.101928],[21.921686,41.095977],[21.916108,41.093653],[21.911925,41.092956],[21.910763,41.086448],[21.908992,41.081726],[21.908672,41.080871],[21.90565,41.073899],[21.905883,41.068321],[21.909136,41.061581],[21.910763,41.054609],[21.911925,41.05089],[21.910298,41.048334],[21.904721,41.042756],[21.897516,41.03927],[21.892403,41.039502],[21.887058,41.040432],[21.883339,41.040664],[21.882177,41.037411],[21.884269,41.031833],[21.883571,41.028114],[21.877994,41.02672],[21.874275,41.024163],[21.871486,41.022304],[21.864049,41.02091],[21.859866,41.016029],[21.851964,41.012543],[21.847316,41.004409],[21.849175,41.000225],[21.845224,40.996972],[21.838019,40.99395],[21.828956,40.989767],[21.821751,40.987908],[21.814779,40.985816],[21.808272,40.980006],[21.804321,40.976985],[21.801067,40.973266],[21.800137,40.965829],[21.800602,40.960716],[21.802926,40.9563],[21.80525,40.951652],[21.802461,40.946539],[21.801299,40.944215],[21.79944,40.940264],[21.793397,40.939335],[21.791306,40.936313],[21.789214,40.933292],[21.787239,40.931665],[21.785263,40.930038],[21.777361,40.929341],[21.768297,40.928876],[21.762022,40.92632],[21.753656,40.926785],[21.747381,40.928876],[21.738317,40.929573],[21.731112,40.930271],[21.723675,40.934919],[21.716703,40.93794],[21.710196,40.941194],[21.705547,40.942356],[21.698575,40.941426],[21.688582,40.941194],[21.683469,40.93887],[21.681609,40.934222],[21.675799,40.929109],[21.671151,40.92539],[21.667665,40.920974],[21.666038,40.917953],[21.668594,40.914235],[21.671151,40.90796],[21.671151,40.902847],[21.669989,40.90029],[21.668827,40.898198],[21.659763,40.899825],[21.654418,40.899825],[21.648143,40.900058],[21.643727,40.898663],[21.639079,40.895642],[21.633733,40.895642],[21.631874,40.890994],[21.62862,40.88774],[21.623508,40.88774],[21.620021,40.887508],[21.616535,40.884254],[21.613281,40.881697],[21.610028,40.879141],[21.607936,40.879141],[21.603753,40.879838],[21.601894,40.876817],[21.599105,40.872866],[21.598175,40.870077],[21.593992,40.867056],[21.591435,40.866591],[21.585857,40.868915],[21.580047,40.866591],[21.574934,40.865894],[21.570983,40.866126],[21.56773,40.868218],[21.565871,40.871704],[21.564476,40.874493],[21.558898,40.877282],[21.553088,40.880303],[21.54844,40.884719],[21.544257,40.890064],[21.539609,40.893318],[21.535658,40.899128],[21.532404,40.903079],[21.529847,40.906565],[21.526361,40.908657],[21.521248,40.908657],[21.515903,40.908192],[21.505658,40.909974],[21.505212,40.910051],[21.497543,40.911213],[21.493127,40.911213],[21.489641,40.911213],[21.481274,40.909819],[21.474069,40.907262],[21.4664,40.90703],[21.461055,40.907262],[21.455244,40.910284],[21.449202,40.912608],[21.4413,40.915164],[21.431539,40.916791],[21.422475,40.917256],[21.416897,40.917023],[21.409228,40.912143],[21.400164,40.905868],[21.389706,40.899825],[21.380177,40.892156],[21.373437,40.885881],[21.362746,40.878211],[21.351358,40.877049],[21.343456,40.873331],[21.335322,40.871704],[21.326491,40.869845],[21.308595,40.865894],[21.301158,40.865429],[21.291397,40.865197],[21.284657,40.864499],[21.27815,40.86357],[21.273967,40.864964],[21.265135,40.862175],[21.25886,40.858224],[21.252585,40.861246],[21.251191,40.864499],[21.245613,40.869148],[21.239066,40.874262],[21.238176,40.874958],[21.230042,40.877049],[21.222372,40.878909],[21.211914,40.882627],[21.204244,40.882627],[21.197505,40.877514],[21.187279,40.876585],[21.179377,40.87612],[21.17194,40.872401],[21.168918,40.867288],[21.162876,40.863337],[21.157763,40.859619],[21.147769,40.856365],[21.135452,40.854971],[21.127317,40.854971],[21.111514,40.854041],[21.093851,40.853344],[21.079442,40.854738],[21.058525,40.854273],[21.043883,40.854041],[21.029474,40.854971],[21.008093,40.854971],[20.983611,40.855833],[20.980567,40.855222],[20.979573,40.863074],[20.978747,40.87209],[20.977976,40.879527],[20.977282,40.886209],[20.977282,40.887782],[20.977109,40.890009],[20.977282,40.891712],[20.977802,40.893678],[20.97851,40.895478],[20.979337,40.897174],[20.979016,40.89787],[20.977976,40.899049],[20.976589,40.899836],[20.974258,40.901549],[20.972131,40.902888],[20.971305,40.903602],[20.970596,40.904316],[20.970347,40.905011],[20.969651,40.90628],[20.96896,40.909007],[20.968007,40.910383],[20.96714,40.910907],[20.964972,40.911496],[20.960638,40.910972],[20.959598,40.911889],[20.956824,40.915427],[20.956477,40.915689],[20.955263,40.916803],[20.95405,40.917392],[20.952663,40.918047],[20.951969,40.918571],[20.950582,40.91962],[20.947635,40.92224],[20.946421,40.922764],[20.944608,40.922616],[20.942434,40.922109],[20.941567,40.923026],[20.940006,40.924074],[20.938273,40.924336],[20.936712,40.924467],[20.934213,40.923866],[20.932087,40.922973],[20.931378,40.922616],[20.929488,40.921545],[20.928044,40.92093],[20.926653,40.920741],[20.924576,40.92093],[20.923016,40.921061],[20.919028,40.922306],[20.916774,40.923026],[20.915734,40.923288],[20.914174,40.92224],[20.912596,40.920473],[20.912005,40.919045],[20.911769,40.917706],[20.911746,40.915755],[20.908712,40.916344],[20.906198,40.916737],[20.903164,40.917196],[20.901691,40.917392],[20.898396,40.918113],[20.896229,40.918703],[20.894322,40.92034],[20.892328,40.922175],[20.891375,40.922961],[20.888341,40.92355],[20.88574,40.924402],[20.883399,40.925123],[20.875858,40.927612],[20.866322,40.930756],[20.85748,40.93377],[20.851498,40.935735],[20.847154,40.937345],[20.844083,40.934132],[20.838929,40.928988],[20.837022,40.926891],[20.835721,40.925057],[20.834074,40.922764],[20.83208,40.919685],[20.829908,40.916813],[20.828353,40.914248],[20.827573,40.913003],[20.827746,40.909728],[20.827573,40.907893],[20.827399,40.906976],[20.826359,40.905338],[20.825232,40.904683],[20.822805,40.903832],[20.820291,40.90239],[20.816043,40.89977],[20.815523,40.899377],[20.814315,40.898603],[20.812489,40.897543],[20.810669,40.896822],[20.807895,40.896232],[20.804947,40.896167],[20.801133,40.89656],[20.797839,40.897346],[20.794285,40.898525],[20.790644,40.900098],[20.788477,40.900753],[20.78709,40.901146],[20.785356,40.901539],[20.783795,40.90167],[20.781021,40.901932],[20.780068,40.901801],[20.778854,40.901342],[20.77686,40.901408],[20.775127,40.902063],[20.773913,40.902849],[20.773393,40.902587],[20.760823,40.901211],[20.759523,40.901015],[20.757789,40.901146],[20.753628,40.902587],[20.752935,40.90298],[20.750763,40.904851],[20.749818,40.905119],[20.748774,40.905076],[20.747928,40.905119],[20.737071,40.9094],[20.73239,40.9113],[20.731696,40.911693],[20.725888,40.928267],[20.720774,40.943203],[20.717913,40.951196],[20.715139,40.959057],[20.708551,40.978317],[20.70485,40.989241],[20.702344,40.998573],[20.702106,40.9997],[20.701986,41.000602],[20.701696,41.002126],[20.701268,41.004029],[20.701032,41.0051],[20.700567,41.007441],[20.70019,41.00901],[20.697276,41.016166],[20.693796,41.025296],[20.689627,41.036324],[20.683216,41.052822],[20.676598,41.070327],[20.671295,41.083423],[20.66972,41.087268],[20.654092,41.086821],[20.632189,41.086373],[20.630907,41.086738],[20.629691,41.087788],[20.628128,41.08792],[20.627259,41.087657],[20.62639,41.087657],[20.626043,41.088051],[20.620136,41.088445],[20.615967,41.08897],[20.613535,41.089233],[20.602242,41.091202],[20.597204,41.092121],[20.595641,41.092515],[20.594425,41.094353],[20.59373,41.09606],[20.593382,41.097372],[20.593209,41.098554],[20.592645,41.10042],[20.591817,41.101673],[20.589908,41.104199],[20.587997,41.105644],[20.586607,41.106825],[20.585565,41.107482],[20.585043,41.108269],[20.583647,41.110173],[20.582611,41.111945],[20.582264,41.113389],[20.582611,41.114308],[20.58487,41.116146],[20.585912,41.116409],[20.58626,41.117328],[20.587128,41.118116],[20.587823,41.118772],[20.587997,41.120348],[20.588865,41.121267],[20.588865,41.122054],[20.587997,41.122973],[20.587997,41.123892],[20.589213,41.124418],[20.593593,41.125383],[20.594772,41.125993],[20.595467,41.126649],[20.596509,41.127175],[20.596857,41.127831],[20.596336,41.13177],[20.595013,41.133256],[20.593474,41.134777],[20.593209,41.135314],[20.594077,41.136365],[20.594425,41.13689],[20.593556,41.137546],[20.590429,41.138597],[20.590429,41.139384],[20.590776,41.139778],[20.590603,41.141747],[20.589734,41.14306],[20.588865,41.143848],[20.588518,41.144242],[20.586086,41.14713],[20.58487,41.147918],[20.583654,41.148443],[20.583132,41.148968],[20.58209,41.151988],[20.582227,41.15294],[20.582785,41.156058],[20.582438,41.156977],[20.578675,41.160276],[20.578094,41.16039],[20.577136,41.160992],[20.576705,41.161572],[20.575489,41.163804],[20.574446,41.165051],[20.573751,41.16551],[20.573404,41.165773],[20.57323,41.166429],[20.57323,41.166955],[20.572361,41.167217],[20.571667,41.167874],[20.570972,41.168267],[20.569756,41.168465],[20.569234,41.168793],[20.569756,41.169712],[20.569582,41.170368],[20.568887,41.170893],[20.568713,41.171812],[20.567546,41.173071],[20.566976,41.173519],[20.56577,41.175129],[20.564717,41.177195],[20.563501,41.178902],[20.562455,41.179602],[20.559679,41.181396],[20.558463,41.182446],[20.55829,41.183103],[20.558984,41.183497],[20.559853,41.184416],[20.559853,41.187041],[20.560201,41.187567],[20.560548,41.18796],[20.559853,41.189667],[20.559679,41.190586],[20.558637,41.191768],[20.558637,41.193081],[20.558116,41.193606],[20.5569,41.193606],[20.555684,41.193081],[20.555162,41.192424],[20.554167,41.191144],[20.553812,41.190876],[20.551681,41.191591],[20.549951,41.192555],[20.549256,41.193343],[20.548735,41.193606],[20.547866,41.193475],[20.546353,41.19517],[20.544459,41.196512],[20.542654,41.196888],[20.541618,41.196602],[20.541786,41.194919],[20.53779,41.195313],[20.537095,41.197151],[20.535879,41.198332],[20.534836,41.198726],[20.534663,41.199514],[20.53362,41.199382],[20.533273,41.199776],[20.531536,41.202665],[20.531536,41.204765],[20.531536,41.205553],[20.532057,41.206538],[20.531536,41.208113],[20.532057,41.208835],[20.531883,41.209754],[20.531536,41.210411],[20.531188,41.21133],[20.530841,41.212249],[20.529451,41.21343],[20.529103,41.214218],[20.528582,41.215137],[20.528235,41.216056],[20.527055,41.216554],[20.526324,41.217106],[20.524934,41.217894],[20.523892,41.218682],[20.523544,41.219075],[20.523197,41.219469],[20.523023,41.220782],[20.52337,41.22157],[20.523023,41.222489],[20.522676,41.223671],[20.522154,41.224327],[20.521807,41.225377],[20.521286,41.226428],[20.520765,41.227215],[20.520243,41.22774],[20.519375,41.228134],[20.518854,41.228266],[20.518332,41.228266],[20.517811,41.228528],[20.517464,41.229447],[20.516595,41.230235],[20.515727,41.23076],[20.515379,41.231679],[20.515205,41.232467],[20.515379,41.232992],[20.515727,41.233648],[20.516248,41.234173],[20.516769,41.234699],[20.516943,41.235486],[20.516595,41.23693],[20.516248,41.237587],[20.5164,41.238385],[20.516992,41.239458],[20.516769,41.239819],[20.516943,41.240607],[20.519375,41.243364],[20.521286,41.245595],[20.521459,41.246383],[20.520938,41.246908],[20.520243,41.247565],[20.519027,41.248221],[20.518506,41.249403],[20.51868,41.249928],[20.517116,41.252028],[20.516248,41.253341],[20.516074,41.253867],[20.514858,41.255311],[20.514337,41.256361],[20.51451,41.257017],[20.51451,41.258462],[20.514858,41.259118],[20.516074,41.259906],[20.515553,41.260431],[20.514337,41.260693],[20.513294,41.262006],[20.512426,41.26345],[20.512078,41.264369],[20.511905,41.265288],[20.512252,41.265814],[20.512493,41.266837],[20.512426,41.26752],[20.512426,41.268308],[20.512138,41.269342],[20.512078,41.27054],[20.512078,41.271196],[20.511664,41.272205],[20.511072,41.273726],[20.510717,41.276857],[20.510599,41.277484],[20.510688,41.278023],[20.51121,41.278942],[20.512252,41.279993],[20.512773,41.280386],[20.512947,41.281043],[20.513294,41.281962],[20.513816,41.282618],[20.51451,41.283537],[20.514684,41.284719],[20.51415,41.285983],[20.514163,41.286688],[20.51451,41.287082],[20.513914,41.287504],[20.510717,41.289204],[20.509415,41.289831],[20.508777,41.291283],[20.508777,41.292596],[20.508604,41.293121],[20.507735,41.293909],[20.507214,41.295484],[20.507214,41.296797],[20.507214,41.297585],[20.508083,41.298767],[20.508777,41.299292],[20.509299,41.299423],[20.509296,41.301015],[20.509472,41.301918],[20.508256,41.302968],[20.506693,41.304149],[20.506928,41.305935],[20.50704,41.3073],[20.507047,41.308888],[20.50704,41.310451],[20.506573,41.311483],[20.504087,41.314521],[20.501246,41.317656],[20.500265,41.318985],[20.49947,41.320251],[20.498878,41.321414],[20.498701,41.322267],[20.498875,41.323711],[20.49957,41.326074],[20.499396,41.327125],[20.498701,41.327781],[20.497485,41.328438],[20.496443,41.3287],[20.495748,41.328831],[20.495053,41.328831],[20.493663,41.32975],[20.493316,41.330407],[20.4921,41.331457],[20.491419,41.33224],[20.491057,41.332901],[20.492447,41.333164],[20.493489,41.333426],[20.493837,41.334608],[20.494532,41.335264],[20.497485,41.336446],[20.498875,41.337628],[20.498875,41.338415],[20.497833,41.339072],[20.497311,41.339597],[20.496964,41.341829],[20.497102,41.343066],[20.496964,41.343929],[20.497659,41.345374],[20.498759,41.346376],[20.500091,41.346555],[20.502311,41.346734],[20.503732,41.346019],[20.505824,41.34498],[20.506345,41.344455],[20.507388,41.343798],[20.508256,41.343273],[20.50982,41.342485],[20.511383,41.341697],[20.511905,41.340778],[20.513121,41.339597],[20.515553,41.337365],[20.516248,41.336709],[20.51729,41.336709],[20.520591,41.338284],[20.521846,41.34074],[20.524569,41.34244],[20.525753,41.343066],[20.526582,41.343961],[20.5267,41.346108],[20.526498,41.347212],[20.527366,41.348262],[20.526937,41.353892],[20.52895,41.354966],[20.532146,41.356576],[20.533099,41.357189],[20.535224,41.35756],[20.536764,41.358276],[20.537269,41.35929],[20.537442,41.360472],[20.536747,41.361522],[20.536574,41.362441],[20.536574,41.362966],[20.537829,41.364181],[20.540222,41.366248],[20.540396,41.366642],[20.540396,41.367824],[20.540743,41.368349],[20.543512,41.369371],[20.544565,41.370318],[20.545406,41.372234],[20.546824,41.372813],[20.548387,41.373206],[20.551167,41.376357],[20.551688,41.377801],[20.551688,41.379114],[20.550971,41.379928],[20.548366,41.381718],[20.546476,41.383053],[20.545608,41.384234],[20.545781,41.384891],[20.54665,41.385416],[20.54804,41.385679],[20.549082,41.386335],[20.550298,41.388436],[20.550124,41.389617],[20.549951,41.390668],[20.551167,41.391455],[20.551688,41.392768],[20.552209,41.393425],[20.552383,41.394737],[20.552035,41.39605],[20.552209,41.396707],[20.553078,41.398413],[20.554989,41.400777],[20.555684,41.401039],[20.556552,41.401433],[20.557768,41.401564],[20.559022,41.401938],[20.561153,41.402833],[20.560201,41.407341],[20.560027,41.408391],[20.558984,41.412592],[20.5569,41.414037],[20.557247,41.416794],[20.556031,41.417319],[20.551862,41.419682],[20.550646,41.420338],[20.548213,41.421914],[20.545086,41.423489],[20.542307,41.425196],[20.541438,41.42559],[20.538485,41.427034],[20.539353,41.428478],[20.539701,41.429135],[20.540396,41.433336],[20.540048,41.43478],[20.539527,41.43583],[20.538658,41.436355],[20.537269,41.436618],[20.536053,41.436026],[20.529897,41.436384],[20.52893,41.435699],[20.527714,41.436093],[20.527366,41.436618],[20.526845,41.436618],[20.525976,41.436749],[20.524934,41.437931],[20.523023,41.438587],[20.520765,41.438325],[20.519201,41.438062],[20.517985,41.437143],[20.516769,41.437406],[20.516074,41.437931],[20.515032,41.438325],[20.514163,41.437668],[20.513121,41.437668],[20.512252,41.440163],[20.511557,41.44095],[20.509651,41.442289],[20.508951,41.442788],[20.508083,41.444101],[20.508083,41.445677],[20.50843,41.446596],[20.509178,41.447389],[20.510167,41.447909],[20.511383,41.448959],[20.511905,41.449747],[20.512252,41.450666],[20.511557,41.451585],[20.510862,41.452372],[20.510862,41.453423],[20.510341,41.453817],[20.509472,41.454473],[20.50843,41.455129],[20.507735,41.456967],[20.507735,41.457755],[20.506866,41.459068],[20.506172,41.46025],[20.505477,41.461563],[20.504955,41.462875],[20.504608,41.463532],[20.504608,41.464057],[20.503913,41.465239],[20.503566,41.466289],[20.50235,41.467339],[20.502176,41.468258],[20.502523,41.468915],[20.50235,41.470096],[20.50235,41.471146],[20.50235,41.472328],[20.503218,41.474166],[20.503044,41.475479],[20.502176,41.476267],[20.50235,41.477186],[20.501655,41.477842],[20.501481,41.478367],[20.50096,41.479155],[20.500439,41.480205],[20.500091,41.481124],[20.498878,41.48282],[20.497931,41.48443],[20.497485,41.485457],[20.496273,41.487651],[20.495922,41.488082],[20.495748,41.488739],[20.495053,41.489658],[20.494358,41.490446],[20.493663,41.491365],[20.492621,41.492021],[20.491057,41.492809],[20.489494,41.493203],[20.48793,41.493465],[20.487062,41.493597],[20.485498,41.493728],[20.484108,41.493728],[20.482371,41.494384],[20.481676,41.495828],[20.480807,41.497273],[20.479591,41.497929],[20.478896,41.498192],[20.47736,41.498135],[20.475943,41.497404],[20.475212,41.496872],[20.4739,41.496422],[20.472348,41.496241],[20.470439,41.496512],[20.469246,41.497053],[20.468888,41.497684],[20.468647,41.498585],[20.469168,41.499898],[20.469843,41.501381],[20.470559,41.502102],[20.471275,41.502463],[20.472468,41.502914],[20.472945,41.503274],[20.4739,41.504086],[20.474257,41.504627],[20.474854,41.505348],[20.475689,41.505799],[20.476405,41.50616],[20.47724,41.506971],[20.477002,41.507512],[20.476644,41.507963],[20.476167,41.508234],[20.475451,41.508324],[20.473661,41.508775],[20.473068,41.509124],[20.471633,41.509496],[20.471036,41.509766],[20.469962,41.509857],[20.46865,41.509586],[20.467456,41.509135],[20.466144,41.508775],[20.464951,41.508504],[20.463996,41.508504],[20.462803,41.508684],[20.462087,41.509135],[20.461491,41.509676],[20.460775,41.510307],[20.45982,41.510758],[20.458746,41.511119],[20.457315,41.51166],[20.455764,41.512562],[20.45457,41.513553],[20.453735,41.514635],[20.453735,41.515447],[20.453616,41.516619],[20.453377,41.517341],[20.4529,41.518062],[20.452423,41.518873],[20.452661,41.520136],[20.453377,41.521849],[20.454451,41.523562],[20.455406,41.524374],[20.45636,41.525095],[20.457076,41.525365],[20.458031,41.526087],[20.458508,41.526808],[20.459462,41.52789],[20.460059,41.528431],[20.460655,41.528702],[20.461729,41.528882],[20.46328,41.528882],[20.466144,41.528702],[20.468769,41.528972],[20.469723,41.529243],[20.471036,41.529874],[20.47199,41.531317],[20.472587,41.531767],[20.473124,41.532399],[20.472945,41.534292],[20.472348,41.535464],[20.471871,41.537177],[20.471333,41.539437],[20.470818,41.541602],[20.47032,41.541956],[20.470081,41.542497],[20.469604,41.542858],[20.469008,41.543038],[20.46853,41.543129],[20.468053,41.54367],[20.467814,41.544842],[20.467337,41.545112],[20.465428,41.545383],[20.463996,41.545653],[20.462445,41.545924],[20.461849,41.546555],[20.461849,41.547276],[20.462445,41.548719],[20.462087,41.54926],[20.46111,41.549565],[20.459582,41.549801],[20.458746,41.549801],[20.458031,41.549981],[20.457434,41.550703],[20.457076,41.551244],[20.456778,41.552236],[20.456838,41.553183],[20.457911,41.553949],[20.459701,41.555031],[20.460536,41.555391],[20.461371,41.555662],[20.461968,41.555932],[20.463042,41.556383],[20.463833,41.556544],[20.465017,41.55717],[20.466502,41.557736],[20.467576,41.558096],[20.468292,41.558187],[20.469127,41.558457],[20.47032,41.558998],[20.471275,41.558998],[20.47211,41.558908],[20.473064,41.559088],[20.4739,41.558908],[20.474854,41.558547],[20.476264,41.558512],[20.478553,41.558908],[20.480223,41.558728],[20.481947,41.558691],[20.484552,41.559139],[20.485354,41.559088],[20.486666,41.558367],[20.488098,41.558006],[20.490007,41.559088],[20.492632,41.56026],[20.49466,41.561162],[20.496808,41.561703],[20.498837,41.561974],[20.501461,41.562244],[20.503848,41.562785],[20.504444,41.562966],[20.507308,41.564138],[20.508501,41.564318],[20.512558,41.563777],[20.514506,41.563433],[20.5164,41.563344],[20.518166,41.563326],[20.520552,41.564679],[20.522103,41.56558],[20.523535,41.56558],[20.524609,41.56558],[20.526518,41.567294],[20.527114,41.567925],[20.528427,41.569187],[20.529978,41.570179],[20.532006,41.57099],[20.534512,41.572253],[20.537614,41.574507],[20.541194,41.576761],[20.542029,41.577753],[20.542864,41.578204],[20.543699,41.578294],[20.544176,41.577933],[20.54517,41.577838],[20.546709,41.577928],[20.548233,41.578655],[20.550262,41.580007],[20.550739,41.580548],[20.552171,41.580638],[20.553722,41.580909],[20.556585,41.58172],[20.557659,41.582171],[20.557301,41.582802],[20.556943,41.583343],[20.556585,41.584516],[20.556705,41.585327],[20.556705,41.586409],[20.556347,41.587491],[20.556108,41.588663],[20.555989,41.590016],[20.55575,41.591008],[20.555631,41.59236],[20.555273,41.592991],[20.55396,41.594254],[20.553244,41.595426],[20.552887,41.596328],[20.553125,41.597861],[20.553364,41.598311],[20.554796,41.600385],[20.554915,41.600836],[20.554796,41.601648],[20.554438,41.602369],[20.552648,41.604082],[20.551932,41.604533],[20.551335,41.604984],[20.55062,41.605525],[20.549784,41.605976],[20.549307,41.606246],[20.547995,41.606877],[20.547637,41.607599],[20.547279,41.60841],[20.546921,41.609853],[20.547159,41.612648],[20.54704,41.614091],[20.546682,41.614992],[20.546086,41.615533],[20.54525,41.616345],[20.544773,41.616886],[20.544176,41.617788],[20.543461,41.618329],[20.542864,41.618599],[20.542446,41.619231],[20.542267,41.619862],[20.541015,41.620538],[20.542267,41.621124],[20.543461,41.621485],[20.543699,41.622026],[20.543699,41.622747],[20.543222,41.623017],[20.542387,41.623378],[20.541671,41.623919],[20.539404,41.626534],[20.538091,41.628337],[20.535944,41.630141],[20.535705,41.630772],[20.535228,41.631133],[20.533557,41.632215],[20.53141,41.633387],[20.529381,41.634018],[20.527472,41.634559],[20.52604,41.63492],[20.525205,41.6351],[20.524489,41.636182],[20.524489,41.636903],[20.525086,41.637625],[20.526398,41.639248],[20.527234,41.64051],[20.527234,41.642674],[20.527353,41.644658],[20.527234,41.64601],[20.527472,41.646912],[20.527114,41.647543],[20.526398,41.648805],[20.525981,41.649798],[20.526518,41.650969],[20.5267,41.65192],[20.526463,41.652278],[20.524012,41.654576],[20.523535,41.654847],[20.521149,41.656921],[20.520671,41.657371],[20.520075,41.658363],[20.517927,41.660257],[20.516972,41.661429],[20.516615,41.661699],[20.516615,41.662331],[20.517569,41.663322],[20.518524,41.664585],[20.519597,41.665396],[20.520433,41.666839],[20.521626,41.669454],[20.522103,41.670265],[20.523296,41.671618],[20.523535,41.672339],[20.523773,41.67297],[20.524332,41.67393],[20.525043,41.675451],[20.525753,41.676704],[20.525921,41.677659],[20.52616,41.679282],[20.527114,41.682438],[20.528665,41.685684],[20.529501,41.688028],[20.52962,41.689561],[20.529381,41.689922],[20.52795,41.690643],[20.527592,41.692537],[20.527711,41.694521],[20.527711,41.695242],[20.528069,41.696324],[20.527711,41.697496],[20.527711,41.698668],[20.527234,41.700021],[20.527234,41.701373],[20.527472,41.702816],[20.527472,41.704169],[20.526821,41.705903],[20.526518,41.706513],[20.524847,41.707595],[20.5227,41.709669],[20.521864,41.711292],[20.52091,41.712735],[20.520075,41.713546],[20.518046,41.714989],[20.516972,41.716071],[20.516495,41.717694],[20.516137,41.719677],[20.515779,41.720489],[20.515541,41.721481],[20.514467,41.722292],[20.51399,41.722833],[20.514228,41.723374],[20.514348,41.724096],[20.514944,41.724997],[20.514586,41.725629],[20.514467,41.726711],[20.514586,41.728875],[20.514944,41.731039],[20.515063,41.73185],[20.515183,41.732481],[20.516376,41.733293],[20.51745,41.733744],[20.518882,41.734736],[20.518882,41.735998],[20.518882,41.73708],[20.519001,41.739064],[20.519239,41.740236],[20.519478,41.741228],[20.519478,41.74231],[20.519001,41.743301],[20.518762,41.744564],[20.518882,41.746097],[20.51912,41.7479],[20.519597,41.748982],[20.519478,41.749884],[20.519239,41.750515],[20.519478,41.751236],[20.520075,41.751777],[20.521864,41.752769],[20.523177,41.754031],[20.524131,41.755204],[20.524847,41.757638],[20.525444,41.759351],[20.526756,41.761245],[20.528069,41.762958],[20.529381,41.764761],[20.530694,41.766745],[20.53141,41.767557],[20.533557,41.768368],[20.534512,41.768999],[20.535347,41.770442],[20.535824,41.772065],[20.535824,41.773057],[20.53487,41.773868],[20.53262,41.775346],[20.532126,41.776123],[20.532126,41.776754],[20.53308,41.777565],[20.535343,41.778433],[20.538211,41.779369],[20.540552,41.779596],[20.542802,41.779506],[20.543699,41.77991],[20.544534,41.78027],[20.545489,41.781443],[20.546324,41.782525],[20.547279,41.784779],[20.547159,41.787213],[20.546443,41.790099],[20.549784,41.789738],[20.553602,41.789107],[20.557301,41.788295],[20.561597,41.787123],[20.563386,41.786492],[20.565653,41.785951],[20.56804,41.785951],[20.569113,41.786221],[20.570784,41.787213],[20.571738,41.788385],[20.572335,41.789107],[20.572574,41.790549],[20.572812,41.791902],[20.572163,41.793553],[20.572282,41.794895],[20.572574,41.795599],[20.573647,41.797042],[20.573702,41.797937],[20.571738,41.799115],[20.571022,41.799566],[20.570545,41.799837],[20.56971,41.801279],[20.568848,41.804021],[20.568636,41.805878],[20.568375,41.808763],[20.567682,41.813452],[20.567443,41.815346],[20.567204,41.816428],[20.566599,41.817531],[20.565415,41.819321],[20.563983,41.820846],[20.561239,41.822559],[20.560403,41.82319],[20.559568,41.824002],[20.559807,41.825354],[20.560642,41.826617],[20.561477,41.829682],[20.561716,41.831756],[20.561597,41.835092],[20.561477,41.836174],[20.561716,41.836986],[20.56281,41.838736],[20.563386,41.840683],[20.563625,41.843208],[20.563267,41.845913],[20.562193,41.84988],[20.560797,41.854215],[20.560087,41.858599],[20.559732,41.861551],[20.559449,41.863495],[20.559449,41.864758],[20.560679,41.868351],[20.561271,41.869067],[20.563864,41.869356],[20.56625,41.870258],[20.568278,41.87116],[20.569471,41.871971],[20.570187,41.873143],[20.571261,41.874225],[20.573702,41.874972],[20.576189,41.87524],[20.580806,41.875688],[20.586653,41.875668],[20.588801,41.875939],[20.59059,41.876119],[20.592595,41.876729],[20.594286,41.877328],[20.595498,41.876498],[20.596918,41.874679],[20.604113,41.86781],[20.614341,41.860423],[20.619247,41.85779],[20.621271,41.857759],[20.626132,41.860092],[20.632018,41.861113],[20.636405,41.863531],[20.640047,41.867188],[20.648426,41.874532],[20.663353,41.875274],[20.670554,41.873412],[20.67848,41.86853],[20.680439,41.863216],[20.681196,41.861449],[20.681272,41.859588],[20.682007,41.85948],[20.682283,41.858614],[20.682822,41.857886],[20.683482,41.857728],[20.684867,41.857641],[20.686769,41.858739],[20.689175,41.859352],[20.690157,41.859435],[20.691567,41.859976],[20.693181,41.860019],[20.694901,41.860851],[20.696489,41.861315],[20.697895,41.862468],[20.700824,41.862894],[20.701927,41.863765],[20.70361,41.863541],[20.705931,41.864659],[20.717191,41.864417],[20.727972,41.864277],[20.735815,41.877156],[20.736036,41.878017],[20.73607,41.878594],[20.736391,41.87911],[20.736574,41.879766],[20.736744,41.880622],[20.736848,41.881757],[20.736728,41.882335],[20.736373,41.883292],[20.736732,41.883928],[20.736831,41.884655],[20.736559,41.885012],[20.736634,41.885478],[20.736679,41.885912],[20.736351,41.886396],[20.736557,41.886757],[20.73686,41.887112],[20.737482,41.888159],[20.737733,41.88855],[20.738074,41.889362],[20.738834,41.890466],[20.739197,41.890881],[20.739465,41.891383],[20.739816,41.891751],[20.740466,41.892799],[20.741131,41.893456],[20.742592,41.893449],[20.743992,41.89374],[20.746578,41.894569],[20.749706,41.894863],[20.75149,41.896491],[20.751678,41.897318],[20.751792,41.898238],[20.752542,41.899063],[20.752653,41.899575],[20.752642,41.900119],[20.752871,41.900603],[20.753253,41.900993],[20.753578,41.90159],[20.753912,41.902803],[20.75416,41.903838],[20.754671,41.904497],[20.754833,41.904888],[20.755432,41.905389],[20.755637,41.905894],[20.756019,41.906228],[20.756779,41.906386],[20.757362,41.906676],[20.758349,41.907384],[20.759306,41.908298],[20.76081,41.909307],[20.762374,41.910161],[20.763579,41.910972],[20.764787,41.911509],[20.766748,41.912233],[20.768139,41.913814],[20.768814,41.9144],[20.769524,41.914887],[20.769726,41.915334],[20.770425,41.91562],[20.771373,41.916143],[20.772112,41.916358],[20.772786,41.916549],[20.774224,41.917369],[20.775222,41.917742],[20.776524,41.918485],[20.775889,41.918849],[20.775577,41.919348],[20.772157,41.921073],[20.770593,41.924497],[20.770185,41.925516],[20.771041,41.925886],[20.772742,41.926313],[20.772944,41.926758],[20.771541,41.927194],[20.770646,41.927643],[20.770224,41.927944],[20.769692,41.9289],[20.768829,41.929123],[20.768341,41.930004],[20.768054,41.930321],[20.767612,41.931015],[20.76736,41.931707],[20.766856,41.932439],[20.766646,41.933001],[20.765849,41.933878],[20.765134,41.934813],[20.764529,41.93508],[20.763525,41.935762],[20.76328,41.936156],[20.763023,41.936784],[20.762675,41.937428],[20.762352,41.937963],[20.762394,41.938898],[20.761705,41.939516],[20.761092,41.940114],[20.76061,41.940362],[20.76021,41.940684],[20.759583,41.941305],[20.758758,41.941953],[20.758353,41.942441],[20.758192,41.943229],[20.757262,41.943948],[20.757123,41.944694],[20.755742,41.945659],[20.754785,41.946846],[20.755764,41.947464],[20.756832,41.94827],[20.757467,41.948857],[20.757457,41.949168],[20.757903,41.950084],[20.758864,41.950578],[20.759059,41.951067],[20.759608,41.951168],[20.761215,41.951936],[20.763253,41.952512],[20.764228,41.952923],[20.765232,41.953225],[20.766032,41.953625],[20.766188,41.954552],[20.766405,41.954902],[20.766411,41.955482],[20.766541,41.956241],[20.766561,41.957578],[20.766635,41.958032],[20.766933,41.958718],[20.767207,41.959715],[20.767208,41.960274],[20.767162,41.960904],[20.767009,41.961655],[20.767132,41.962188],[20.767117,41.962759],[20.766455,41.963023],[20.766082,41.963254],[20.764785,41.964461],[20.76377,41.96631],[20.763736,41.966954],[20.763537,41.967587],[20.762622,41.969023],[20.762374,41.969363],[20.761707,41.969972],[20.760958,41.970548],[20.760477,41.970817],[20.760189,41.971171],[20.760015,41.971603],[20.758509,41.973656],[20.757889,41.974893],[20.75772,41.975602],[20.757132,41.976339],[20.756433,41.976997],[20.755985,41.977301],[20.755262,41.978509],[20.754197,41.979681],[20.753577,41.980129],[20.752628,41.980627],[20.750982,41.981186],[20.750405,41.981567],[20.749895,41.981755],[20.7496,41.982244],[20.748761,41.982377],[20.749243,41.982676],[20.749382,41.983099],[20.749313,41.983546],[20.748884,41.984139],[20.748171,41.985954],[20.748157,41.986594],[20.748207,41.988273],[20.748328,41.989234],[20.748329,41.990135],[20.748072,41.991457],[20.748311,41.993215],[20.748262,41.995418],[20.748685,41.996756],[20.749253,41.997712],[20.749211,41.998169],[20.74931,41.99881],[20.749585,41.999814],[20.7496,42.000268],[20.749451,42.000931],[20.749107,42.001267],[20.749421,42.0017],[20.749636,42.003304],[20.750115,42.004533],[20.749981,42.006416],[20.750099,42.007271],[20.750708,42.009013],[20.751035,42.010518],[20.751267,42.012519],[20.751662,42.013865],[20.751832,42.014706],[20.751899,42.01528],[20.751444,42.015282],[20.750897,42.015494],[20.750652,42.015887],[20.750756,42.016399],[20.750511,42.016782],[20.75058,42.017186],[20.750525,42.017974],[20.750561,42.018706],[20.74986,42.019096],[20.749467,42.019468],[20.749378,42.020358],[20.749511,42.021055],[20.749901,42.021526],[20.749647,42.0219],[20.749662,42.022358],[20.749554,42.02299],[20.749432,42.023611],[20.749078,42.023901],[20.748331,42.024324],[20.748142,42.024829],[20.748154,42.025705],[20.748371,42.026662],[20.748751,42.027008],[20.749936,42.027804],[20.751128,42.028418],[20.75133,42.028833],[20.751677,42.029189],[20.752851,42.029764],[20.753254,42.030232],[20.753567,42.03084],[20.753546,42.031268],[20.754283,42.032958],[20.75463,42.033339],[20.755724,42.034378],[20.757261,42.035688],[20.758023,42.036481],[20.758595,42.037226],[20.759382,42.037858],[20.759662,42.038229],[20.761113,42.038887],[20.761726,42.039653],[20.763551,42.040833],[20.763604,42.041471],[20.763913,42.042788],[20.763843,42.043692],[20.765071,42.045305],[20.763981,42.044996],[20.763405,42.044918],[20.762995,42.04498],[20.761898,42.045672],[20.760699,42.046673],[20.760117,42.047456],[20.759398,42.048147],[20.75892,42.048975],[20.758989,42.049803],[20.758906,42.050969],[20.758643,42.052291],[20.758158,42.05337],[20.758977,42.053654],[20.760129,42.053849],[20.76103,42.054547],[20.763387,42.055559],[20.763689,42.055853],[20.765131,42.056825],[20.766328,42.057292],[20.766896,42.057608],[20.768795,42.05811],[20.769291,42.058347],[20.771288,42.059602],[20.773131,42.061526],[20.776312,42.06414],[20.778624,42.064778],[20.778681,42.065425],[20.778499,42.066],[20.778461,42.066422],[20.778575,42.066828],[20.778857,42.067143],[20.780193,42.068122],[20.78244,42.070272],[20.78326,42.070912],[20.785078,42.07154],[20.785986,42.071754],[20.785522,42.072332],[20.785,42.072619],[20.784608,42.07294],[20.784356,42.073329],[20.784342,42.073759],[20.783924,42.074582],[20.78382,42.075273],[20.783939,42.075685],[20.784155,42.076666],[20.784126,42.077099],[20.784353,42.077689],[20.784447,42.078473],[20.784648,42.078892],[20.790843,42.083138],[20.792807,42.083652],[20.79407,42.083666],[20.795754,42.083441],[20.79676,42.083185],[20.797486,42.08307],[20.797929,42.082876],[20.798535,42.082954],[20.799633,42.083239],[20.80015,42.083022],[20.800417,42.082653],[20.80102,42.082153],[20.802024,42.081745],[20.802593,42.081637],[20.803182,42.081746],[20.804224,42.082134],[20.804815,42.08224],[20.807779,42.082541],[20.808368,42.082567],[20.809938,42.082294],[20.812503,42.082511],[20.81403,42.082809],[20.816628,42.083521],[20.818812,42.083821],[20.820754,42.084208],[20.82581,42.084053],[20.827156,42.084636],[20.82852,42.085473],[20.82901,42.085613],[20.829586,42.085594],[20.83013,42.085437],[20.83131,42.085436],[20.832462,42.0856],[20.834145,42.085969],[20.834501,42.086299],[20.835001,42.08708],[20.835883,42.088365],[20.835711,42.089069],[20.83593,42.089452],[20.83668,42.089751],[20.837065,42.090121],[20.837715,42.090937],[20.837886,42.091448],[20.83864,42.092012],[20.840043,42.093973],[20.840441,42.094278],[20.840477,42.094789],[20.841274,42.095983],[20.841596,42.096301],[20.841989,42.097034],[20.841664,42.097316],[20.842465,42.097916],[20.843424,42.098641],[20.844188,42.098541],[20.84477,42.098524],[20.845698,42.098597],[20.846601,42.098792],[20.848167,42.099401],[20.849558,42.09904],[20.851747,42.098661],[20.853891,42.098064],[20.855658,42.098241],[20.857488,42.098658],[20.859124,42.099082],[20.860632,42.09965],[20.861412,42.098714],[20.867315,42.098037],[20.869125,42.098065],[20.869612,42.097951],[20.87046,42.097506],[20.871143,42.097296],[20.872778,42.097251],[20.874885,42.096916],[20.875812,42.09648],[20.87668,42.096433],[20.877151,42.096208],[20.878152,42.096307],[20.879077,42.096191],[20.880387,42.096192],[20.882106,42.096739],[20.883204,42.096347],[20.883699,42.096086],[20.884235,42.096168],[20.885322,42.097015],[20.88753,42.096439],[20.88927,42.096787],[20.889988,42.097179],[20.891542,42.097442],[20.891703,42.097862],[20.892858,42.099217],[20.895199,42.100674],[20.896086,42.101477],[20.89715,42.103578],[20.89842,42.104946],[20.901878,42.106711],[20.90478,42.108455],[20.905105,42.109056],[20.905874,42.109547],[20.906411,42.110257],[20.907127,42.110958],[20.907752,42.111742],[20.908425,42.112448],[20.9093,42.112866],[20.909873,42.113393],[20.91234,42.114577],[20.913875,42.114901],[20.914487,42.115211],[20.914951,42.11666],[20.915312,42.116859],[20.915958,42.11762],[20.916611,42.118587],[20.916809,42.119201],[20.916823,42.119639],[20.916446,42.120544],[20.916334,42.121076],[20.916584,42.122392],[20.916697,42.123059],[20.918684,42.124499],[20.91921,42.124989],[20.919362,42.125527],[20.919408,42.127391],[20.920008,42.128584],[20.920842,42.127977],[20.921351,42.127747],[20.923542,42.12702],[20.924439,42.12685],[20.926221,42.126985],[20.927939,42.127327],[20.928452,42.127646],[20.929225,42.12839],[20.929622,42.128838],[20.929887,42.129369],[20.930403,42.129864],[20.931657,42.130672],[20.932253,42.130694],[20.933141,42.131083],[20.933754,42.131195],[20.934162,42.131432],[20.935209,42.132446],[20.935728,42.132671],[20.935935,42.132943],[20.937753,42.13391],[20.938495,42.134477],[20.94035,42.135648],[20.941025,42.136385],[20.941389,42.137028],[20.941919,42.137296],[20.9428,42.137434],[20.944823,42.138091],[20.945505,42.137775],[20.946066,42.137615],[20.947825,42.137411],[20.948629,42.137198],[20.951724,42.138058],[20.954255,42.137888],[20.955298,42.137137],[20.956526,42.136442],[20.95728,42.136402],[20.959981,42.136493],[20.960778,42.136293],[20.96171,42.13627],[20.96324,42.136804],[20.964396,42.136301],[20.965524,42.136205],[20.96636,42.136269],[20.967491,42.136464],[20.968219,42.136369],[20.9693,42.136473],[20.970367,42.136796],[20.970606,42.137138],[20.971757,42.137866],[20.972271,42.138524],[20.972722,42.138867],[20.973139,42.138878],[20.974669,42.138955],[20.975982,42.139229],[20.976421,42.139163],[20.977058,42.139179],[20.97839,42.139552],[20.979567,42.139764],[20.980346,42.139346],[20.981002,42.139098],[20.982079,42.139012],[20.982608,42.139063],[20.983526,42.139416],[20.983673,42.139855],[20.985037,42.141021],[20.986308,42.142226],[20.987353,42.142586],[20.988064,42.14256],[20.989565,42.143014],[20.990307,42.143281],[20.991193,42.143756],[20.991726,42.143761],[20.992545,42.143545],[20.993819,42.143785],[20.994812,42.143885],[20.995739,42.144911],[20.996807,42.145105],[20.997391,42.145193],[20.999053,42.145085],[20.999448,42.144974],[21.000606,42.145186],[21.001144,42.145307],[21.001935,42.145662],[21.002925,42.146285],[21.003827,42.146761],[21.004467,42.147208],[21.005664,42.147586],[21.006685,42.148122],[21.008798,42.15008],[21.009231,42.150506],[21.010748,42.150136],[21.013188,42.150241],[21.015269,42.150438],[21.016647,42.150464],[21.017169,42.150675],[21.019239,42.150803],[21.01981,42.151092],[21.020427,42.151516],[21.021765,42.151971],[21.0227,42.152034],[21.024656,42.151892],[21.026438,42.152253],[21.026781,42.152495],[21.026986,42.153028],[21.027449,42.153347],[21.027508,42.153686],[21.027849,42.154683],[21.028338,42.15522],[21.028148,42.155989],[21.028579,42.156342],[21.030305,42.156634],[21.031621,42.157052],[21.032006,42.157251],[21.032719,42.157744],[21.033574,42.158585],[21.033864,42.159212],[21.034961,42.159644],[21.036846,42.160794],[21.037591,42.161074],[21.041649,42.163806],[21.042288,42.164571],[21.042857,42.164912],[21.043251,42.166094],[21.043896,42.165649],[21.044739,42.165343],[21.04519,42.165277],[21.046737,42.16528],[21.048503,42.1657],[21.04884,42.166005],[21.049344,42.166253],[21.051473,42.170171],[21.051922,42.170457],[21.052297,42.17081],[21.05259,42.171207],[21.053006,42.172025],[21.053533,42.172583],[21.054464,42.17406],[21.054619,42.174443],[21.055416,42.175321],[21.056041,42.175442],[21.057091,42.175749],[21.057984,42.176562],[21.058862,42.178165],[21.060237,42.179614],[21.060436,42.180271],[21.060927,42.181023],[21.061475,42.181417],[21.062461,42.181575],[21.064259,42.182173],[21.064776,42.18241],[21.066201,42.183586],[21.066713,42.184752],[21.0673,42.185425],[21.06797,42.185837],[21.069345,42.186468],[21.07168,42.186862],[21.072545,42.187075],[21.073542,42.187064],[21.074234,42.187152],[21.0749,42.187307],[21.075603,42.187667],[21.07809,42.188457],[21.078765,42.188622],[21.080709,42.188804],[21.081442,42.189143],[21.082956,42.18961],[21.083662,42.189984],[21.084942,42.190977],[21.085739,42.191704],[21.087143,42.192318],[21.087521,42.192549],[21.088155,42.193375],[21.088476,42.193671],[21.088957,42.193653],[21.090298,42.193961],[21.091129,42.194118],[21.092374,42.195323],[21.092652,42.195978],[21.092969,42.196274],[21.093726,42.196469],[21.0944,42.197302],[21.094241,42.198243],[21.094481,42.198932],[21.094878,42.199693],[21.096612,42.200962],[21.096896,42.201456],[21.097071,42.202005],[21.097623,42.202554],[21.098251,42.202804],[21.099397,42.202925],[21.100269,42.203379],[21.100902,42.203557],[21.10146,42.204089],[21.102405,42.204493],[21.103,42.20503],[21.103283,42.205449],[21.103772,42.205887],[21.106305,42.205661],[21.10894,42.206171],[21.109525,42.206165],[21.110642,42.205846],[21.111295,42.205882],[21.111836,42.205827],[21.113722,42.20609],[21.114584,42.206382],[21.115092,42.206387],[21.116248,42.206598],[21.117019,42.206584],[21.119157,42.206679],[21.119563,42.206159],[21.119886,42.205616],[21.120447,42.204875],[21.121271,42.203987],[21.124031,42.202712],[21.125197,42.202278],[21.129241,42.201897],[21.130971,42.201868],[21.134847,42.201381],[21.135996,42.201061],[21.138533,42.200576],[21.14022,42.200039],[21.145496,42.199706],[21.149282,42.199088],[21.150199,42.198829],[21.15403,42.198046],[21.154864,42.197684],[21.15629,42.197663],[21.158097,42.198121],[21.160041,42.197577],[21.160607,42.19752],[21.161753,42.197084],[21.162838,42.196191],[21.16317,42.195549],[21.163694,42.194934],[21.164831,42.193221],[21.165456,42.192793],[21.165934,42.192304],[21.166527,42.191974],[21.166849,42.191499],[21.167343,42.190889],[21.167952,42.191018],[21.168296,42.190209],[21.167786,42.18988],[21.168252,42.189179],[21.168988,42.188499],[21.169884,42.188268],[21.169975,42.187875],[21.170216,42.187332],[21.17117,42.18681],[21.170895,42.186641],[21.171134,42.185918],[21.170411,42.185821],[21.170189,42.18625],[21.169595,42.185938],[21.169233,42.185339],[21.16948,42.18453],[21.169759,42.184024],[21.170114,42.183707],[21.170083,42.182937],[21.170569,42.182512],[21.170834,42.182178],[21.171487,42.180983],[21.171893,42.180452],[21.172364,42.180109],[21.173108,42.180322],[21.174027,42.179608],[21.173479,42.179207],[21.174408,42.178018],[21.174738,42.177749],[21.175128,42.17687],[21.176099,42.175344],[21.176458,42.174617],[21.176754,42.17369],[21.176492,42.173261],[21.17732,42.173003],[21.177932,42.172807],[21.178426,42.171809],[21.178351,42.171289],[21.178874,42.170791],[21.178601,42.170241],[21.178964,42.169552],[21.179454,42.168582],[21.179897,42.168423],[21.180216,42.167905],[21.18037,42.167374],[21.180598,42.166749],[21.18114,42.166394],[21.181931,42.166191],[21.182836,42.166129],[21.183705,42.16561],[21.184437,42.165556],[21.18519,42.165149],[21.18593,42.164444],[21.186576,42.163988],[21.185478,42.163527],[21.18444,42.163454],[21.184523,42.163001],[21.185463,42.163001],[21.186174,42.16338],[21.186588,42.162814],[21.186206,42.162308],[21.186837,42.161821],[21.18726,42.161675],[21.188042,42.161249],[21.188482,42.160789],[21.189564,42.160272],[21.190427,42.160028],[21.190969,42.15972],[21.191478,42.159146],[21.191682,42.158587],[21.191481,42.157938],[21.191596,42.157297],[21.191625,42.156691],[21.191829,42.156383],[21.192065,42.156082],[21.192156,42.15554],[21.192661,42.155115],[21.193875,42.154787],[21.194186,42.15424],[21.195022,42.154106],[21.194924,42.153509],[21.195365,42.152229],[21.196288,42.151744],[21.196976,42.151352],[21.197566,42.151021],[21.19822,42.151012],[21.199319,42.150763],[21.199931,42.151068],[21.199613,42.150174],[21.199665,42.149681],[21.199971,42.149075],[21.199868,42.148628],[21.199998,42.147869],[21.200738,42.147814],[21.201748,42.147318],[21.202188,42.147434],[21.202641,42.147777],[21.203025,42.147495],[21.203152,42.14693],[21.203053,42.145669],[21.203402,42.144812],[21.204036,42.144732],[21.20495,42.145066],[21.205443,42.14442],[21.205772,42.143932],[21.205514,42.143207],[21.205894,42.142047],[21.20646,42.141678],[21.207657,42.141307],[21.208583,42.1407],[21.208493,42.140038],[21.208071,42.138993],[21.208062,42.138425],[21.208928,42.137817],[21.208846,42.137327],[21.209661,42.136906],[21.210393,42.136885],[21.210842,42.136635],[21.211024,42.136086],[21.210862,42.13569],[21.210576,42.135169],[21.212148,42.134535],[21.212423,42.134979],[21.212771,42.134887],[21.213271,42.134459],[21.213693,42.133228],[21.214392,42.132892],[21.214628,42.131985],[21.214524,42.131374],[21.214937,42.131104],[21.215174,42.130702],[21.215211,42.129985],[21.215922,42.129785],[21.216422,42.128822],[21.215857,42.12851],[21.215324,42.127902],[21.215808,42.127149],[21.21587,42.126544],[21.216415,42.12597],[21.216134,42.125054],[21.216303,42.124425],[21.216921,42.124035],[21.216717,42.123598],[21.216153,42.123058],[21.216141,42.122544],[21.215771,42.121918],[21.216026,42.121284],[21.215954,42.119941],[21.215444,42.119335],[21.215268,42.118843],[21.215495,42.118147],[21.215039,42.117457],[21.215097,42.116387],[21.214568,42.115926],[21.21494,42.115379],[21.215045,42.114674],[21.215213,42.114164],[21.214496,42.113506],[21.214674,42.113032],[21.214339,42.112411],[21.213302,42.11182],[21.213084,42.111397],[21.212617,42.111053],[21.213176,42.109789],[21.213874,42.109123],[21.214357,42.108418],[21.214191,42.107781],[21.214558,42.107426],[21.215011,42.107336],[21.215315,42.106776],[21.2152,42.106384],[21.21574,42.105945],[21.216354,42.105376],[21.216582,42.104763],[21.216525,42.104252],[21.217377,42.103504],[21.218054,42.103307],[21.219057,42.102164],[21.22018,42.102167],[21.220418,42.101904],[21.220257,42.101438],[21.220283,42.100799],[21.221134,42.100409],[21.221635,42.099722],[21.221603,42.098818],[21.222066,42.097418],[21.22139,42.09622],[21.222189,42.095131],[21.222253,42.094612],[21.222165,42.094074],[21.222473,42.093631],[21.22297,42.093673],[21.223172,42.094303],[21.223461,42.09491],[21.224436,42.095574],[21.22488,42.095463],[21.22569,42.095385],[21.226099,42.095731],[21.226986,42.096052],[21.227245,42.0967],[21.227562,42.097104],[21.228002,42.097142],[21.228403,42.096762],[21.228842,42.096637],[21.229209,42.09677],[21.229204,42.096333],[21.229792,42.096113],[21.229811,42.096442],[21.229959,42.096874],[21.230478,42.097366],[21.230901,42.097549],[21.231477,42.097631],[21.231993,42.098043],[21.233526,42.098227],[21.233624,42.097866],[21.233499,42.097448],[21.233532,42.096623],[21.233415,42.095443],[21.23525,42.095182],[21.237445,42.094689],[21.239135,42.093892],[21.239677,42.093822],[21.240409,42.094026],[21.241883,42.093592],[21.243161,42.093478],[21.244266,42.093654],[21.244784,42.093565],[21.245167,42.093147],[21.245796,42.092674],[21.250913,42.092297],[21.251862,42.092397],[21.253219,42.092764],[21.256101,42.093096],[21.256879,42.092786],[21.25752,42.093912],[21.265854,42.094315],[21.268358,42.094677],[21.272441,42.095907],[21.273579,42.096559],[21.274017,42.096967],[21.274506,42.097688],[21.275433,42.097881],[21.275639,42.098465],[21.276148,42.098828],[21.278017,42.099779],[21.278558,42.100204],[21.278533,42.10062],[21.279004,42.101015],[21.279561,42.10073],[21.280676,42.100795],[21.280928,42.101284],[21.28128,42.102057],[21.282043,42.101647],[21.283372,42.10129],[21.288785,42.104226],[21.289218,42.104552],[21.291348,42.105095],[21.291021,42.105389],[21.291732,42.105533],[21.292332,42.105787],[21.2929,42.106373],[21.292458,42.106566],[21.292061,42.107112],[21.292479,42.107554],[21.293167,42.108013],[21.292551,42.108624],[21.293436,42.109253],[21.293787,42.108873],[21.294057,42.10924],[21.294174,42.109774],[21.294691,42.109768],[21.294704,42.110091],[21.295344,42.110599],[21.294935,42.111156],[21.294744,42.111538],[21.294665,42.111959],[21.297455,42.112408],[21.298162,42.111869],[21.29837,42.110866],[21.298883,42.111025],[21.29936,42.110927],[21.299244,42.110032],[21.299652,42.109459],[21.300271,42.108513],[21.301214,42.107675],[21.301508,42.107124],[21.302396,42.106261],[21.303078,42.106225],[21.303428,42.105981],[21.303333,42.105459],[21.303498,42.104675],[21.304872,42.104987],[21.306072,42.10552],[21.3066,42.105454],[21.306942,42.105573],[21.307493,42.105783],[21.308073,42.105806],[21.308709,42.106138],[21.31502,42.106918],[21.315695,42.107205],[21.317196,42.107533],[21.318298,42.107228],[21.318726,42.10737],[21.319235,42.10737],[21.31969,42.107568],[21.320271,42.107669],[21.321257,42.108],[21.320532,42.108513],[21.320188,42.108843],[21.31975,42.109979],[21.319445,42.110527],[21.318632,42.111554],[21.317529,42.112472],[21.316802,42.112927],[21.315925,42.113586],[21.31509,42.114566],[21.314798,42.115135],[21.3147,42.115597],[21.315504,42.116588],[21.316081,42.116991],[21.316655,42.117523],[21.315839,42.119185],[21.315235,42.119995],[21.314198,42.120691],[21.31397,42.120907],[21.312884,42.120642],[21.312132,42.121097],[21.311661,42.122131],[21.311558,42.124721],[21.311148,42.125281],[21.310492,42.125819],[21.310624,42.127088],[21.310441,42.127802],[21.309894,42.128298],[21.308799,42.129023],[21.308769,42.129473],[21.308523,42.130061],[21.30796,42.130338],[21.30724,42.130328],[21.306316,42.130807],[21.30569,42.13162],[21.305232,42.132091],[21.305485,42.132716],[21.304792,42.133225],[21.30463,42.13361],[21.30659,42.134003],[21.305349,42.136174],[21.304534,42.136921],[21.302344,42.138518],[21.302562,42.139145],[21.30358,42.139902],[21.302665,42.14073],[21.302523,42.14139],[21.303088,42.141687],[21.303825,42.14201],[21.304413,42.142179],[21.304759,42.142595],[21.305556,42.142819],[21.306232,42.143276],[21.306986,42.143531],[21.307641,42.143522],[21.308259,42.143643],[21.309306,42.144065],[21.309644,42.144595],[21.30993,42.14483],[21.310508,42.144833],[21.310893,42.146074],[21.310267,42.146189],[21.310468,42.1468],[21.310242,42.148193],[21.310389,42.14885],[21.311897,42.150165],[21.312193,42.150991],[21.314509,42.152811],[21.31593,42.154232],[21.316221,42.154872],[21.316368,42.156126],[21.316643,42.156662],[21.31668,42.157156],[21.318814,42.158825],[21.319271,42.159262],[21.320479,42.159777],[21.320656,42.160409],[21.320989,42.160765],[21.321218,42.161419],[21.320613,42.162654],[21.319908,42.163173],[21.318894,42.164151],[21.318573,42.1648],[21.31822,42.166034],[21.318083,42.167089],[21.317638,42.167642],[21.317786,42.168876],[21.317632,42.169586],[21.317339,42.170045],[21.318521,42.170089],[21.318759,42.17051],[21.319735,42.170845],[21.320424,42.171143],[21.320173,42.171557],[21.31953,42.171874],[21.319117,42.172337],[21.318199,42.172915],[21.319143,42.173005],[21.320519,42.173848],[21.321656,42.173836],[21.3223,42.174096],[21.322586,42.174504],[21.322686,42.175154],[21.322876,42.175439],[21.324195,42.175799],[21.324629,42.175687],[21.324976,42.175441],[21.325369,42.17575],[21.326247,42.17627],[21.326853,42.176141],[21.326535,42.176918],[21.327497,42.177795],[21.327911,42.178389],[21.328656,42.178955],[21.328698,42.179433],[21.328115,42.180166],[21.328389,42.180643],[21.328529,42.181107],[21.329085,42.181451],[21.329151,42.182194],[21.329401,42.183188],[21.329842,42.183603],[21.331112,42.183851],[21.331268,42.184183],[21.332022,42.184937],[21.33225,42.185467],[21.332293,42.186173],[21.332327,42.186853],[21.332487,42.187235],[21.333058,42.187486],[21.334161,42.188249],[21.334414,42.189159],[21.334767,42.189637],[21.335202,42.190324],[21.335369,42.191157],[21.335283,42.192584],[21.334683,42.193388],[21.333666,42.194068],[21.333414,42.194414],[21.332685,42.195059],[21.332505,42.195646],[21.331738,42.196778],[21.331749,42.197389],[21.331337,42.198274],[21.331062,42.199071],[21.33122,42.199561],[21.331184,42.200154],[21.331421,42.200494],[21.331603,42.201109],[21.33201,42.201901],[21.333034,42.203157],[21.333743,42.203759],[21.333781,42.204319],[21.333933,42.204824],[21.334351,42.205002],[21.335026,42.205098],[21.335706,42.205064],[21.33576,42.205827],[21.335067,42.206608],[21.335078,42.207328],[21.336301,42.207025],[21.336718,42.206725],[21.336755,42.206317],[21.337323,42.20565],[21.337394,42.205043],[21.337816,42.204515],[21.337921,42.204041],[21.338337,42.20368],[21.338886,42.203672],[21.340446,42.204736],[21.341353,42.205055],[21.341852,42.205046],[21.342486,42.204847],[21.343253,42.204818],[21.344141,42.204649],[21.344826,42.204599],[21.345803,42.204795],[21.345814,42.205641],[21.345718,42.206363],[21.346097,42.207335],[21.347008,42.207977],[21.348077,42.208313],[21.349034,42.208913],[21.350885,42.210623],[21.351202,42.211351],[21.351146,42.212187],[21.351372,42.212618],[21.351437,42.213137],[21.351654,42.213524],[21.352464,42.214299],[21.352462,42.214612],[21.352616,42.214883],[21.353245,42.215228],[21.354642,42.215276],[21.355775,42.21522],[21.3562,42.215184],[21.356156,42.215789],[21.356564,42.216465],[21.35657,42.217565],[21.357165,42.217958],[21.357132,42.218989],[21.357714,42.219608],[21.357798,42.220257],[21.358379,42.220769],[21.358958,42.221121],[21.359922,42.221542],[21.36037,42.222063],[21.361389,42.222166],[21.362114,42.221879],[21.363331,42.22185],[21.363624,42.221742],[21.364808,42.221699],[21.365162,42.221815],[21.365721,42.221647],[21.366105,42.221401],[21.366741,42.221167],[21.36753,42.221669],[21.367852,42.222561],[21.368229,42.223109],[21.36864,42.223129],[21.369068,42.223356],[21.370194,42.223598],[21.3709,42.223967],[21.371287,42.224254],[21.371567,42.224953],[21.371839,42.225535],[21.37163,42.22607],[21.371075,42.226605],[21.370082,42.227036],[21.369681,42.227288],[21.370414,42.227841],[21.37091,42.228008],[21.371491,42.22838],[21.372235,42.228941],[21.372529,42.229563],[21.372716,42.230033],[21.373115,42.230433],[21.374176,42.23076],[21.37491,42.230985],[21.374915,42.231517],[21.374673,42.231895],[21.37438,42.232185],[21.374366,42.232648],[21.374162,42.233138],[21.374159,42.233662],[21.374517,42.234109],[21.374756,42.234683],[21.374863,42.235157],[21.375285,42.235756],[21.376057,42.236389],[21.37687,42.237058],[21.377228,42.237409],[21.37717,42.237926],[21.377526,42.237894],[21.378466,42.237542],[21.379095,42.237434],[21.379727,42.237157],[21.380805,42.237888],[21.381287,42.238638],[21.381421,42.238993],[21.381997,42.238975],[21.383037,42.239722],[21.383654,42.239993],[21.384374,42.240103],[21.384223,42.240562],[21.384763,42.240927],[21.385182,42.241162],[21.385667,42.241496],[21.385106,42.24175],[21.384321,42.24193],[21.383986,42.242362],[21.383618,42.242995],[21.382944,42.243041],[21.382852,42.243344],[21.38233,42.243994],[21.382275,42.244751],[21.38302,42.245171],[21.383162,42.245575],[21.383675,42.245526],[21.38422,42.245273],[21.384553,42.24585],[21.385102,42.24648],[21.385792,42.246542],[21.386391,42.246686],[21.387545,42.245883],[21.388336,42.245312],[21.390818,42.245558],[21.390707,42.24595],[21.390969,42.246421],[21.392605,42.246772],[21.396024,42.247654],[21.39646,42.247691],[21.397354,42.247532],[21.397462,42.248021],[21.397698,42.248301],[21.398124,42.248703],[21.398788,42.249073],[21.399251,42.249191],[21.400197,42.249192],[21.400749,42.249116],[21.401293,42.249157],[21.402132,42.248861],[21.402886,42.248434],[21.403368,42.247819],[21.403261,42.247497],[21.403501,42.246955],[21.403854,42.246799],[21.405249,42.246768],[21.40635,42.247164],[21.406955,42.247332],[21.408394,42.246931],[21.409323,42.247071],[21.410509,42.246337],[21.410878,42.245934],[21.411176,42.244891],[21.411594,42.244501],[21.412268,42.244389],[21.413822,42.243922],[21.414689,42.243857],[21.415423,42.243938],[21.416027,42.244189],[21.415905,42.24469],[21.415908,42.245188],[21.416778,42.245922],[21.417241,42.245617],[21.418016,42.244826],[21.418551,42.245038],[21.419965,42.244049],[21.420147,42.243639],[21.419331,42.243415],[21.419544,42.242559],[21.419833,42.24226],[21.420258,42.242377],[21.421164,42.242466],[21.421976,42.242387],[21.421777,42.241387]]],"type":"Polygon"}
 }


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/2186

This PR updates the `edtf:inception` property value to a valid edtf string, based on the 'Interval' examples in the [EDTF spec doc](https://www.loc.gov/standards/datetime/).